### PR TITLE
Locale-aware dates and lang helper refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ t('resource:success.was_actioned', { resource: 'my catalog', action: 'created' }
 import { capitalize, modelLabel, actionLabel, statusLabel } from '@/utils/lang';
 
 modelLabel('catalog'); // "catalog" (from models:catalog)
-actionLabel('created'); // "created" (from common:created)
+actionLabel('created'); // "Created" (auto-capitalized from common:created)
 statusLabel('pending'); // "pending" (from statuses:pending)
 capitalize(modelLabel('catalog')); // "Catalog"
 ```

--- a/app/[lang]/(dashboard)/addresses/page.tsx
+++ b/app/[lang]/(dashboard)/addresses/page.tsx
@@ -10,7 +10,13 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useAddressList } from '@/hooks/addresses';
@@ -18,19 +24,7 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, MapPin } from 'lucide-react';
-
-function formatDate(dateString?: string): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
+import { formatDate } from '@/utils/format';
 
 export default function AddressesPage() {
   const { t, ready } = useTranslation();
@@ -54,9 +48,7 @@ export default function AddressesPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('address', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('address', 2))}</h1>
           <p className="text-muted-foreground">
             {t('addresses:manage_description', {
               defaultValue: 'View saved addresses',
@@ -113,14 +105,10 @@ export default function AddressesPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{validationAttribute('label', true)}</TableHead>
-                  <TableHead>
-                    {capitalize(modelLabel('address'))}
-                  </TableHead>
+                  <TableHead>{capitalize(modelLabel('address'))}</TableHead>
                   <TableHead>{validationAttribute('city', true)}</TableHead>
                   <TableHead>{validationAttribute('type', true)}</TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/addresses/page.tsx
+++ b/app/[lang]/(dashboard)/addresses/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useAddressList } from '@/hooks/addresses';
@@ -55,7 +55,7 @@ export default function AddressesPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:address_other', { defaultValue: 'Addresses' }))}
+            {capitalize(modelLabel('address', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('addresses:manage_description', {
@@ -114,12 +114,12 @@ export default function AddressesPage() {
                 <TableRow>
                   <TableHead>{validationAttribute('label', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('models:address_one', { defaultValue: 'Address' }))}
+                    {capitalize(modelLabel('address'))}
                   </TableHead>
                   <TableHead>{validationAttribute('city', true)}</TableHead>
                   <TableHead>{validationAttribute('type', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -85,14 +85,14 @@ export default function BusinessDetailPage() {
           <div>
             <h1 className="text-3xl font-bold">{business.name}</h1>
             <p className="text-muted-foreground">
-              {capitalize(t('models:business_one', { defaultValue: 'Business' }))}{' '}
+              {capitalize(modelLabel('business'))}{' '}
               {business.publicId}
             </p>
           </div>
         </div>
         <Button variant="destructive" onClick={handleDelete} disabled={deleteBusiness.isPending}>
           <Trash2 className="mr-2 h-4 w-4" />
-          {capitalize(t('common:delete', { defaultValue: 'Delete' }))}
+          {actionLabel('delete')}
         </Button>
       </div>
 
@@ -186,13 +186,13 @@ export default function BusinessDetailPage() {
           <CardContent className="space-y-4">
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                {actionLabel('created')}
               </span>
               <span className="font-medium">{formatDate(business.createdAt)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:updated', { defaultValue: 'Updated' }))}
+                {actionLabel('updated')}
               </span>
               <span className="font-medium">{formatDate(business.updatedAt)}</span>
             </div>

--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -9,19 +15,7 @@ import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { useBusiness, useDeleteBusiness } from '@/hooks/businesses';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Building2, User, MapPin, Calendar, Trash2 } from 'lucide-react';
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
+import { formatDate } from '@/utils/format';
 
 export default function BusinessDetailPage() {
   const params = useParams();
@@ -85,8 +79,7 @@ export default function BusinessDetailPage() {
           <div>
             <h1 className="text-3xl font-bold">{business.name}</h1>
             <p className="text-muted-foreground">
-              {capitalize(modelLabel('business'))}{' '}
-              {business.publicId}
+              {capitalize(modelLabel('business'))} {business.publicId}
             </p>
           </div>
         </div>
@@ -185,15 +178,11 @@ export default function BusinessDetailPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('created')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('created')}</span>
               <span className="font-medium">{formatDate(business.createdAt)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('updated')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('updated')}</span>
               <span className="font-medium">{formatDate(business.updatedAt)}</span>
             </div>
           </CardContent>

--- a/app/[lang]/(dashboard)/businesses/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/page.tsx
@@ -10,7 +10,13 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -18,19 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { useBusinessList } from '@/hooks/businesses';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Building2 } from 'lucide-react';
-
-function formatDate(dateString?: string): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
+import { formatDate } from '@/utils/format';
 
 export default function BusinessesPage() {
   const { t, ready } = useTranslation();
@@ -55,9 +49,7 @@ export default function BusinessesPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('business', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('business', 2))}</h1>
           <p className="text-muted-foreground">
             {t('businesses:manage_description', { defaultValue: 'Manage business accounts' })}
           </p>
@@ -110,9 +102,7 @@ export default function BusinessesPage() {
                   <TableHead>{validationAttribute('name', true)}</TableHead>
                   <TableHead>{validationAttribute('type', true)}</TableHead>
                   <TableHead>{validationAttribute('owner', true)}</TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/businesses/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -56,7 +56,7 @@ export default function BusinessesPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:business_other', { defaultValue: 'Businesses' }))}
+            {capitalize(modelLabel('business', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('businesses:manage_description', { defaultValue: 'Manage business accounts' })}
@@ -111,7 +111,7 @@ export default function BusinessesPage() {
                   <TableHead>{validationAttribute('type', true)}</TableHead>
                   <TableHead>{validationAttribute('owner', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/catalogs/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/catalogs/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ArrowLeft, Database, List, Calendar, Pencil } from 'lucide-react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { ElementEditDialog } from '@/components/catalogs/ElementEditDialog';
 
 type CatalogElementData = App.Data.CatalogElement.CatalogElementData;
@@ -106,7 +106,7 @@ export default function CatalogDetailPage() {
             <Badge variant="outline">{catalog.code}</Badge>
           </div>
           <p className="text-muted-foreground">
-            {capitalize(t('models:catalog_one', { defaultValue: 'Catalog' }))} #{catalog.id}
+            {capitalize(modelLabel('catalog'))} #{catalog.id}
           </p>
         </div>
       </div>
@@ -149,13 +149,13 @@ export default function CatalogDetailPage() {
           <CardContent className="space-y-4">
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                {actionLabel('created')}
               </span>
               <span className="font-medium">{formatDate(catalog.createdAt)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:updated', { defaultValue: 'Updated' }))}
+                {actionLabel('updated')}
               </span>
               <span className="font-medium">{formatDate(catalog.updatedAt)}</span>
             </div>

--- a/app/[lang]/(dashboard)/catalogs/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/catalogs/[id]/page.tsx
@@ -17,23 +17,17 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ArrowLeft, Database, List, Calendar, Pencil } from 'lucide-react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { ElementEditDialog } from '@/components/catalogs/ElementEditDialog';
+import { formatDate } from '@/utils/format';
 
 type CatalogElementData = App.Data.CatalogElement.CatalogElementData;
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 export default function CatalogDetailPage() {
   const params = useParams();
@@ -148,15 +142,11 @@ export default function CatalogDetailPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('created')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('created')}</span>
               <span className="font-medium">{formatDate(catalog.createdAt)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('updated')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('updated')}</span>
               <span className="font-medium">{formatDate(catalog.updatedAt)}</span>
             </div>
           </CardContent>

--- a/app/[lang]/(dashboard)/catalogs/page.tsx
+++ b/app/[lang]/(dashboard)/catalogs/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
@@ -57,7 +57,7 @@ export default function CatalogsPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:catalog_other', { defaultValue: 'Catalogs' }))}
+            {capitalize(modelLabel('catalog', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('catalogs:manage_description', { defaultValue: 'Manage catalog data' })}
@@ -110,7 +110,7 @@ export default function CatalogsPage() {
                   <TableHead>{validationAttribute('name', true)}</TableHead>
                   <TableHead>{validationAttribute('elements', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/catalogs/page.tsx
+++ b/app/[lang]/(dashboard)/catalogs/page.tsx
@@ -10,7 +10,13 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
@@ -19,19 +25,7 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Database } from 'lucide-react';
-
-function formatDate(dateString?: string): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
+import { formatDate } from '@/utils/format';
 
 export default function CatalogsPage() {
   const { t, ready } = useTranslation();
@@ -56,9 +50,7 @@ export default function CatalogsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('catalog', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('catalog', 2))}</h1>
           <p className="text-muted-foreground">
             {t('catalogs:manage_description', { defaultValue: 'Manage catalog data' })}
           </p>
@@ -109,9 +101,7 @@ export default function CatalogsPage() {
                   <TableHead>{validationAttribute('code', true)}</TableHead>
                   <TableHead>{validationAttribute('name', true)}</TableHead>
                   <TableHead>{validationAttribute('elements', true)}</TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -99,13 +99,13 @@ export default function DriverDetailPage() {
               {driver.user?.name || t('common:unknown', { defaultValue: 'Unknown' })}
             </h1>
             <p className="text-muted-foreground">
-              {capitalize(t('models:driver_one', { defaultValue: 'Driver' }))} {driver.publicId}
+              {capitalize(modelLabel('driver'))} {driver.publicId}
             </p>
           </div>
         </div>
         <Button variant="destructive" onClick={handleDelete} disabled={deleteDriver.isPending}>
           <Trash2 className="mr-2 h-4 w-4" />
-          {capitalize(t('common:delete', { defaultValue: 'Delete' }))}
+          {actionLabel('delete')}
         </Button>
       </div>
 
@@ -199,13 +199,13 @@ export default function DriverDetailPage() {
           <CardContent className="space-y-4">
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                {actionLabel('created')}
               </span>
               <span className="font-medium">{formatDate(driver.createdAt)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:updated', { defaultValue: 'Updated' }))}
+                {actionLabel('updated')}
               </span>
               <span className="font-medium">{formatDate(driver.updatedAt)}</span>
             </div>

--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -10,19 +16,7 @@ import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, User, CreditCard, Car, Calendar, Trash2 } from 'lucide-react';
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
+import { formatDate } from '@/utils/format';
 
 function getInitials(name?: string): string {
   if (!name) return '?';
@@ -198,15 +192,11 @@ export default function DriverDetailPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('created')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('created')}</span>
               <span className="font-medium">{formatDate(driver.createdAt)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('updated')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('updated')}</span>
               <span className="font-medium">{formatDate(driver.updatedAt)}</span>
             </div>
           </CardContent>

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -10,7 +10,13 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useDriverList } from '@/hooks/drivers';
 import { useRouter } from 'next/navigation';
@@ -19,19 +25,7 @@ import { useTranslation } from 'react-i18next';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Truck } from 'lucide-react';
-
-function formatDate(dateString?: string): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
+import { formatDate } from '@/utils/format';
 
 function getInitials(name?: string): string {
   if (!name) return '?';
@@ -66,9 +60,7 @@ export default function DriversPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('driver', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('driver', 2))}</h1>
           <p className="text-muted-foreground">
             {t('drivers:manage_description', { defaultValue: 'Manage driver accounts' })}
           </p>
@@ -120,9 +112,7 @@ export default function DriversPage() {
                   <TableHead>{validationAttribute('licenseNumber', true)}</TableHead>
                   <TableHead>{validationAttribute('licensePlate', true)}</TableHead>
                   <TableHead>{validationAttribute('licenseExpires', true)}</TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useDriverList } from '@/hooks/drivers';
 import { useRouter } from 'next/navigation';
@@ -67,7 +67,7 @@ export default function DriversPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:driver_other', { defaultValue: 'Drivers' }))}
+            {capitalize(modelLabel('driver', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('drivers:manage_description', { defaultValue: 'Manage driver accounts' })}
@@ -121,7 +121,7 @@ export default function DriversPage() {
                   <TableHead>{validationAttribute('licensePlate', true)}</TableHead>
                   <TableHead>{validationAttribute('licenseExpires', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/notifications/page.tsx
+++ b/app/[lang]/(dashboard)/notifications/page.tsx
@@ -119,9 +119,7 @@ export default function NotificationsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('notification', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('notification', 2))}</h1>
           <p className="text-muted-foreground">
             {t('notifications:page_description', {
               defaultValue: 'View and manage your notifications',
@@ -335,9 +333,7 @@ export default function NotificationsPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-12"></TableHead>
-                  <TableHead>
-                    {capitalize(modelLabel('notification'))}
-                  </TableHead>
+                  <TableHead>{capitalize(modelLabel('notification'))}</TableHead>
                   <TableHead className="w-32">
                     {t('common:status', { defaultValue: 'Status' })}
                   </TableHead>

--- a/app/[lang]/(dashboard)/notifications/page.tsx
+++ b/app/[lang]/(dashboard)/notifications/page.tsx
@@ -29,7 +29,7 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
-import { capitalize } from '@/utils/lang';
+import { capitalize, modelLabel } from '@/utils/lang';
 import { getDateLocale } from '@/utils/format';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -120,7 +120,7 @@ export default function NotificationsPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:notification_other', { defaultValue: 'Notifications' }))}
+            {capitalize(modelLabel('notification', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('notifications:page_description', {
@@ -336,7 +336,7 @@ export default function NotificationsPage() {
                 <TableRow>
                   <TableHead className="w-12"></TableHead>
                   <TableHead>
-                    {capitalize(t('models:notification_one', { defaultValue: 'Notification' }))}
+                    {capitalize(modelLabel('notification'))}
                   </TableHead>
                   <TableHead className="w-32">
                     {t('common:status', { defaultValue: 'Status' })}

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -24,7 +24,7 @@ import { CreateQuoteDialog } from '@/components/orders/CreateQuoteDialog';
 import { OrderStatusBadge } from '@/components/orders/OrderStatusBadge';
 import { PaymentSection } from '@/components/payments/PaymentSection';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
 import { useOrder, useDeleteOrder } from '@/hooks/orders';
 import { useCurrencyList } from '@/hooks/currencies';
 
@@ -128,7 +128,7 @@ export default function OrderDetailPage() {
               })}
             </h1>
             <p className="text-muted-foreground text-sm">
-              {capitalize(t('common:created', { defaultValue: 'Created' }))}{' '}
+              {actionLabel('created')}{' '}
               {formatDate(order.createdAt)}
             </p>
           </div>
@@ -146,7 +146,7 @@ export default function OrderDetailPage() {
           )}
           <Button variant="destructive" onClick={handleDelete} disabled={deleteOrder.isPending}>
             <Trash2 className="mr-2 h-4 w-4" />
-            {capitalize(t('common:delete', { defaultValue: 'Delete' }))}
+            {actionLabel('delete')}
           </Button>
         </div>
       </div>

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -25,25 +25,11 @@ import { OrderStatusBadge } from '@/components/orders/OrderStatusBadge';
 import { PaymentSection } from '@/components/payments/PaymentSection';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { actionLabel, capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { useOrder, useDeleteOrder } from '@/hooks/orders';
 import { useCurrencyList } from '@/hooks/currencies';
 
 type OrderStatus = App.Enums.OrderStatus;
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 export default function OrderDetailPage() {
   const params = useParams();
@@ -128,8 +114,7 @@ export default function OrderDetailPage() {
               })}
             </h1>
             <p className="text-muted-foreground text-sm">
-              {actionLabel('created')}{' '}
-              {formatDate(order.createdAt)}
+              {actionLabel('created')} {formatDate(order.createdAt)}
             </p>
           </div>
         </div>

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useOrderList } from '@/hooks/orders';
 import { useRouter } from 'next/navigation';
@@ -98,7 +98,7 @@ export default function OrdersPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:order_other', { defaultValue: 'Orders' }))}
+            {capitalize(modelLabel('order', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('orders:manage_description', { defaultValue: 'Manage delivery orders and quotes' })}
@@ -179,10 +179,10 @@ export default function OrdersPage() {
                   <TableHead>{t('orders:from', { defaultValue: 'From' })}</TableHead>
                   <TableHead>{t('orders:to', { defaultValue: 'To' })}</TableHead>
                   <TableHead>
-                    {capitalize(t('models:quote_one', { defaultValue: 'Quote' }))}
+                    {capitalize(modelLabel('quote'))}
                   </TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -17,7 +17,14 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { Input } from '@/components/ui/input';
 import { useOrderList } from '@/hooks/orders';
 import { useRouter } from 'next/navigation';
@@ -29,21 +36,6 @@ import { PaymentStatusBadge } from '@/components/orders/PaymentStatusBadge';
 import { ChevronLeft, ChevronRight, Search, Package } from 'lucide-react';
 
 type OrderStatus = App.Enums.OrderStatus;
-
-function formatDate(dateString?: string): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 function formatAddress(address?: App.Data.Address.AddressData | null): string {
   if (!address) return '-';
@@ -97,9 +89,7 @@ export default function OrdersPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('order', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('order', 2))}</h1>
           <p className="text-muted-foreground">
             {t('orders:manage_description', { defaultValue: 'Manage delivery orders and quotes' })}
           </p>
@@ -178,12 +168,8 @@ export default function OrdersPage() {
                   </TableHead>
                   <TableHead>{t('orders:from', { defaultValue: 'From' })}</TableHead>
                   <TableHead>{t('orders:to', { defaultValue: 'To' })}</TableHead>
-                  <TableHead>
-                    {capitalize(modelLabel('quote'))}
-                  </TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{capitalize(modelLabel('quote'))}</TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/pricing/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/pricing/[id]/page.tsx
@@ -33,7 +33,7 @@ import {
 import { ArrowLeft, Pencil, Trash2, Copy, Power, DollarSign } from 'lucide-react';
 import { useState } from 'react';
 import { Enums } from '@/data/app-enums';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
 
 function formatCurrency(amount?: number): string {
   if (amount === undefined) return '-';
@@ -146,7 +146,7 @@ export default function PricingRuleDetailPage() {
           {rule.status !== Enums.PricingRuleStatus.DRAFT && (
             <Button variant="outline" onClick={handleClone} disabled={cloneMutation.isPending}>
               <Copy className="mr-2 h-4 w-4" />
-              {capitalize(t('common:clone'))}
+              {actionLabel('clone')}
             </Button>
           )}
           {rule.status === Enums.PricingRuleStatus.DRAFT && (
@@ -157,15 +157,15 @@ export default function PricingRuleDetailPage() {
                 disabled={activateMutation.isPending}
               >
                 <Power className="mr-2 h-4 w-4" />
-                {capitalize(t('common:activate'))}
+                {actionLabel('activate')}
               </Button>
               <Button onClick={() => router.push(`/pricing/${ruleId}/edit`)}>
                 <Pencil className="mr-2 h-4 w-4" />
-                {capitalize(t('common:edit'))}
+                {actionLabel('edit')}
               </Button>
               <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)}>
                 <Trash2 className="mr-2 h-4 w-4" />
-                {capitalize(t('common:delete'))}
+                {actionLabel('delete')}
               </Button>
             </>
           )}
@@ -267,12 +267,12 @@ export default function PricingRuleDetailPage() {
       <AlertDialog open={activateDialogOpen} onOpenChange={setActivateDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{capitalize(t('common:activate'))}</AlertDialogTitle>
+            <AlertDialogTitle>{actionLabel('activate')}</AlertDialogTitle>
             <AlertDialogDescription>{t('confirm_activate')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common:cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleActivate}>{capitalize(t('common:activate'))}</AlertDialogAction>
+            <AlertDialogAction onClick={handleActivate}>{actionLabel('activate')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -281,7 +281,7 @@ export default function PricingRuleDetailPage() {
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{capitalize(t('common:delete'))}</AlertDialogTitle>
+            <AlertDialogTitle>{actionLabel('delete')}</AlertDialogTitle>
             <AlertDialogDescription>{t('confirm_delete')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -290,7 +290,7 @@ export default function PricingRuleDetailPage() {
               onClick={handleDelete}
               className="bg-destructive text-destructive-foreground"
             >
-              {capitalize(t('common:delete'))}
+              {actionLabel('delete')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/[lang]/(dashboard)/pricing/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/pricing/[id]/page.tsx
@@ -34,6 +34,7 @@ import { ArrowLeft, Pencil, Trash2, Copy, Power, DollarSign } from 'lucide-react
 import { useState } from 'react';
 import { Enums } from '@/data/app-enums';
 import { actionLabel, capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 
 function formatCurrency(amount?: number): string {
   if (amount === undefined) return '-';
@@ -43,21 +44,6 @@ function formatCurrency(amount?: number): string {
 function formatPercent(rate?: number): string {
   if (rate === undefined) return '-';
   return `${(rate * 100).toFixed(1)}%`;
-}
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateString;
-  }
 }
 
 export default function PricingRuleDetailPage() {
@@ -272,7 +258,9 @@ export default function PricingRuleDetailPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common:cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleActivate}>{actionLabel('activate')}</AlertDialogAction>
+            <AlertDialogAction onClick={handleActivate}>
+              {actionLabel('activate')}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/app/[lang]/(dashboard)/pricing/page.tsx
+++ b/app/[lang]/(dashboard)/pricing/page.tsx
@@ -51,7 +51,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
 import {
   usePricingRuleList,
   useActivatePricingRule,
@@ -236,7 +236,7 @@ export default function PricingPage() {
                               onClick={() => router.push(`/pricing/${rule.id}/edit`)}
                             >
                               <Pencil className="mr-2 h-4 w-4" />
-                              {capitalize(t('common:edit'))}
+                              {actionLabel('edit')}
                             </DropdownMenuItem>
                           )}
                           {rule.status !== Enums.PricingRuleStatus.DRAFT && (
@@ -245,7 +245,7 @@ export default function PricingPage() {
                               disabled={cloneMutation.isPending}
                             >
                               <Copy className="mr-2 h-4 w-4" />
-                              {capitalize(t('common:clone'))}
+                              {actionLabel('clone')}
                             </DropdownMenuItem>
                           )}
                           {rule.status === Enums.PricingRuleStatus.DRAFT && (
@@ -256,7 +256,7 @@ export default function PricingPage() {
                               }}
                             >
                               <Power className="mr-2 h-4 w-4" />
-                              {capitalize(t('common:activate'))}
+                              {actionLabel('activate')}
                             </DropdownMenuItem>
                           )}
                           {rule.status === Enums.PricingRuleStatus.DRAFT && (
@@ -270,7 +270,7 @@ export default function PricingPage() {
                                 }}
                               >
                                 <Trash2 className="mr-2 h-4 w-4" />
-                                {capitalize(t('common:delete'))}
+                                {actionLabel('delete')}
                               </DropdownMenuItem>
                             </>
                           )}
@@ -323,12 +323,12 @@ export default function PricingPage() {
       <AlertDialog open={activateDialogOpen} onOpenChange={setActivateDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{capitalize(t('common:activate'))}</AlertDialogTitle>
+            <AlertDialogTitle>{actionLabel('activate')}</AlertDialogTitle>
             <AlertDialogDescription>{t('confirm_activate')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common:cancel', { defaultValue: 'Cancel' })}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleActivate}>{capitalize(t('common:activate'))}</AlertDialogAction>
+            <AlertDialogAction onClick={handleActivate}>{actionLabel('activate')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -337,7 +337,7 @@ export default function PricingPage() {
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{capitalize(t('common:delete'))}</AlertDialogTitle>
+            <AlertDialogTitle>{actionLabel('delete')}</AlertDialogTitle>
             <AlertDialogDescription>{t('confirm_delete')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -346,7 +346,7 @@ export default function PricingPage() {
               onClick={handleDelete}
               className="bg-destructive text-destructive-foreground"
             >
-              {capitalize(t('common:delete'))}
+              {actionLabel('delete')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/[lang]/(dashboard)/pricing/page.tsx
+++ b/app/[lang]/(dashboard)/pricing/page.tsx
@@ -328,7 +328,9 @@ export default function PricingPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('common:cancel', { defaultValue: 'Cancel' })}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleActivate}>{actionLabel('activate')}</AlertDialogAction>
+            <AlertDialogAction onClick={handleActivate}>
+              {actionLabel('activate')}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/app/[lang]/(dashboard)/quotes/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/quotes/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
@@ -107,12 +107,12 @@ export default function QuoteDetailPage() {
           <div>
             <div className="flex items-center gap-3">
               <h1 className="text-3xl font-bold">
-                {capitalize(t('models:quote_one', { defaultValue: 'Quote' }))} {quote.publicId}
+                {capitalize(modelLabel('quote'))} {quote.publicId}
               </h1>
               <QuoteStatusBadge status={quote.status as QuoteStatus} />
             </div>
             <p className="text-muted-foreground">
-              {capitalize(t('common:created', { defaultValue: 'Created' }))}{' '}
+              {actionLabel('created')}{' '}
               {formatDate(quote.createdAt)}
             </p>
           </div>
@@ -127,7 +127,7 @@ export default function QuoteDetailPage() {
           {canDelete && (
             <Button variant="destructive" onClick={handleDelete} disabled={deleteQuote.isPending}>
               <Trash2 className="mr-2 h-4 w-4" />
-              {capitalize(t('common:delete', { defaultValue: 'Delete' }))}
+              {actionLabel('delete')}
             </Button>
           )}
         </div>
@@ -150,7 +150,7 @@ export default function QuoteDetailPage() {
             {quote.orderId && (
               <div className="flex justify-between">
                 <span className="text-muted-foreground">
-                  {capitalize(t('models:order_one', { defaultValue: 'Order' }))}
+                  {capitalize(modelLabel('order'))}
                 </span>
                 <Button
                   variant="link"
@@ -316,13 +316,13 @@ export default function QuoteDetailPage() {
           <CardContent className="space-y-4">
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                {actionLabel('created')}
               </span>
               <span className="font-medium">{formatDate(quote.createdAt)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:updated', { defaultValue: 'Updated' }))}
+                {actionLabel('updated')}
               </span>
               <span className="font-medium">{formatDate(quote.updatedAt)}</span>
             </div>

--- a/app/[lang]/(dashboard)/quotes/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/quotes/[id]/page.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
@@ -12,21 +19,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, FileText, DollarSign, Calendar, Send, Trash2, Package } from 'lucide-react';
 
 type QuoteStatus = App.Enums.QuoteStatus;
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 function formatCurrency(amount?: number | null, currencyCode?: string): string {
   if (amount == null) return '-';
@@ -112,8 +104,7 @@ export default function QuoteDetailPage() {
               <QuoteStatusBadge status={quote.status as QuoteStatus} />
             </div>
             <p className="text-muted-foreground">
-              {actionLabel('created')}{' '}
-              {formatDate(quote.createdAt)}
+              {actionLabel('created')} {formatDate(quote.createdAt)}
             </p>
           </div>
         </div>
@@ -149,9 +140,7 @@ export default function QuoteDetailPage() {
             </div>
             {quote.orderId && (
               <div className="flex justify-between">
-                <span className="text-muted-foreground">
-                  {capitalize(modelLabel('order'))}
-                </span>
+                <span className="text-muted-foreground">{capitalize(modelLabel('order'))}</span>
                 <Button
                   variant="link"
                   className="h-auto p-0"
@@ -315,15 +304,11 @@ export default function QuoteDetailPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('created')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('created')}</span>
               <span className="font-medium">{formatDate(quote.createdAt)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('updated')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('updated')}</span>
               <span className="font-medium">{formatDate(quote.updatedAt)}</span>
             </div>
           </CardContent>

--- a/app/[lang]/(dashboard)/quotes/page.tsx
+++ b/app/[lang]/(dashboard)/quotes/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useQuoteList } from '@/hooks/quotes';
 import { useCurrencyList } from '@/hooks/currencies';
@@ -96,7 +96,7 @@ export default function QuotesPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:quote_other', { defaultValue: 'Quotes' }))}
+            {capitalize(modelLabel('quote', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('quotes:manage_description', { defaultValue: 'Create and manage delivery quotes' })}
@@ -229,13 +229,13 @@ export default function QuotesPage() {
                 <TableRow>
                   <TableHead>{validationAttribute('id', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('models:order_one', { defaultValue: 'Order' }))}
+                    {capitalize(modelLabel('order'))}
                   </TableHead>
                   <TableHead>{validationAttribute('status', true)}</TableHead>
                   <TableHead>{validationAttribute('total', true)}</TableHead>
                   <TableHead>{t('quotes:valid_until', { defaultValue: 'Valid Until' })}</TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/quotes/page.tsx
+++ b/app/[lang]/(dashboard)/quotes/page.tsx
@@ -17,7 +17,14 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { Input } from '@/components/ui/input';
 import { useQuoteList } from '@/hooks/quotes';
 import { useCurrencyList } from '@/hooks/currencies';
@@ -30,21 +37,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, FileText, X } from 'lucide-react';
 
 type QuoteStatus = App.Enums.QuoteStatus;
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 function formatCurrency(amount?: number | null, currencyCode?: string): string {
   if (amount == null) return '-';
@@ -95,9 +87,7 @@ export default function QuotesPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('quote', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('quote', 2))}</h1>
           <p className="text-muted-foreground">
             {t('quotes:manage_description', { defaultValue: 'Create and manage delivery quotes' })}
           </p>
@@ -228,15 +218,11 @@ export default function QuotesPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{validationAttribute('id', true)}</TableHead>
-                  <TableHead>
-                    {capitalize(modelLabel('order'))}
-                  </TableHead>
+                  <TableHead>{capitalize(modelLabel('order'))}</TableHead>
                   <TableHead>{validationAttribute('status', true)}</TableHead>
                   <TableHead>{validationAttribute('total', true)}</TableHead>
                   <TableHead>{t('quotes:valid_until', { defaultValue: 'Valid Until' })}</TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/settings/currencies/page.tsx
+++ b/app/[lang]/(dashboard)/settings/currencies/page.tsx
@@ -35,6 +35,7 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { resourceMessage, validationAttribute } from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { useCurrencyList, useUpdateCurrency } from '@/hooks/currencies';
 import { useSyncExchangeRates } from '@/hooks/exchange-rates';
 
@@ -43,17 +44,6 @@ type CurrencyData = App.Data.Currency.CurrencyData;
 function formatRate(rate?: number | null): string {
   if (rate === undefined || rate === null) return '-';
   return rate.toFixed(6);
-}
-
-function formatDate(dateStr?: string | null): string {
-  if (!dateStr) return '-';
-  // Append T00:00:00 to parse as local time, not UTC
-  const localDate = dateStr.includes('T') ? dateStr : `${dateStr}T00:00:00`;
-  return new Date(localDate).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
 }
 
 export default function CurrencySettingsPage() {

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -113,13 +113,13 @@ export default function UserDetailPage() {
               <RoleBadge role={user.role as Role} />
             </div>
             <p className="text-muted-foreground">
-              {capitalize(t('models:user_one', { defaultValue: 'User' }))} {user.publicId}
+              {capitalize(modelLabel('user'))} {user.publicId}
             </p>
           </div>
         </div>
         <Button variant="destructive" onClick={handleDelete} disabled={deleteUser.isPending}>
           <Trash2 className="mr-2 h-4 w-4" />
-          {capitalize(t('common:delete', { defaultValue: 'Delete' }))}
+          {actionLabel('delete')}
         </Button>
       </div>
 
@@ -286,13 +286,13 @@ export default function UserDetailPage() {
           <CardContent className="space-y-4">
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                {actionLabel('created')}
               </span>
               <span className="font-medium">{formatDate(user.createdAt)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {capitalize(t('common:updated', { defaultValue: 'Updated' }))}
+                {actionLabel('updated')}
               </span>
               <span className="font-medium">{formatDate(user.updatedAt)}</span>
             </div>

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -28,19 +35,6 @@ import {
 } from 'lucide-react';
 
 type Role = App.Enums.Role;
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 function getInitials(name?: string): string {
   if (!name) return '?';
@@ -285,15 +279,11 @@ export default function UserDetailPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('created')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('created')}</span>
               <span className="font-medium">{formatDate(user.createdAt)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">
-                {actionLabel('updated')}
-              </span>
+              <span className="text-muted-foreground">{actionLabel('updated')}</span>
               <span className="font-medium">{formatDate(user.updatedAt)}</span>
             </div>
           </CardContent>

--- a/app/[lang]/(dashboard)/users/page.tsx
+++ b/app/[lang]/(dashboard)/users/page.tsx
@@ -17,7 +17,14 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { formatDate } from '@/utils/format';
 import { useUserList } from '@/hooks/users';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
@@ -29,19 +36,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Users } from 'lucide-react';
 
 type Role = App.Enums.Role;
-
-function formatDate(dateString?: string): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return dateString;
-  }
-}
 
 function getInitials(name?: string): string {
   if (!name) return '?';
@@ -94,9 +88,7 @@ export default function UsersPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">
-            {capitalize(modelLabel('user', 2))}
-          </h1>
+          <h1 className="text-3xl font-bold">{capitalize(modelLabel('user', 2))}</h1>
           <p className="text-muted-foreground">
             {t('users:manage_description', { defaultValue: 'Manage user accounts' })}
           </p>
@@ -168,15 +160,11 @@ export default function UsersPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>
-                    {capitalize(modelLabel('user'))}
-                  </TableHead>
+                  <TableHead>{capitalize(modelLabel('user'))}</TableHead>
                   <TableHead>{validationAttribute('email', true)}</TableHead>
                   <TableHead>{validationAttribute('role', true)}</TableHead>
                   <TableHead>{validationAttribute('phone', true)}</TableHead>
-                  <TableHead>
-                    {actionLabel('created')}
-                  </TableHead>
+                  <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/app/[lang]/(dashboard)/users/page.tsx
+++ b/app/[lang]/(dashboard)/users/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { capitalize, resourceMessage, validationAttribute } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { useUserList } from '@/hooks/users';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
@@ -95,7 +95,7 @@ export default function UsersPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">
-            {capitalize(t('models:user_other', { defaultValue: 'Users' }))}
+            {capitalize(modelLabel('user', 2))}
           </h1>
           <p className="text-muted-foreground">
             {t('users:manage_description', { defaultValue: 'Manage user accounts' })}
@@ -169,13 +169,13 @@ export default function UsersPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>
-                    {capitalize(t('models:user_one', { defaultValue: 'User' }))}
+                    {capitalize(modelLabel('user'))}
                   </TableHead>
                   <TableHead>{validationAttribute('email', true)}</TableHead>
                   <TableHead>{validationAttribute('role', true)}</TableHead>
                   <TableHead>{validationAttribute('phone', true)}</TableHead>
                   <TableHead>
-                    {capitalize(t('common:created', { defaultValue: 'Created' }))}
+                    {actionLabel('created')}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
-import { capitalize } from '@/utils/lang';
+import { actionLabel, capitalize } from '@/utils/lang';
 import {
   LayoutDashboard,
   Package,
@@ -111,7 +111,7 @@ export function Sidebar() {
             )}
           >
             <Settings className="h-5 w-5" />
-            {ready ? capitalize(t('common:settings_other', { defaultValue: 'Settings' })) : ''}
+            {ready ? actionLabel('settings_other') : ''}
           </Link>
         </div>
       </div>

--- a/components/orders/CreateQuoteDialog.tsx
+++ b/components/orders/CreateQuoteDialog.tsx
@@ -21,7 +21,13 @@ import { useCurrencyList } from '@/hooks/currencies';
 import { useCalculatePricing } from '@/hooks/pricing';
 import { useCreateQuote, useSendQuote } from '@/hooks/quotes';
 import { validationAttribute } from '@/utils/lang';
-import { formatCurrency, applyRounding, toDateTimeLocal, dateTimeLocalToISO } from '@/utils/format';
+import {
+  formatCurrency,
+  applyRounding,
+  toDateTimeLocal,
+  dateTimeLocalToISO,
+  formatDateTime,
+} from '@/utils/format';
 import { formatRateDisplay } from '@/utils/currency';
 
 interface CreateQuoteDialogProps {
@@ -434,15 +440,7 @@ export function CreateQuoteDialog({
                   {t('quotes:create.from_order_request', { defaultValue: 'From order request' })}
                 </p>
               </div>
-              <p className="text-lg font-semibold">
-                {new Date(customerDesiredDelivery).toLocaleString('en-US', {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  minute: '2-digit',
-                })}
-              </p>
+              <p className="text-lg font-semibold">{formatDateTime(customerDesiredDelivery)}</p>
             </div>
           )}
 

--- a/components/payments/PaymentSection.tsx
+++ b/components/payments/PaymentSection.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useOrderPayments } from '@/hooks/payments';
 import { RefundDialog } from './RefundDialog';
-import { formatCurrency } from '@/utils/format';
+import { formatDate, formatCurrency } from '@/utils/format';
 import { capitalize } from '@/utils/lang';
 import { Enums } from '@/data/app-enums';
 
@@ -49,21 +49,6 @@ function getPaymentMethodLabel(method?: string | null, brand?: string | null): s
       return 'Cash';
     default:
       return capitalize(method);
-  }
-}
-
-function formatDate(dateString?: string | null): string {
-  if (!dateString) return '-';
-  try {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateString;
   }
 }
 

--- a/utils/__tests__/format.test.ts
+++ b/utils/__tests__/format.test.ts
@@ -5,6 +5,7 @@ import {
   toDateTimeLocal,
   dateTimeLocalToISO,
   formatDateTime,
+  formatDate,
 } from '../format';
 
 describe('formatCurrency', () => {
@@ -166,5 +167,25 @@ describe('formatDateTime', () => {
 
   it('returns original string for invalid date', () => {
     expect(formatDateTime('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats ISO string for display', () => {
+    const result = formatDate('2026-01-18T14:30:00.000Z');
+    expect(result).toMatch(/Jan 18.*2026/);
+  });
+
+  it('returns fallback for null input', () => {
+    expect(formatDate(null)).toBe('-');
+    expect(formatDate(undefined)).toBe('-');
+  });
+
+  it('returns custom fallback when provided', () => {
+    expect(formatDate(null, 'N/A')).toBe('N/A');
+  });
+
+  it('returns original string for invalid date', () => {
+    expect(formatDate('not-a-date')).toBe('not-a-date');
   });
 });

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -1,5 +1,8 @@
 import { es, fr, enUS } from 'date-fns/locale';
 import type { Locale } from 'date-fns';
+import i18n from '@/config/i18next';
+
+const getLocale = (): string => i18n.language || 'en';
 
 /**
  * Get date-fns locale from language code.
@@ -72,7 +75,7 @@ export function formatDateTime(
   try {
     const date = new Date(isoString);
     if (isNaN(date.getTime())) return isoString;
-    return date.toLocaleString('en-US', {
+    return date.toLocaleString(getLocale(), {
       month: 'short',
       day: 'numeric',
       hour: 'numeric',
@@ -80,5 +83,24 @@ export function formatDateTime(
     });
   } catch {
     return isoString;
+  }
+}
+
+/**
+ * Format an ISO date string for date-only display (locale-aware).
+ * e.g. "18 ene 2026" (es), "Jan 18, 2026" (en)
+ */
+export function formatDate(dateString: string | null | undefined, fallback: string = '-'): string {
+  if (!dateString) return fallback;
+  try {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return dateString;
+    return date.toLocaleDateString(getLocale(), {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return dateString;
   }
 }

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -80,7 +80,7 @@ export const orderStatusLabel = (status: string | undefined): string => {
  * @returns Translated action label
  */
 export const actionLabel = (action: string): string => {
-  return i18next.t(`common:${action}`, { defaultValue: action });
+  return capitalize(i18next.t(`common:${action}`, { defaultValue: action }));
 };
 
 /**


### PR DESCRIPTION
## Summary
- Centralized locale-aware `formatDate` and `formatDateTime` in `utils/format.ts` using `i18next.language`
- Removed 16 duplicate local `formatDate` functions with hardcoded `'en-US'` across page files
- Replaced inline `toLocaleString('en-US', ...)` in components with shared utility
- Added `formatDate` tests to format test suite — 125 tests passing

## Test plan
- [ ] Dates display in the correct locale when language is changed (en/es/fr)
- [ ] All date columns render correctly across addresses, orders, quotes, users, drivers, catalogs, pricing, currencies pages
- [ ] `npm test` — 125 tests pass
- [ ] `npm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)