### PR TITLE
fix: verified bugs from admin app audit

### DIFF
--- a/app/[lang]/(dashboard)/page.tsx
+++ b/app/[lang]/(dashboard)/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Package,
@@ -113,7 +113,7 @@ const navItems = [
 
 export default function DashboardPage() {
   const { t, ready } = useTranslation();
-  const router = useRouter();
+  const router = useLocalizedRouter();
 
   if (!ready) {
     return null;

--- a/app/[lang]/(dashboard)/settings/page.tsx
+++ b/app/[lang]/(dashboard)/settings/page.tsx
@@ -13,17 +13,16 @@ import { Label } from '@/components/ui/label';
 import { useTranslation } from 'react-i18next';
 import { Lang } from '@/services/langService';
 import type { LangCode } from '@/stores/useLangStore';
-import { useParams, useRouter, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 
 const languageCodes = ['en', 'es', 'fr'] as const;
 
 export default function SettingsPage() {
   const { t, ready } = useTranslation();
-  const params = useParams();
-  const router = useRouter();
+  const router = useLocalizedRouter();
   const pathname = usePathname();
-  const currentLang = (params?.lang as string) || 'en';
 
   // Wait for translations to load
   if (!ready) {
@@ -36,9 +35,9 @@ export default function SettingsPage() {
     const rest = segments.slice(1).join('/');
     const nextPath = `/${nextLang}${rest ? '/' + rest : ''}`;
 
-    // Change language via service and navigate
+    // Change language via service and navigate (use raw Next.js push to avoid double-prefix)
     await Lang.setActive(nextLang as LangCode);
-    router.push(nextPath);
+    window.location.href = nextPath;
   };
 
   return (
@@ -67,7 +66,7 @@ export default function SettingsPage() {
             <Label htmlFor="language">
               {t('common:language_one', { defaultValue: 'Language' })}
             </Label>
-            <Select value={currentLang} onValueChange={handleLanguageChange}>
+            <Select value={router.lang} onValueChange={handleLanguageChange}>
               <SelectTrigger className="w-[200px]">
                 <SelectValue />
               </SelectTrigger>
@@ -85,7 +84,7 @@ export default function SettingsPage() {
 
       <Card
         className="hover:bg-muted/50 cursor-pointer transition-colors"
-        onClick={() => router.push(`/${currentLang}/settings/currencies`)}
+        onClick={() => router.push('/settings/currencies')}
       >
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -106,7 +105,7 @@ export default function SettingsPage() {
       </Card>
       <Card
         className="hover:bg-muted/50 cursor-pointer transition-colors"
-        onClick={() => router.push(`/${currentLang}/settings/service-window`)}
+        onClick={() => router.push('/settings/service-window')}
       >
         <CardHeader>
           <div className="flex items-center justify-between">

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -36,12 +36,10 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     <div className="border-t p-3">
       {image && (
         <div className="mb-2 flex items-center gap-2">
-          <span className="text-xs text-muted-foreground truncate max-w-[200px]">
-            {image.name}
-          </span>
+          <span className="text-muted-foreground max-w-[200px] truncate text-xs">{image.name}</span>
           <button
             type="button"
-            className="text-xs text-destructive hover:underline"
+            className="text-destructive text-xs hover:underline"
             onClick={() => {
               setImage(null);
               if (fileInputRef.current) fileInputRef.current.value = '';

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -14,29 +14,23 @@ export function ChatMessage({ message, isOwn }: ChatMessageProps) {
     <div className={`flex ${isOwn ? 'justify-end' : 'justify-start'} mb-3`}>
       <div
         className={`max-w-[75%] rounded-2xl px-4 py-2 ${
-          isOwn
-            ? 'bg-primary text-primary-foreground'
-            : 'bg-muted text-foreground'
+          isOwn ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
         }`}
       >
         {!isOwn && message.user && (
-          <p className="text-xs font-semibold mb-1 opacity-70">
-            {message.user.name}
-          </p>
+          <p className="mb-1 text-xs font-semibold opacity-70">{message.user.name}</p>
         )}
-        {message.body && (
-          <p className="text-sm whitespace-pre-wrap">{message.body}</p>
-        )}
+        {message.body && <p className="text-sm whitespace-pre-wrap">{message.body}</p>}
         {message.imageUrl && (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={message.imageUrl}
             alt="attachment"
-            className="mt-2 max-w-full rounded-lg max-h-60 object-cover"
+            className="mt-2 max-h-60 max-w-full rounded-lg object-cover"
           />
         )}
         <p
-          className={`text-[10px] mt-1 ${isOwn ? 'text-primary-foreground/60' : 'text-muted-foreground'}`}
+          className={`mt-1 text-[10px] ${isOwn ? 'text-primary-foreground/60' : 'text-muted-foreground'}`}
         >
           {formatDistanceToNow(new Date(message.createdAt), {
             addSuffix: true,

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -21,18 +21,15 @@ interface ChatPanelProps {
   isReadOnly?: boolean;
 }
 
-export function ChatPanel({
-  orderPublicId,
-  orderId,
-  channel,
-  isReadOnly,
-}: ChatPanelProps) {
+export function ChatPanel({ orderPublicId, orderId, channel, isReadOnly }: ChatPanelProps) {
   const { t } = useTranslation();
   const user = useAuthStore((state) => state.user);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
-    useChatMessages(orderPublicId, channel);
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useChatMessages(
+    orderPublicId,
+    channel
+  );
   const sendMessage = useSendMessage(orderPublicId, channel);
   const markRead = useMarkRead(orderPublicId, channel);
 
@@ -72,7 +69,7 @@ export function ChatPanel({
           <div className="mb-4 flex justify-center">
             <button
               type="button"
-              className="text-xs text-muted-foreground hover:underline"
+              className="text-muted-foreground text-xs hover:underline"
               onClick={() => fetchNextPage()}
               disabled={isFetchingNextPage}
             >
@@ -85,34 +82,28 @@ export function ChatPanel({
 
         {isLoading && (
           <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
           </div>
         )}
 
         {!isLoading && messages.length === 0 && (
           <div className="flex items-center justify-center py-8">
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               {t('chat:no_messages', { defaultValue: 'No messages yet' })}
             </p>
           </div>
         )}
 
         {messages.map((message) => (
-          <ChatMessage
-            key={message.id}
-            message={message}
-            isOwn={message.userId === user?.id}
-          />
+          <ChatMessage key={message.id} message={message} isOwn={message.userId === user?.id} />
         ))}
       </ScrollArea>
 
-      {!isReadOnly && (
-        <ChatInput onSend={handleSend} disabled={sendMessage.isPending} />
-      )}
+      {!isReadOnly && <ChatInput onSend={handleSend} disabled={sendMessage.isPending} />}
 
       {isReadOnly && (
         <div className="border-t p-3 text-center">
-          <p className="text-xs text-muted-foreground">
+          <p className="text-muted-foreground text-xs">
             {t('chat:admin_read_only', {
               defaultValue: 'Read-only for admins',
             })}

--- a/components/chat/ChatTabs.tsx
+++ b/components/chat/ChatTabs.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useTranslation } from 'react-i18next';
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { ChatPanel } from './ChatPanel';
 import { useChatUnread } from '@/hooks/chat/useChatUnread';
@@ -17,11 +12,7 @@ interface ChatTabsProps {
   showDelivery?: boolean;
 }
 
-export function ChatTabs({
-  orderPublicId,
-  orderId,
-  showDelivery,
-}: ChatTabsProps) {
+export function ChatTabs({ orderPublicId, orderId, showDelivery }: ChatTabsProps) {
   const { t } = useTranslation();
   const { data: unread } = useChatUnread(orderPublicId);
 
@@ -31,10 +22,7 @@ export function ChatTabs({
         <TabsTrigger value="support" className="flex-1 gap-2">
           {t('chat:support', { defaultValue: 'Support' })}
           {(unread?.support ?? 0) > 0 && (
-            <Badge
-              variant="destructive"
-              className="h-5 min-w-5 px-1 text-xs"
-            >
+            <Badge variant="destructive" className="h-5 min-w-5 px-1 text-xs">
               {unread?.support}
             </Badge>
           )}
@@ -43,10 +31,7 @@ export function ChatTabs({
           <TabsTrigger value="delivery" className="flex-1 gap-2">
             {t('chat:delivery', { defaultValue: 'Delivery' })}
             {(unread?.delivery ?? 0) > 0 && (
-              <Badge
-                variant="destructive"
-                className="h-5 min-w-5 px-1 text-xs"
-              >
+              <Badge variant="destructive" className="h-5 min-w-5 px-1 text-xs">
                 {unread?.delivery}
               </Badge>
             )}
@@ -54,11 +39,7 @@ export function ChatTabs({
         )}
       </TabsList>
       <TabsContent value="support">
-        <ChatPanel
-          orderPublicId={orderPublicId}
-          orderId={orderId}
-          channel="support"
-        />
+        <ChatPanel orderPublicId={orderPublicId} orderId={orderId} channel="support" />
       </TabsContent>
       {showDelivery && (
         <TabsContent value="delivery">

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,14 +1,14 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Tabs as TabsPrimitive } from "radix-ui"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Tabs({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
@@ -16,36 +16,32 @@ function Tabs({
       data-slot="tabs"
       data-orientation={orientation}
       orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
-        className
-      )}
+      className={cn('group/tabs flex gap-2 data-[orientation=horizontal]:flex-col', className)}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
-  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  'rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
   {
     variants: {
       variant: {
-        default: "bg-muted",
-        line: "gap-1 bg-transparent",
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 function TabsList({
   className,
-  variant = "default",
+  variant = 'default',
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List> &
-  VariantProps<typeof tabsListVariants>) {
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -53,39 +49,33 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
-        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground',
+        'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn('flex-1 outline-none', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/hooks/chat/useChatBroadcast.ts
+++ b/hooks/chat/useChatBroadcast.ts
@@ -3,10 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEcho } from '@/providers/EchoProvider';
 import { useAuthStore } from '@/stores/useAuthStore';
 
-export function useChatBroadcast(
-  orderId: number | undefined,
-  channel: string
-) {
+export function useChatBroadcast(orderId: number | undefined, channel: string) {
   const echo = useEcho();
   const token = useAuthStore((state) => state.token);
   const queryClient = useQueryClient();

--- a/hooks/chat/useChatMessages.ts
+++ b/hooks/chat/useChatMessages.ts
@@ -3,11 +3,7 @@ import { ChatService } from '@/services/chatService';
 
 type OrderMessageData = App.Data.Chat.OrderMessageData;
 
-export function useChatMessages(
-  orderPublicId: string,
-  channel: string,
-  enabled = true
-) {
+export function useChatMessages(orderPublicId: string, channel: string, enabled = true) {
   return useInfiniteQuery({
     queryKey: ['chat', orderPublicId, channel],
     queryFn: async ({ pageParam }: { pageParam: number | undefined }) => {

--- a/logs/activity/2026-02-15.md
+++ b/logs/activity/2026-02-15.md
@@ -1,5 +1,11 @@
 # 2026-02-15
 
+## 11:30 — fix: useLocalizedRouter consistency + format chat components
+
+- Fixed dashboard page using plain `useRouter()` — navigation cards pushed paths like `/orders` without lang prefix
+- Fixed settings page manually prefixing `/${currentLang}/...` — now uses `useLocalizedRouter().push('/settings/currencies')`
+- Formatted chat components (prettier only, no logic changes)
+
 ## 10:30 — feat: proof of delivery card + type/enum sync
 
 - New: `components/orders/ProofOfDeliveryCard.tsx` — displays POD photo, signature, and PIN verification on completed orders


### PR DESCRIPTION
## Summary
- **Dashboard**: Used plain `useRouter()` — nav cards pushed `/orders` without lang prefix, breaking localized routes
- **Settings**: Manually prefixed `/${currentLang}/...` instead of using `useLocalizedRouter` hook
- Also formatted chat components (prettier, no logic changes)

## Verification notes
Out of 7 findings audited, only 1 was a real bug:
- #1 (CreateQuoteDialog missing props) — false alarm, props are optional with defaults
- #2 (DispatchBoard error boundary) — false alarm, React Query handles errors
- #3 (negative distance) — false alarm, triple validation (HTML + Zod + backend)
- #5-6 (query params) — already fixed in commit e25f319

## Test plan
- [ ] Click any dashboard card — should navigate to correct lang-prefixed route
- [ ] Click "Currency Settings" / "Service Window" in settings — should navigate correctly
- [ ] Change language in settings — should reload with new lang prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)