### PR TITLE
feat: vehicle type, dispatch policy, and preferred-driver admin UI

### DIFF
--- a/app/[lang]/(dashboard)/addresses/page.tsx
+++ b/app/[lang]/(dashboard)/addresses/page.tsx
@@ -12,7 +12,6 @@ import {
 import { useState } from 'react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -48,7 +47,7 @@ export default function AddressesPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('address', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('address', 2)}</h1>
           <p className="text-muted-foreground">
             {t('addresses:manage_description', {
               defaultValue: 'View saved addresses',
@@ -105,7 +104,7 @@ export default function AddressesPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{validationAttribute('label', true)}</TableHead>
-                  <TableHead>{capitalize(modelLabel('address'))}</TableHead>
+                  <TableHead>{modelLabel('address')}</TableHead>
                   <TableHead>{validationAttribute('city', true)}</TableHead>
                   <TableHead>{validationAttribute('type', true)}</TableHead>
                   <TableHead>{actionLabel('created')}</TableHead>

--- a/app/[lang]/(dashboard)/audit-logs/page.tsx
+++ b/app/[lang]/(dashboard)/audit-logs/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select';
 
 import { useState, useCallback, Fragment } from 'react';
-import { actionLabel, capitalize, modelLabel } from '@/utils/lang';
+import { actionLabel, modelLabel } from '@/utils/lang';
 import { formatDateTime } from '@/utils/format';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
@@ -91,7 +91,7 @@ export default function AuditLogsPage() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold">{capitalize(modelLabel('audit_log', 2))}</h1>
+        <h1 className="text-3xl font-bold">{modelLabel('audit_log', 2)}</h1>
         <p className="text-muted-foreground">
           {t('audit_logs:description', {
             defaultValue: 'Track all changes to orders, payments, settings, and more',
@@ -139,7 +139,7 @@ export default function AuditLogsPage() {
                   <SelectItem key={key} value={key}>
                     {key === 'all'
                       ? t('statuses:all', { defaultValue: 'All' })
-                      : capitalize(modelLabel(key))}
+                      : modelLabel(key)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -231,7 +231,7 @@ export default function AuditLogsPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{t('common:date', { defaultValue: 'Date' })}</TableHead>
-                  <TableHead>{capitalize(modelLabel('user'))}</TableHead>
+                  <TableHead>{modelLabel('user')}</TableHead>
                   <TableHead>{t('common:action', { defaultValue: 'Action' })}</TableHead>
                   <TableHead>{t('common:model', { defaultValue: 'Model' })}</TableHead>
                   <TableHead>ID</TableHead>

--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -82,7 +81,7 @@ export default function BusinessDetailPage() {
           <div>
             <h1 className="text-3xl font-bold">{business.name}</h1>
             <p className="text-muted-foreground">
-              {capitalize(modelLabel('business'))} {business.publicId}
+              {modelLabel('business')} {business.publicId}
             </p>
           </div>
         </div>

--- a/app/[lang]/(dashboard)/businesses/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/page.tsx
@@ -12,7 +12,6 @@ import {
 import { useState } from 'react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -49,7 +48,7 @@ export default function BusinessesPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('business', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('business', 2)}</h1>
           <p className="text-muted-foreground">
             {t('businesses:manage_description', { defaultValue: 'Manage business accounts' })}
           </p>

--- a/app/[lang]/(dashboard)/catalogs/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/catalogs/[id]/page.tsx
@@ -19,7 +19,6 @@ import {
 import { ArrowLeft, Database, List, Calendar, Pencil, Plus } from 'lucide-react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -102,7 +101,7 @@ export default function CatalogDetailPage() {
             <Badge variant="outline">{catalog.code}</Badge>
           </div>
           <p className="text-muted-foreground">
-            {capitalize(modelLabel('catalog'))} #{catalog.id}
+            {modelLabel('catalog')} #{catalog.id}
           </p>
         </div>
       </div>

--- a/app/[lang]/(dashboard)/catalogs/page.tsx
+++ b/app/[lang]/(dashboard)/catalogs/page.tsx
@@ -12,7 +12,6 @@ import {
 import { useState } from 'react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -50,7 +49,7 @@ export default function CatalogsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('catalog', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('catalog', 2)}</h1>
           <p className="text-muted-foreground">
             {t('catalogs:manage_description', { defaultValue: 'Manage catalog data' })}
           </p>

--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -162,7 +162,7 @@ export default function DriverDetailPage() {
               {driver.user?.name || t('common:unknown', { defaultValue: 'Unknown' })}
             </h1>
             <p className="text-muted-foreground">
-              {capitalize(modelLabel('driver'))} {driver.publicId}
+              {modelLabel('driver')} {driver.publicId}
             </p>
           </div>
         </div>

--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -7,10 +7,20 @@ import {
   resourceMessage,
   statusLabel,
   validationAttribute,
+  vehicleTypeLabel,
+  dispatchPolicyLabel,
 } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useCallback, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -128,6 +138,9 @@ export default function DriverDetailPage() {
   }
 
   const expired = isLicenseExpired(driver.licenseExpirationDate);
+  // `isOutsourced` was replaced by `dispatchPolicy`: catch-all drivers are the outsourced ones
+  // (see api/database/migrations/2026_07_21_095445_add_vehicle_and_dispatch_policy_to_drivers_table.php).
+  const isOutsourced = driver.dispatchPolicy === Enums.DispatchPolicy.CatchAll;
   const baseCenter =
     driver.baseLatitude != null && driver.baseLongitude != null
       ? { lat: driver.baseLatitude, lng: driver.baseLongitude }
@@ -178,7 +191,7 @@ export default function DriverDetailPage() {
           <TabsTrigger value="details">
             {t('drivers:tabs.details', { defaultValue: 'Details' })}
           </TabsTrigger>
-          {!driver.isOutsourced && (
+          {!isOutsourced && (
             <TabsTrigger value="schedule">
               {t('drivers:tabs.schedule', { defaultValue: 'Schedule' })}
             </TabsTrigger>
@@ -253,17 +266,77 @@ export default function DriverDetailPage() {
 
             <Card>
               <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Car className="h-5 w-5" />
-                  {t('drivers:detail.vehicle_info', { defaultValue: 'Vehicle Information' })}
+                <CardTitle className="flex items-center justify-between gap-2">
+                  <span className="flex items-center gap-2">
+                    <Car className="h-5 w-5" />
+                    {t('drivers:detail.vehicle_info', { defaultValue: 'Vehicle Information' })}
+                  </span>
+                  <Badge variant="outline">
+                    {capitalize(vehicleTypeLabel(driver.defaultVehicleType))} ·{' '}
+                    {capitalize(dispatchPolicyLabel(driver.dispatchPolicy))}
+                  </Badge>
                 </CardTitle>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">
                     {validationAttribute('licensePlate', true)}
                   </span>
                   <span className="font-medium">{driver.licensePlateNumber || '-'}</span>
+                </div>
+
+                <div className="grid gap-2">
+                  <Label className="text-muted-foreground text-sm">
+                    {t('drivers:default_vehicle_type', { defaultValue: 'Default Vehicle' })}
+                  </Label>
+                  <Select
+                    value={driver.defaultVehicleType}
+                    onValueChange={(value) =>
+                      updateDriver.mutate({
+                        id: driverId,
+                        data: { defaultVehicleType: value as App.Enums.VehicleType },
+                      })
+                    }
+                    disabled={updateDriver.isPending}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.values(Enums.VehicleType).map((vt) => (
+                        <SelectItem key={vt} value={vt}>
+                          {capitalize(vehicleTypeLabel(vt))}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="grid gap-2">
+                  <Label className="text-muted-foreground text-sm">
+                    {t('drivers:dispatch_policy', { defaultValue: 'Dispatch Policy' })}
+                  </Label>
+                  <Select
+                    value={driver.dispatchPolicy}
+                    onValueChange={(value) =>
+                      updateDriver.mutate({
+                        id: driverId,
+                        data: { dispatchPolicy: value as App.Enums.DispatchPolicy },
+                      })
+                    }
+                    disabled={updateDriver.isPending}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.values(Enums.DispatchPolicy).map((policy) => (
+                        <SelectItem key={policy} value={policy}>
+                          {capitalize(dispatchPolicyLabel(policy))}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </CardContent>
             </Card>
@@ -288,7 +361,7 @@ export default function DriverDetailPage() {
             </Card>
 
             {/* Base Location — internal drivers only */}
-            {!driver.isOutsourced && (
+            {!isOutsourced && (
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
@@ -349,7 +422,7 @@ export default function DriverDetailPage() {
           </div>
         </TabsContent>
 
-        {!driver.isOutsourced && (
+        {!isOutsourced && (
           <TabsContent value="schedule">
             <DriverScheduleTab driverId={driverId} />
           </TabsContent>

--- a/app/[lang]/(dashboard)/drivers/create/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/page.tsx
@@ -189,7 +189,7 @@ export default function CreateDriverPage() {
           <ArrowLeft className="h-5 w-5" />
         </Button>
         <h1 className="text-3xl font-bold">
-          {t('resource:create_one', { resource: capitalize(modelLabel('driver')) })}
+          {t('resource:create_one', { resource: modelLabel('driver') })}
         </h1>
       </div>
 

--- a/app/[lang]/(dashboard)/drivers/create/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/page.tsx
@@ -93,13 +93,13 @@ export default function CreateDriverPage() {
   const [uploadingBack, setUploadingBack] = useState(false);
 
   const { data: sexOptions } = useQuery({
-    queryKey: ['catalogs', 'SEX', 'elements'],
-    queryFn: () => CatalogService.getElementsByCode('SEX'),
+    queryKey: ['catalogs', 'sex', 'elements'],
+    queryFn: () => CatalogService.getElementsByCode('sex'),
   });
 
   const { data: langOptions } = useQuery({
-    queryKey: ['catalogs', 'LANGUAGE', 'elements'],
-    queryFn: () => CatalogService.getElementsByCode('LANGUAGE'),
+    queryKey: ['catalogs', 'language', 'elements'],
+    queryFn: () => CatalogService.getElementsByCode('language'),
   });
 
   const form = useForm<FormValues>({

--- a/app/[lang]/(dashboard)/drivers/create/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/page.tsx
@@ -12,7 +12,15 @@ import { useCreateDriver } from '@/hooks/drivers';
 import { CatalogService } from '@/services/catalogService';
 import { UploadService } from '@/services/uploadService';
 import { applyApiErrorsToForm } from '@/utils/form';
-import { actionLabel, validationAttribute, capitalize, modelLabel } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  validationAttribute,
+  vehicleTypeLabel,
+  dispatchPolicyLabel,
+} from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -60,6 +68,17 @@ const formSchema = z.object({
     .refine((val) => new Date(val) > today, { message: 'Must be a future date' }),
   licensePhotoFront: z.string().min(1),
   licensePhotoBack: z.string().min(1),
+  defaultVehicleType: z.enum([
+    Enums.VehicleType.Motorcycle,
+    Enums.VehicleType.Car,
+    Enums.VehicleType.PickupVan,
+    Enums.VehicleType.Truck,
+  ]),
+  dispatchPolicy: z.enum([
+    Enums.DispatchPolicy.Auto,
+    Enums.DispatchPolicy.CatchAll,
+    Enums.DispatchPolicy.ManualOnly,
+  ]),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -101,6 +120,8 @@ export default function CreateDriverPage() {
       licenseExpirationDate: '',
       licensePhotoFront: '',
       licensePhotoBack: '',
+      defaultVehicleType: Enums.VehicleType.Car,
+      dispatchPolicy: Enums.DispatchPolicy.Auto,
     },
   });
 
@@ -132,6 +153,8 @@ export default function CreateDriverPage() {
         licenseExpirationDate: values.licenseExpirationDate,
         licensePhotoFront: values.licensePhotoFront,
         licensePhotoBack: values.licensePhotoBack,
+        defaultVehicleType: values.defaultVehicleType as App.Enums.VehicleType,
+        dispatchPolicy: values.dispatchPolicy as App.Enums.DispatchPolicy,
       });
       router.push('/drivers');
     } catch (error) {
@@ -149,6 +172,8 @@ export default function CreateDriverPage() {
         license_expiration_date: 'licenseExpirationDate',
         license_photo_front: 'licensePhotoFront',
         license_photo_back: 'licensePhotoBack',
+        default_vehicle_type: 'defaultVehicleType',
+        dispatch_policy: 'dispatchPolicy',
       });
     }
   };
@@ -455,6 +480,72 @@ export default function CreateDriverPage() {
                           )}
                         </div>
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Vehicle & Dispatch */}
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                {t('drivers:vehicle_dispatch_info', { defaultValue: 'Vehicle & Dispatch' })}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="defaultVehicleType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        {t('drivers:default_vehicle_type', { defaultValue: 'Default Vehicle' })}
+                      </FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {Object.values(Enums.VehicleType).map((vt) => (
+                            <SelectItem key={vt} value={vt}>
+                              {capitalize(vehicleTypeLabel(vt))}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="dispatchPolicy"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        {t('drivers:dispatch_policy', { defaultValue: 'Dispatch Policy' })}
+                      </FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {Object.values(Enums.DispatchPolicy).map((policy) => (
+                            <SelectItem key={policy} value={policy}>
+                              {capitalize(dispatchPolicyLabel(policy))}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -17,6 +17,8 @@ import {
   resourceMessage,
   statusLabel,
   validationAttribute,
+  vehicleTypeLabel,
+  dispatchPolicyLabel,
 } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useDriverList } from '@/hooks/drivers';
@@ -116,6 +118,9 @@ export default function DriversPage() {
                 <TableRow>
                   <TableHead>{t('models:driver_one', { defaultValue: 'Driver' })}</TableHead>
                   <TableHead>{t('common:status', { defaultValue: 'Status' })}</TableHead>
+                  <TableHead>
+                    {t('drivers:vehicle_dispatch_info', { defaultValue: 'Vehicle & Dispatch' })}
+                  </TableHead>
                   <TableHead>{validationAttribute('licenseNumber', true)}</TableHead>
                   <TableHead>{validationAttribute('licensePlate', true)}</TableHead>
                   <TableHead>{validationAttribute('licenseExpires', true)}</TableHead>
@@ -143,6 +148,12 @@ export default function DriversPage() {
                     <TableCell>
                       <Badge variant={driver.active !== false ? 'default' : 'secondary'}>
                         {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        {capitalize(vehicleTypeLabel(driver.defaultVehicleType))} ·{' '}
+                        {capitalize(dispatchPolicyLabel(driver.dispatchPolicy))}
                       </Badge>
                     </TableCell>
                     <TableCell>{driver.licenseNumber || '-'}</TableCell>

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -64,7 +64,7 @@ export default function DriversPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('driver', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('driver', 2)}</h1>
           <p className="text-muted-foreground">
             {t('drivers:manage_description', { defaultValue: 'Manage driver accounts' })}
           </p>
@@ -116,7 +116,7 @@ export default function DriversPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>{t('models:driver_one', { defaultValue: 'Driver' })}</TableHead>
+                  <TableHead>{modelLabel('driver')}</TableHead>
                   <TableHead>{t('common:status', { defaultValue: 'Status' })}</TableHead>
                   <TableHead>
                     {t('drivers:vehicle_dispatch_info', { defaultValue: 'Vehicle & Dispatch' })}

--- a/app/[lang]/(dashboard)/notifications/page.tsx
+++ b/app/[lang]/(dashboard)/notifications/page.tsx
@@ -119,7 +119,7 @@ export default function NotificationsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('notification', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('notification', 2)}</h1>
           <p className="text-muted-foreground">
             {t('notifications:page_description', {
               defaultValue: 'View and manage your notifications',
@@ -333,7 +333,7 @@ export default function NotificationsPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-12"></TableHead>
-                  <TableHead>{capitalize(modelLabel('notification'))}</TableHead>
+                  <TableHead>{modelLabel('notification')}</TableHead>
                   <TableHead className="w-32">
                     {t('common:status', { defaultValue: 'Status' })}
                   </TableHead>

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -19,7 +19,6 @@ import {
 import { useState, useCallback } from 'react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   statusLabel,
@@ -102,7 +101,7 @@ export default function OrdersPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('order', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('order', 2)}</h1>
           <p className="text-muted-foreground">
             {t('orders:manage_description', { defaultValue: 'Manage delivery orders and quotes' })}
           </p>
@@ -263,7 +262,7 @@ export default function OrdersPage() {
                   </TableHead>
                   <TableHead>{t('orders:detail.stops', { defaultValue: 'Stops' })}</TableHead>
                   <TableHead>{t('orders:to', { defaultValue: 'To' })}</TableHead>
-                  <TableHead>{capitalize(modelLabel('quote'))}</TableHead>
+                  <TableHead>{modelLabel('quote')}</TableHead>
                   <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>

--- a/app/[lang]/(dashboard)/quotes/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/quotes/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -109,7 +108,7 @@ export default function QuoteDetailPage() {
           <div>
             <div className="flex items-center gap-3">
               <h1 className="text-3xl font-bold">
-                {capitalize(modelLabel('quote'))} {quote.publicId}
+                {modelLabel('quote')} {quote.publicId}
               </h1>
               <QuoteStatusBadge status={quote.status as QuoteStatus} />
             </div>
@@ -150,7 +149,7 @@ export default function QuoteDetailPage() {
             </div>
             {quote.orderId && (
               <div className="flex justify-between">
-                <span className="text-muted-foreground">{capitalize(modelLabel('order'))}</span>
+                <span className="text-muted-foreground">{modelLabel('order')}</span>
                 <Button
                   variant="link"
                   className="h-auto p-0"

--- a/app/[lang]/(dashboard)/quotes/page.tsx
+++ b/app/[lang]/(dashboard)/quotes/page.tsx
@@ -19,7 +19,6 @@ import {
 import { useState } from 'react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   statusLabel,
@@ -89,7 +88,7 @@ export default function QuotesPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('quote', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('quote', 2)}</h1>
           <p className="text-muted-foreground">
             {t('quotes:manage_description', { defaultValue: 'Create and manage delivery quotes' })}
           </p>
@@ -220,7 +219,7 @@ export default function QuotesPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{validationAttribute('id', true)}</TableHead>
-                  <TableHead>{capitalize(modelLabel('order'))}</TableHead>
+                  <TableHead>{modelLabel('order')}</TableHead>
                   <TableHead>{validationAttribute('status', true)}</TableHead>
                   <TableHead>{validationAttribute('total', true)}</TableHead>
                   <TableHead>{t('quotes:valid_until', { defaultValue: 'Valid Until' })}</TableHead>

--- a/app/[lang]/(dashboard)/settings/page.tsx
+++ b/app/[lang]/(dashboard)/settings/page.tsx
@@ -38,7 +38,7 @@ export default function SettingsPage() {
 
   // Initialize local state from fetched data
   if (vehicleTypesData && !vehicleTypesInitialized) {
-    setSupportedVehicleTypes(vehicleTypesData.supportedVehicleTypes);
+    setSupportedVehicleTypes(vehicleTypesData.supportedVehicleTypes ?? []);
     setVehicleTypesInitialized(true);
   }
 

--- a/app/[lang]/(dashboard)/settings/page.tsx
+++ b/app/[lang]/(dashboard)/settings/page.tsx
@@ -7,15 +7,21 @@ import {
   SelectItem,
   Select,
 } from '@/components/ui/select';
-import { Globe, Coins, Clock, ChevronRight } from 'lucide-react';
+import { Globe, Coins, Clock, Truck, ChevronRight } from 'lucide-react';
 
+import { useState } from 'react';
 import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { useTranslation } from 'react-i18next';
 import { Lang } from '@/services/langService';
 import type { LangCode } from '@/stores/useLangStore';
 import { usePathname } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
+import { useSupportedVehicleTypes, useUpdateSupportedVehicleTypes } from '@/hooks/settings';
+import { Enums } from '@/data/app-enums';
+import { actionLabel, capitalize, vehicleTypeLabel } from '@/utils/lang';
 
 const languageCodes = ['en', 'es', 'fr'] as const;
 
@@ -23,6 +29,28 @@ export default function SettingsPage() {
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
   const pathname = usePathname();
+
+  const { data: vehicleTypesData, isLoading: vehicleTypesLoading } = useSupportedVehicleTypes();
+  const updateVehicleTypes = useUpdateSupportedVehicleTypes();
+
+  const [supportedVehicleTypes, setSupportedVehicleTypes] = useState<string[]>([]);
+  const [vehicleTypesInitialized, setVehicleTypesInitialized] = useState(false);
+
+  // Initialize local state from fetched data
+  if (vehicleTypesData && !vehicleTypesInitialized) {
+    setSupportedVehicleTypes(vehicleTypesData.supportedVehicleTypes);
+    setVehicleTypesInitialized(true);
+  }
+
+  const toggleVehicleType = (value: string) => {
+    setSupportedVehicleTypes((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
+  };
+
+  const handleSaveVehicleTypes = () => {
+    updateVehicleTypes.mutate(supportedVehicleTypes);
+  };
 
   // Wait for translations to load
   if (!ready) {
@@ -79,6 +107,53 @@ export default function SettingsPage() {
               </SelectContent>
             </Select>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Truck className="h-5 w-5" />
+            {t('common:supported_vehicle_types', { defaultValue: 'Supported Vehicle Types' })}
+          </CardTitle>
+          <CardDescription>
+            {t('common:supported_vehicle_types_description', {
+              defaultValue: 'Choose which vehicle types drivers can be assigned in this fleet',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {vehicleTypesLoading ? (
+            <div className="flex items-center justify-center py-6">
+              <div className="border-primary h-6 w-6 animate-spin rounded-full border-4 border-t-transparent" />
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {Object.values(Enums.VehicleType).map((vt) => (
+                  <div key={vt} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`vehicle-type-${vt}`}
+                      checked={supportedVehicleTypes.includes(vt)}
+                      onCheckedChange={() => toggleVehicleType(vt)}
+                    />
+                    <Label htmlFor={`vehicle-type-${vt}`} className="font-normal">
+                      {capitalize(vehicleTypeLabel(vt))}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+              <Button
+                onClick={handleSaveVehicleTypes}
+                disabled={updateVehicleTypes.isPending}
+                size="sm"
+              >
+                {updateVehicleTypes.isPending
+                  ? t('common:saving', { defaultValue: 'Saving...' })
+                  : actionLabel('save')}
+              </Button>
+            </>
+          )}
         </CardContent>
       </Card>
 

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -107,7 +106,7 @@ export default function UserDetailPage() {
               <RoleBadge role={user.role as Role} />
             </div>
             <p className="text-muted-foreground">
-              {capitalize(modelLabel('user'))} {user.publicId}
+              {modelLabel('user')} {user.publicId}
             </p>
           </div>
         </div>

--- a/app/[lang]/(dashboard)/users/page.tsx
+++ b/app/[lang]/(dashboard)/users/page.tsx
@@ -19,7 +19,6 @@ import {
 import { useState } from 'react';
 import {
   actionLabel,
-  capitalize,
   modelLabel,
   resourceMessage,
   validationAttribute,
@@ -88,7 +87,7 @@ export default function UsersPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{capitalize(modelLabel('user', 2))}</h1>
+          <h1 className="text-3xl font-bold">{modelLabel('user', 2)}</h1>
           <p className="text-muted-foreground">
             {t('users:manage_description', { defaultValue: 'Manage user accounts' })}
           </p>
@@ -160,7 +159,7 @@ export default function UsersPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>{capitalize(modelLabel('user'))}</TableHead>
+                  <TableHead>{modelLabel('user')}</TableHead>
                   <TableHead>{validationAttribute('email', true)}</TableHead>
                   <TableHead>{validationAttribute('role', true)}</TableHead>
                   <TableHead>{validationAttribute('phone', true)}</TableHead>

--- a/components/drivers/DriverScheduleTab.tsx
+++ b/components/drivers/DriverScheduleTab.tsx
@@ -59,6 +59,7 @@ export function DriverScheduleTab({ driverId }: Props) {
   const [dialogDate, setDialogDate] = useState('');
   const [dialogStartTime, setDialogStartTime] = useState<string | undefined>();
   const [dialogEndTime, setDialogEndTime] = useState<string | undefined>();
+  const [dialogVehicleType, setDialogVehicleType] = useState<App.Enums.VehicleType | null>(null);
   // Track original startTime when editing, so we can identify which block to replace
   const [editOriginalStartTime, setEditOriginalStartTime] = useState<string | undefined>();
 
@@ -102,6 +103,7 @@ export function DriverScheduleTab({ driverId }: Props) {
       setDialogDate(dateStr);
       setDialogStartTime(timeStr);
       setDialogEndTime(undefined);
+      setDialogVehicleType(null);
       setDialogOpen(true);
     },
     [isPastDate]
@@ -116,6 +118,7 @@ export function DriverScheduleTab({ driverId }: Props) {
       setDialogMode('edit');
       setDialogDate(dateStr);
       setEditOriginalStartTime(props._startTime);
+      setDialogVehicleType(props._vehicleType ?? null);
 
       if (arg.event.start) {
         setDialogStartTime(formatTimeHHMM(arg.event.start));
@@ -217,6 +220,7 @@ export function DriverScheduleTab({ driverId }: Props) {
         date={dialogDate}
         startTime={dialogStartTime}
         endTime={dialogEndTime}
+        vehicleType={dialogVehicleType}
         isSaving={syncSchedules.isPending}
         onSave={handleSaveEntry}
         onDelete={handleDeleteEntry}

--- a/components/drivers/ScheduleEventDialog.tsx
+++ b/components/drivers/ScheduleEventDialog.tsx
@@ -7,14 +7,25 @@ import {
   DialogTitle,
   Dialog,
 } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
-import { actionLabel } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+import { actionLabel, capitalize, vehicleTypeLabel } from '@/utils/lang';
 
 type ScheduleEntry = App.Data.Driver.DriverScheduleData;
+type VehicleType = App.Enums.VehicleType;
+
+const USE_DEFAULT_VEHICLE = '__use_default__';
 
 interface ScheduleEventDialogProps {
   open: boolean;
@@ -23,6 +34,7 @@ interface ScheduleEventDialogProps {
   date: string;
   startTime?: string;
   endTime?: string;
+  vehicleType?: VehicleType | null;
   isSaving?: boolean;
   onSave: (entry: ScheduleEntry) => void;
   onDelete?: () => void;
@@ -35,20 +47,23 @@ export function ScheduleEventDialog({
   date,
   startTime: initialStartTime,
   endTime: initialEndTime,
+  vehicleType: initialVehicleType,
   isSaving,
   onSave,
   onDelete,
 }: ScheduleEventDialogProps) {
   const { t } = useTranslation();
-  const resetKey = `${date}-${initialStartTime}-${initialEndTime}`;
+  const resetKey = `${date}-${initialStartTime}-${initialEndTime}-${initialVehicleType}`;
   const [prevResetKey, setPrevResetKey] = useState(resetKey);
   const [startTime, setStartTime] = useState(initialStartTime ?? '08:00');
   const [endTime, setEndTime] = useState(initialEndTime ?? '17:00');
+  const [vehicleType, setVehicleType] = useState<VehicleType | null>(initialVehicleType ?? null);
 
   if (resetKey !== prevResetKey) {
     setPrevResetKey(resetKey);
     setStartTime(initialStartTime ?? '08:00');
     setEndTime(initialEndTime ?? '17:00');
+    setVehicleType(initialVehicleType ?? null);
   }
 
   const isTimeValid = startTime < endTime;
@@ -60,6 +75,7 @@ export function ScheduleEventDialog({
       date,
       startTime,
       endTime,
+      vehicleType,
     };
 
     onSave(entry);
@@ -120,6 +136,34 @@ export function ScheduleEventDialog({
                 })}
               </p>
             )}
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-sm">
+              {t('drivers:schedule.vehicle_override', { defaultValue: 'Vehicle Override' })}
+            </Label>
+            <Select
+              value={vehicleType ?? USE_DEFAULT_VEHICLE}
+              onValueChange={(value) =>
+                setVehicleType(value === USE_DEFAULT_VEHICLE ? null : (value as VehicleType))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={USE_DEFAULT_VEHICLE}>
+                  {t('drivers:schedule.use_default_vehicle', {
+                    defaultValue: 'Use default vehicle',
+                  })}
+                </SelectItem>
+                {Object.values(Enums.VehicleType).map((vt) => (
+                  <SelectItem key={vt} value={vt}>
+                    {capitalize(vehicleTypeLabel(vt))}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
 

--- a/components/notifications/NotificationDropdown.tsx
+++ b/components/notifications/NotificationDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslation } from 'react-i18next';
-import { capitalize, modelLabel } from '@/utils/lang';
+import { modelLabel } from '@/utils/lang';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
@@ -34,7 +34,7 @@ export function NotificationDropdown({ onClose }: NotificationDropdownProps) {
     <div className="flex flex-col">
       <div className="flex items-center justify-between border-b p-4">
         <div className="flex items-center gap-2">
-          <h4 className="font-semibold">{capitalize(modelLabel('notification', 2))}</h4>
+          <h4 className="font-semibold">{modelLabel('notification', 2)}</h4>
           {isFetching && !isLoading && (
             <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
           )}

--- a/components/orders/AssignDriverModal.tsx
+++ b/components/orders/AssignDriverModal.tsx
@@ -55,7 +55,9 @@ export function AssignDriverModal({ order }: AssignDriverModalProps) {
   const assignOrder = useAssignOrder();
 
   const candidates = feasibility?.candidates ?? [];
-  const drivers = driversData?.items ?? [];
+  // Inactive drivers can never be assigned (the API blocks it), so keep them out
+  // of the override list — ranked candidates are already active.
+  const drivers = (driversData?.items ?? []).filter((d) => d.active);
 
   const handleOpenChange = (val: boolean) => {
     if (!val) {

--- a/components/orders/AssignDriverModal.tsx
+++ b/components/orders/AssignDriverModal.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useFeasibilityCheck } from '@/hooks/feasibility';
+import { useDriverList } from '@/hooks/drivers';
+import { useAssignOrder } from '@/hooks/orders';
+import { actionLabel, vehicleTypeLabel, dispatchPolicyLabel } from '@/utils/lang';
+import { formatDateTime } from '@/utils/format';
+import { ChevronDown, UserPlus, Users } from 'lucide-react';
+
+type DriverCandidate = App.Data.Feasibility.DriverCandidate;
+
+interface AssignDriverModalOrder {
+  publicId: string;
+  /** DTO enum value — kept as string per project convention for enum-from-DTO props */
+  finalVehicleType?: string | null;
+}
+
+interface AssignDriverModalProps {
+  order: AssignDriverModalOrder;
+}
+
+export function AssignDriverModal({ order }: AssignDriverModalProps) {
+  const { t } = useTranslation('orders');
+  const [open, setOpen] = useState(false);
+  const [selectedCandidateId, setSelectedCandidateId] = useState<number | null>(null);
+  const [overrideOpen, setOverrideOpen] = useState(false);
+  const [overrideDriverId, setOverrideDriverId] = useState<string>('');
+
+  const { data: feasibility, isLoading } = useFeasibilityCheck({
+    orderPublicId: order.publicId,
+    enabled: open,
+  });
+  const { data: driversData } = useDriverList({ perPage: 200, enabled: open });
+  const assignOrder = useAssignOrder();
+
+  const candidates = feasibility?.candidates ?? [];
+  const drivers = driversData?.items ?? [];
+
+  const handleOpenChange = (val: boolean) => {
+    if (!val) {
+      setSelectedCandidateId(null);
+      setOverrideDriverId('');
+      setOverrideOpen(false);
+    }
+    setOpen(val);
+  };
+
+  const handleAssign = (driverId: number) => {
+    assignOrder.mutate(
+      { orderPublicId: order.publicId, driverId },
+      { onSuccess: () => handleOpenChange(false) }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <UserPlus className="mr-1 h-4 w-4" />
+          {t('assign_driver.button', { defaultValue: 'Assign Driver' })}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('assign_driver.title', { defaultValue: 'Assign Driver' })}</DialogTitle>
+          <DialogDescription>
+            {t('assign_driver.description', {
+              defaultValue: 'Pick a ranked candidate below, or override with any active driver.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {order.finalVehicleType && (
+            <div className="text-muted-foreground flex items-center gap-2 text-sm">
+              <span>{t('assign_driver.requires_vehicle', { defaultValue: 'Requires:' })}</span>
+              <Badge variant="secondary">{vehicleTypeLabel(order.finalVehicleType)}</Badge>
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="text-muted-foreground py-8 text-center text-sm">
+              {t('common:loading', { defaultValue: 'Loading...' })}
+            </div>
+          ) : candidates.length === 0 ? (
+            <div className="text-muted-foreground rounded-md border border-dashed py-8 text-center text-sm">
+              {t('assign_driver.no_candidates', {
+                defaultValue:
+                  'No internal candidates found. Pick a driver below, or outsource this order elsewhere.',
+              })}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {candidates.map((candidate) => (
+                <CandidateRow
+                  key={candidate.driverId}
+                  candidate={candidate}
+                  selected={selectedCandidateId === candidate.driverId}
+                  onSelect={() => setSelectedCandidateId(candidate.driverId)}
+                />
+              ))}
+            </div>
+          )}
+
+          <Collapsible open={overrideOpen} onOpenChange={setOverrideOpen}>
+            <CollapsibleTrigger asChild>
+              <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+                <Users className="mr-1 h-4 w-4" />
+                {t('assign_driver.override_toggle', { defaultValue: 'Assign a different driver' })}
+                <ChevronDown
+                  className={`ml-1 h-4 w-4 transition-transform ${overrideOpen ? 'rotate-180' : ''}`}
+                />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-2 pt-2">
+              <Select value={overrideDriverId} onValueChange={setOverrideDriverId}>
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={t('assign_driver.override_placeholder', {
+                      defaultValue: 'Select any active driver',
+                    })}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {drivers.map((driver) => (
+                    <SelectItem key={driver.id} value={String(driver.id)}>
+                      {driver.user?.name ?? `Driver #${driver.publicId}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={!overrideDriverId || assignOrder.isPending}
+                onClick={() => handleAssign(Number(overrideDriverId))}
+              >
+                {assignOrder.isPending
+                  ? t('common:loading', { defaultValue: 'Loading...' })
+                  : t('assign_driver.assign_override', { defaultValue: 'Assign This Driver' })}
+              </Button>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button
+            type="button"
+            disabled={selectedCandidateId == null || assignOrder.isPending}
+            onClick={() => selectedCandidateId != null && handleAssign(selectedCandidateId)}
+          >
+            {assignOrder.isPending
+              ? t('common:loading', { defaultValue: 'Loading...' })
+              : t('assign_driver.assign_selected', { defaultValue: 'Assign Selected Driver' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CandidateRow({
+  candidate,
+  selected,
+  onSelect,
+}: {
+  candidate: DriverCandidate;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const { t } = useTranslation('orders');
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full rounded-lg border p-3 text-left transition-colors ${
+        selected ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'
+      }`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-medium">{candidate.driverName}</span>
+        <div className="flex flex-wrap gap-1.5">
+          <Badge variant="outline">{vehicleTypeLabel(candidate.vehicleType)}</Badge>
+          <Badge variant="outline">{dispatchPolicyLabel(candidate.dispatchPolicy)}</Badge>
+        </div>
+      </div>
+      <div className="text-muted-foreground mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        <span>
+          {t('assign_driver.onboard_load', {
+            count: candidate.onboardLoad,
+            defaultValue: `Carrying ${candidate.onboardLoad}`,
+          })}
+        </span>
+        <span>
+          {t('assign_driver.extra_distance', {
+            km: candidate.extraDistanceKm.toFixed(1),
+            defaultValue: `+${candidate.extraDistanceKm.toFixed(1)} km`,
+          })}
+        </span>
+        {candidate.suggestedPickup && (
+          <span>
+            {t('assign_driver.suggested_pickup', {
+              time: formatDateTime(candidate.suggestedPickup),
+              defaultValue: `Pickup: ${formatDateTime(candidate.suggestedPickup)}`,
+            })}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/components/orders/CreateQuoteDialog.tsx
+++ b/components/orders/CreateQuoteDialog.tsx
@@ -99,8 +99,11 @@ export function CreateQuoteDialog({
 
   const [formData, setFormData] = useState(getDefaultFormData);
   const [items, setItems] = useState<QuoteLineItem[]>([]);
-  // Preferred driver chosen by the admin (null = use system suggestion / leave to admin).
-  const [preferredDriverId, setPreferredDriverId] = useState<number | null>(null);
+  // Preferred driver selection, tri-state:
+  //   undefined = untouched → accept the system suggestion
+  //   number    = explicit override
+  //   null      = explicit "none" → leave for manual assignment
+  const [preferredDriverId, setPreferredDriverId] = useState<number | null | undefined>(undefined);
   // stopPublicId → minutes the driver is occupied at that stop. Only holds
   // admin overrides; the editor falls back to the default for absent stops.
   const [stopDurations, setStopDurations] = useState<Record<string, number>>({});
@@ -116,9 +119,12 @@ export function CreateQuoteDialog({
       ? toDateTimeLocal(new Date(feasibility.suggestedDelivery))
       : formData.deliveryProposedFor;
 
-  // Top-ranked candidate is the system suggestion; explicit choice overrides it.
+  // Top-ranked candidate is the system suggestion; an explicit choice (a driver
+  // id, or null for "none") overrides it. An untouched selector accepts the
+  // suggestion.
   const suggestedDriverId = feasibility?.candidates?.[0]?.driverId ?? null;
-  const effectivePreferredDriverId = preferredDriverId ?? suggestedDriverId;
+  const effectivePreferredDriverId =
+    preferredDriverId === undefined ? suggestedDriverId : preferredDriverId;
 
   // Auto-calculate distance when dialog opens if not yet calculated
   useEffect(() => {
@@ -145,7 +151,8 @@ export function CreateQuoteDialog({
       setEditingTimes(false);
       setItems([]);
       setStopDurations({});
-      setPreferredDriverId(null);
+      // undefined = untouched, so an unedited quote accepts the suggestion.
+      setPreferredDriverId(undefined);
     }
     setOpen(isOpen);
   };

--- a/components/orders/CreateQuoteDialog.tsx
+++ b/components/orders/CreateQuoteDialog.tsx
@@ -21,6 +21,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useTranslation } from 'react-i18next';
+import { QuoteDriverSelector } from './QuoteDriverSelector';
 import { useCurrencyList } from '@/hooks/currencies';
 import { useCalculatePricing } from '@/hooks/pricing';
 import { useCreateQuote, useSendQuote } from '@/hooks/quotes';
@@ -32,6 +33,7 @@ import {
   toDateTimeLocal,
   dateTimeLocalToISO,
   formatDateTime,
+  extractDatePart,
 } from '@/utils/format';
 import { formatRateDisplay } from '@/utils/currency';
 import { Enums } from '@/data/app-enums';
@@ -97,6 +99,8 @@ export function CreateQuoteDialog({
 
   const [formData, setFormData] = useState(getDefaultFormData);
   const [items, setItems] = useState<QuoteLineItem[]>([]);
+  // Preferred driver chosen by the admin (null = use system suggestion / leave to admin).
+  const [preferredDriverId, setPreferredDriverId] = useState<number | null>(null);
   // stopPublicId → minutes the driver is occupied at that stop. Only holds
   // admin overrides; the editor falls back to the default for absent stops.
   const [stopDurations, setStopDurations] = useState<Record<string, number>>({});
@@ -111,6 +115,10 @@ export function CreateQuoteDialog({
     !editingTimes && feasibility?.suggestedDelivery
       ? toDateTimeLocal(new Date(feasibility.suggestedDelivery))
       : formData.deliveryProposedFor;
+
+  // Top-ranked candidate is the system suggestion; explicit choice overrides it.
+  const suggestedDriverId = feasibility?.candidates?.[0]?.driverId ?? null;
+  const effectivePreferredDriverId = preferredDriverId ?? suggestedDriverId;
 
   // Auto-calculate distance when dialog opens if not yet calculated
   useEffect(() => {
@@ -137,6 +145,7 @@ export function CreateQuoteDialog({
       setEditingTimes(false);
       setItems([]);
       setStopDurations({});
+      setPreferredDriverId(null);
     }
     setOpen(isOpen);
   };
@@ -259,6 +268,7 @@ export function CreateQuoteDialog({
       surcharge: formData.surcharge ? parseFloat(formData.surcharge) : null,
       discountRate: formData.discountRate ? parseFloat(formData.discountRate) / 100 : null,
       cancellationFee: formData.cancellationFee ? parseFloat(formData.cancellationFee) : null,
+      preferredDriverId: effectivePreferredDriverId,
       notes: formData.notes || undefined,
       pickupProposedFor: dateTimeLocalToISO(effectivePickup),
       deliveryProposedFor: dateTimeLocalToISO(effectiveDelivery),
@@ -695,6 +705,24 @@ export function CreateQuoteDialog({
                 </div>
               )}
             </>
+          )}
+
+          {/* Driver selection — system suggests, admin can override.
+              Sits with the scheduling info so who + when read together. */}
+          {feasibility && (
+            <QuoteDriverSelector
+              candidates={feasibility.candidates ?? []}
+              suggestedDriverId={suggestedDriverId}
+              value={preferredDriverId}
+              onChange={setPreferredDriverId}
+              initialDate={
+                feasibility.suggestedPickup
+                  ? extractDatePart(feasibility.suggestedPickup)
+                  : windowStart
+                    ? extractDatePart(windowStart)
+                    : undefined
+              }
+            />
           )}
 
           {/* Proposed Pickup/Delivery — smart display with edit */}

--- a/components/orders/NeedsAttentionCard.tsx
+++ b/components/orders/NeedsAttentionCard.tsx
@@ -14,6 +14,7 @@ import { UrgencyBadge } from './UrgencyBadge';
 import { PaymentStatusBadge } from './PaymentStatusBadge';
 import { ReasonBadge } from './ReasonBadge';
 import { CancelOrderDialog } from './CancelOrderDialog';
+import { AssignDriverModal } from './AssignDriverModal';
 import { useChangeTier, useOutsourceOrder, useRetryDispatch } from '@/hooks/orders';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Enums } from '@/data/app-enums';
@@ -133,6 +134,15 @@ export function NeedsAttentionCard({ item }: NeedsAttentionCardProps) {
             <RefreshCw className={`mr-1 h-4 w-4 ${retryDispatch.isPending ? 'animate-spin' : ''}`} />
             {t('needs_attention.retry_dispatch', { defaultValue: 'Retry' })}
           </Button>
+
+          {!order.driverId && (
+            <AssignDriverModal
+              order={{
+                publicId: order.publicId as string,
+                finalVehicleType: order.finalVehicleType,
+              }}
+            />
+          )}
 
           <Button
             variant="outline"

--- a/components/orders/NeedsAttentionCard.tsx
+++ b/components/orders/NeedsAttentionCard.tsx
@@ -89,6 +89,15 @@ export function NeedsAttentionCard({ item }: NeedsAttentionCardProps) {
           )}
         </div>
 
+        {item.preferredDriverName && (
+          <p className="text-muted-foreground text-xs">
+            {t(`needs_attention.preferred_issue.${item.preferredDriverIssue ?? 'unavailable'}`, {
+              name: item.preferredDriverName,
+              defaultValue: `${item.preferredDriverName} is no longer available`,
+            })}
+          </p>
+        )}
+
         <div className="flex flex-wrap items-center gap-2">
           <Button
             variant="outline"

--- a/components/orders/QuoteDriverSelector.tsx
+++ b/components/orders/QuoteDriverSelector.tsx
@@ -41,8 +41,11 @@ interface QuoteDriverSelectorProps {
   candidates: DriverCandidate[];
   /** Top-ranked candidate id — the system suggestion. */
   suggestedDriverId: number | null;
-  /** Currently chosen preferred driver (null = use suggestion / leave to admin). */
-  value: number | null;
+  /**
+   * Current selection: `undefined` = untouched (accept the suggestion),
+   * a driver id = explicit override, `null` = explicit "none".
+   */
+  value: number | null | undefined;
   onChange: (driverId: number | null) => void;
   /** Date the schedule/routes tabs open on (YYYY-MM-DD). Defaults to today. */
   initialDate?: string | null;
@@ -63,7 +66,9 @@ export function QuoteDriverSelector({
   const { data: driversData } = useDriverList({ perPage: 200, enabled: open });
   const drivers = useMemo(() => driversData?.items ?? [], [driversData]);
 
-  const effectiveId = value ?? suggestedDriverId;
+  // Untouched (undefined) falls back to the suggestion; an explicit choice
+  // (a driver id, or null for "none") is honored as-is.
+  const effectiveId = value === undefined ? suggestedDriverId : value;
 
   // Ranked candidate ids first, then any other active driver as override options.
   const otherDrivers = useMemo(
@@ -85,7 +90,7 @@ export function QuoteDriverSelector({
   // The schedules endpoint binds Driver by public_id, but candidates only carry the numeric id.
   const effectiveDriverPublicId = effectiveDriver?.publicId ?? null;
 
-  const isSuggested = value == null && suggestedDriverId != null;
+  const isSuggested = value === undefined && suggestedDriverId != null;
   const today = toDateString(getTodayAppTz());
 
   return (
@@ -285,7 +290,7 @@ export function QuoteDriverSelector({
                 variant="ghost"
                 size="sm"
                 onClick={() => onChange(null)}
-                disabled={value == null}
+                disabled={effectiveId == null}
               >
                 {t('driver_select.clear', { defaultValue: 'Clear override' })}
               </Button>

--- a/components/orders/QuoteDriverSelector.tsx
+++ b/components/orders/QuoteDriverSelector.tsx
@@ -1,0 +1,441 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { RouteStatusBadge } from '@/components/routes/RouteStatusBadge';
+import { useDriverList } from '@/hooks/drivers';
+import { useDriverSchedules } from '@/hooks/drivers/useDriverSchedules';
+import { useRouteList } from '@/hooks/routes';
+import { statusLabel, vehicleTypeLabel, dispatchPolicyLabel, actionLabel } from '@/utils/lang';
+import {
+  formatDateTime,
+  formatDateOnly,
+  getTodayAppTz,
+  toDateString,
+  addDays,
+} from '@/utils/format';
+import { CalendarClock, ChevronLeft, ChevronRight, Route as RouteIcon, UserCog } from 'lucide-react';
+
+type DriverCandidate = App.Data.Feasibility.DriverCandidate;
+
+interface QuoteDriverSelectorProps {
+  candidates: DriverCandidate[];
+  /** Top-ranked candidate id — the system suggestion. */
+  suggestedDriverId: number | null;
+  /** Currently chosen preferred driver (null = use suggestion / leave to admin). */
+  value: number | null;
+  onChange: (driverId: number | null) => void;
+  /** Date the schedule/routes tabs open on (YYYY-MM-DD). Defaults to today. */
+  initialDate?: string | null;
+}
+
+
+export function QuoteDriverSelector({
+  candidates,
+  suggestedDriverId,
+  value,
+  onChange,
+  initialDate,
+}: QuoteDriverSelectorProps) {
+  const { t, i18n } = useTranslation('quotes');
+  const [open, setOpen] = useState(false);
+  const [date, setDate] = useState(() => initialDate || toDateString(getTodayAppTz()));
+
+  const { data: driversData } = useDriverList({ perPage: 200, enabled: open });
+  const drivers = useMemo(() => driversData?.items ?? [], [driversData]);
+
+  const effectiveId = value ?? suggestedDriverId;
+
+  // Ranked candidate ids first, then any other active driver as override options.
+  const otherDrivers = useMemo(
+    () => drivers.filter((d) => !candidates.some((c) => c.driverId === d.id)),
+    [drivers, candidates]
+  );
+
+  const effectiveCandidate = useMemo(
+    () => candidates.find((c) => c.driverId === effectiveId) ?? null,
+    [candidates, effectiveId]
+  );
+
+  // Resolve the selected driver once; name and (public_id-bound) schedules key derive from it.
+  const effectiveDriver = useMemo(
+    () => drivers.find((d) => d.id === effectiveId) ?? null,
+    [drivers, effectiveId]
+  );
+  const effectiveName = effectiveCandidate?.driverName ?? effectiveDriver?.user?.name ?? null;
+  // The schedules endpoint binds Driver by public_id, but candidates only carry the numeric id.
+  const effectiveDriverPublicId = effectiveDriver?.publicId ?? null;
+
+  const isSuggested = value == null && suggestedDriverId != null;
+  const today = toDateString(getTodayAppTz());
+
+  return (
+    <div className="bg-muted/50 rounded-lg border p-4">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <p className="text-sm font-medium">
+            {t('driver_select.label', { defaultValue: 'Assigned Driver' })}
+          </p>
+          <p className="text-muted-foreground text-xs">
+            {effectiveId == null
+              ? t('driver_select.none', {
+                  defaultValue: 'None — will surface for manual assignment',
+                })
+              : `${effectiveName ?? `#${effectiveId}`}${
+                  isSuggested
+                    ? ` · ${t('driver_select.suggested', { defaultValue: 'suggested' })}`
+                    : ''
+                }`}
+          </p>
+          {effectiveCandidate?.suggestedPickup && (
+            <p className="text-muted-foreground mt-1 text-xs">
+              {t('driver_select.eta', {
+                pickup: formatDateTime(effectiveCandidate.suggestedPickup),
+                delivery: effectiveCandidate.suggestedDelivery
+                  ? formatDateTime(effectiveCandidate.suggestedDelivery)
+                  : '—',
+                defaultValue: `Pickup ${formatDateTime(effectiveCandidate.suggestedPickup)} · Delivery ${
+                  effectiveCandidate.suggestedDelivery
+                    ? formatDateTime(effectiveCandidate.suggestedDelivery)
+                    : '—'
+                }`,
+              })}
+            </p>
+          )}
+        </div>
+
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button type="button" variant="outline" size="sm">
+              <UserCog className="mr-1 h-4 w-4" />
+              {t('driver_select.button', { defaultValue: 'Select Driver' })}
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+            <DialogHeader>
+              <DialogTitle>
+                {t('driver_select.title', { defaultValue: 'Select Driver' })}
+              </DialogTitle>
+              <DialogDescription>
+                {t('driver_select.description', {
+                  defaultValue:
+                    'The system suggests the best-ranked driver. Pick another to override — they are assigned when the customer accepts and pays.',
+                })}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              {/* Driver selector */}
+              <div className="bg-muted/40 space-y-2 rounded-lg border p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">
+                    {t('driver_select.field_label', { defaultValue: 'Driver' })}
+                  </span>
+                  {isSuggested && (
+                    <Badge
+                      variant="secondary"
+                      className="bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                    >
+                      {t('driver_select.suggested', { defaultValue: 'suggested' })}
+                    </Badge>
+                  )}
+                </div>
+                <Select
+                  value={effectiveId != null ? String(effectiveId) : ''}
+                  onValueChange={(val) => onChange(Number(val))}
+                >
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={t('driver_select.override_placeholder', {
+                        defaultValue: 'Select any active driver',
+                      })}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {candidates.map((c, i) => (
+                      <SelectItem key={`c-${c.driverId}`} value={String(c.driverId)}>
+                        {c.driverName}
+                        {i === 0
+                          ? ` · ${t('driver_select.suggested', { defaultValue: 'suggested' })}`
+                          : ''}
+                      </SelectItem>
+                    ))}
+                    {otherDrivers.map((d) => (
+                      <SelectItem key={`d-${d.id}`} value={String(d.id)}>
+                        {d.user?.name ?? `Driver #${d.publicId}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {effectiveCandidate && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {effectiveCandidate.vehicleType && (
+                      <Badge variant="outline">
+                        {vehicleTypeLabel(effectiveCandidate.vehicleType)}
+                      </Badge>
+                    )}
+                    {effectiveCandidate.dispatchPolicy && (
+                      <Badge variant="outline">
+                        {dispatchPolicyLabel(effectiveCandidate.dispatchPolicy)}
+                      </Badge>
+                    )}
+                    <Badge variant="outline">
+                      {t('feasibility.onboard_load', {
+                        count: effectiveCandidate.onboardLoad,
+                        defaultValue: `Carrying ${effectiveCandidate.onboardLoad}`,
+                      })}
+                    </Badge>
+                    <Badge variant="outline">
+                      {t('feasibility.extra_distance', {
+                        km: effectiveCandidate.extraDistanceKm.toFixed(1),
+                        defaultValue: `+${effectiveCandidate.extraDistanceKm.toFixed(1)} km`,
+                      })}
+                    </Badge>
+                  </div>
+                )}
+              </div>
+
+              {/* Shared date navigator */}
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setDate((d) => addDays(d, -1))}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <div className="flex flex-1 items-center justify-center gap-2 rounded-md border py-2 text-sm font-medium">
+                  <CalendarClock className="text-muted-foreground h-4 w-4" />
+                  {formatDateOnly(date, i18n.language)}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setDate((d) => addDays(d, 1))}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant={date === today ? 'secondary' : 'ghost'}
+                  size="sm"
+                  onClick={() => setDate(today)}
+                >
+                  {t('driver_select.today', { defaultValue: 'Today' })}
+                </Button>
+              </div>
+
+              {/* Horario / Rutas tabs — both scoped to the date above */}
+              {effectiveId == null ? (
+                <p className="text-muted-foreground rounded-md border border-dashed py-6 text-center text-sm">
+                  {t('driver_select.pick_to_view', {
+                    defaultValue: 'Select a driver to view their schedule and routes.',
+                  })}
+                </p>
+              ) : (
+                <Tabs defaultValue="schedule">
+                  <TabsList className="grid w-full grid-cols-2">
+                    <TabsTrigger value="schedule">
+                      <CalendarClock className="mr-1 h-4 w-4" />
+                      {t('driver_select.tab_schedule', { defaultValue: 'Schedule' })}
+                    </TabsTrigger>
+                    <TabsTrigger value="routes">
+                      <RouteIcon className="mr-1 h-4 w-4" />
+                      {t('driver_select.tab_routes', { defaultValue: 'Routes' })}
+                    </TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="schedule" className="pt-3">
+                    <ScheduleList
+                      driverPublicId={effectiveDriverPublicId}
+                      date={date}
+                      enabled={open}
+                    />
+                  </TabsContent>
+                  <TabsContent value="routes" className="pt-3">
+                    <RoutesList driverId={effectiveId} date={date} enabled={open} />
+                  </TabsContent>
+                </Tabs>
+              )}
+            </div>
+
+            <DialogFooter className="flex-row justify-between gap-2 sm:justify-between">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => onChange(null)}
+                disabled={value == null}
+              >
+                {t('driver_select.clear', { defaultValue: 'Clear override' })}
+              </Button>
+              <Button type="button" size="sm" onClick={() => setOpen(false)}>
+                {actionLabel('confirm')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+}
+
+function ScheduleList({
+  driverPublicId,
+  date,
+  enabled,
+}: {
+  driverPublicId: string | null;
+  date: string;
+  enabled: boolean;
+}) {
+  const { t } = useTranslation('quotes');
+  // One day at a time — the modal only ever shows the selected date.
+  const { data, isLoading } = useDriverSchedules(driverPublicId ?? '', {
+    from: date,
+    to: date,
+    enabled: enabled && !!driverPublicId,
+  });
+
+  const blocks = useMemo(
+    () => [...(data?.schedules ?? [])].sort((a, b) => a.startTime.localeCompare(b.startTime)),
+    [data]
+  );
+
+  if (isLoading) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        {t('common:loading', { defaultValue: 'Loading...' })}
+      </p>
+    );
+  }
+  if (blocks.length === 0) {
+    return (
+      <p className="text-muted-foreground rounded-md border border-dashed py-6 text-center text-sm">
+        {t('driver_select.no_schedule', { defaultValue: 'No schedule blocks on this day.' })}
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {blocks.map((b) => (
+        <div
+          key={b.id ?? `${b.date}-${b.startTime}`}
+          className="flex items-center justify-between gap-2 rounded-lg border p-2.5 text-sm"
+        >
+          <span className="font-medium">
+            {b.startTime} – {b.endTime}
+          </span>
+          {b.vehicleType && <Badge variant="outline">{vehicleTypeLabel(b.vehicleType)}</Badge>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RoutesList({
+  driverId,
+  date,
+  enabled,
+}: {
+  driverId: number;
+  date: string;
+  enabled: boolean;
+}) {
+  const { t } = useTranslation('quotes');
+  const { data, isLoading } = useRouteList({ driverId, date, perPage: 50, enabled });
+
+  // Sort each route's stops once here rather than on every render row.
+  const routes = useMemo(
+    () =>
+      ((data?.items ?? []) as App.Data.Route.RouteData[]).map((r) => ({
+        ...r,
+        stops: [...(r.stops ?? [])].sort((a, b) => a.sequence - b.sequence),
+      })),
+    [data]
+  );
+
+  if (isLoading) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        {t('common:loading', { defaultValue: 'Loading...' })}
+      </p>
+    );
+  }
+  if (routes.length === 0) {
+    return (
+      <p className="text-muted-foreground rounded-md border border-dashed py-6 text-center text-sm">
+        {t('driver_select.no_routes', { defaultValue: 'No routes on this day.' })}
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {routes.map((route) => {
+        const stops = route.stops;
+        return (
+          <div key={route.id ?? route.publicId} className="rounded-lg border p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-sm font-medium">
+                {t('driver_select.route_label', {
+                  id: route.publicId ?? route.id,
+                  defaultValue: `Route ${route.publicId ?? route.id}`,
+                })}
+              </span>
+              <div className="flex items-center gap-2">
+                {route.status && <RouteStatusBadge status={route.status} />}
+                <span className="text-muted-foreground text-xs">
+                  {t('driver_select.stop_count', {
+                    count: stops.length,
+                    defaultValue: `${stops.length} stops`,
+                  })}
+                </span>
+              </div>
+            </div>
+            {stops.length > 0 && (
+              <ol className="mt-2 space-y-1">
+                {stops.map((stop) => (
+                  <li
+                    key={stop.id}
+                    className="text-muted-foreground flex items-center justify-between gap-2 text-xs"
+                  >
+                    <span className="truncate">
+                      {stop.sequence}. {statusLabel(stop.type)}
+                      {stop.order?.publicId ? ` · ${stop.order.publicId}` : ''}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {stop.scheduledFor && <span>{formatDateTime(stop.scheduledFor)}</span>}
+                      <Badge variant="outline" className="text-[10px]">
+                        {statusLabel(stop.status)}
+                      </Badge>
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/orders/QuoteDriverSelector.tsx
+++ b/components/orders/QuoteDriverSelector.tsx
@@ -71,8 +71,10 @@ export function QuoteDriverSelector({
   const effectiveId = value === undefined ? suggestedDriverId : value;
 
   // Ranked candidate ids first, then any other active driver as override options.
+  // Inactive drivers are off the roster and can never be assigned, so they are
+  // excluded from the override options (ranked candidates are already active).
   const otherDrivers = useMemo(
-    () => drivers.filter((d) => !candidates.some((c) => c.driverId === d.id)),
+    () => drivers.filter((d) => d.active && !candidates.some((c) => c.driverId === d.id)),
     [drivers, candidates]
   );
 

--- a/components/orders/ReasonBadge.tsx
+++ b/components/orders/ReasonBadge.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Enums } from '@/data/app-enums';
 import { useTranslation } from 'react-i18next';
-import { Users, Clock, CalendarX, Loader } from 'lucide-react';
+import { Users, Clock, CalendarX, Loader, UserX } from 'lucide-react';
 
 const reasonConfig: Record<string, { icon: typeof Users; className: string }> = {
   [Enums.AttentionReason.NoDriversAvailable]: {
@@ -19,6 +19,10 @@ const reasonConfig: Record<string, { icon: typeof Users; className: string }> = 
   [Enums.AttentionReason.AwaitingDispatch]: {
     icon: Loader,
     className: 'bg-blue-50 text-blue-700 border-blue-200',
+  },
+  [Enums.AttentionReason.PreferredDriverUnavailable]: {
+    icon: UserX,
+    className: 'bg-purple-50 text-purple-700 border-purple-200',
   },
 };
 

--- a/config/i18next.ts
+++ b/config/i18next.ts
@@ -8,9 +8,9 @@ import HttpBackend from 'i18next-http-backend';
 const defaultLocale = 'en';
 const supportedLngs = ['en', 'es', 'fr'] as const;
 
-// Locales are static files served by the API (nginx) with CORS enabled, so we
-// fetch them directly cross-origin — no Next.js rewrite proxy needed.
-const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://api.mandados.test:60';
+// Locale JSON are static files served by nginx, which emits no CORS headers,
+// so we fetch them same-origin (`/locales/...`) and let the Next.js rewrite in
+// next.config.ts forward them to the API server-side. See next.config.ts.
 const namespaces = [
   'addresses',
   'audit_logs',
@@ -76,7 +76,7 @@ export async function ensureI18nInitialized(pathname?: string) {
         cookieName: 'lang',
       } as DetectorOptions,
       backend: {
-        loadPath: `${apiBase}/locales/{{lng}}/{{ns}}.json`,
+        loadPath: '/locales/{{lng}}/{{ns}}.json',
         requestOptions: {
           cache: 'no-store',
         },

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -118,6 +118,7 @@ export const Enums = {
     Custom: "custom",
   },
   DispatchEligibilityReason: {
+    Inactive: "inactive",
     UnsupportedTier: "unsupported_tier",
     ManualOnlyPolicy: "manual_only_policy",
     CatchAllPolicy: "catch_all_policy",

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -11,6 +11,7 @@ export const Enums = {
     ScheduleConflict: "schedule_conflict",
     WindowTooTight: "window_too_tight",
     UnassignedTooLong: "unassigned_too_long",
+    PreferredDriverUnavailable: "preferred_driver_unavailable",
   },
   AttentionUrgency: {
     Critical: "critical",

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -116,6 +116,17 @@ export const Enums = {
     Cheapest: "cheapest",
     Custom: "custom",
   },
+  DispatchEligibilityReason: {
+    UnsupportedTier: "unsupported_tier",
+    ManualOnlyPolicy: "manual_only_policy",
+    CatchAllPolicy: "catch_all_policy",
+    InsufficientVehicle: "insufficient_vehicle",
+  },
+  DispatchPolicy: {
+    Auto: "auto",
+    CatchAll: "catch_all",
+    ManualOnly: "manual_only",
+  },
   ErrorAction: {
     Retrieving: "retrieving",
     Creating: "creating",
@@ -364,6 +375,12 @@ export const Enums = {
     Succeeded: "succeeded",
     Voided: "voided",
     Failed: "failed",
+  },
+  VehicleType: {
+    Motorcycle: "motorcycle",
+    Car: "car",
+    PickupVan: "pickup_van",
+    Truck: "truck",
   },
 } as const;
 export type Enums = typeof Enums;

--- a/hooks/drivers/useDriverSchedules.ts
+++ b/hooks/drivers/useDriverSchedules.ts
@@ -1,10 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { DriverService } from '@/services/driverService';
 
-export function useDriverSchedules(driverId: string) {
+interface UseDriverSchedulesParams {
+  /** Lower bound (YYYY-MM-DD), inclusive. Omit to fetch from the start. */
+  from?: string;
+  /** Upper bound (YYYY-MM-DD), inclusive. Omit to fetch to the end. */
+  to?: string;
+  enabled?: boolean;
+}
+
+export function useDriverSchedules(driverId: string, params: UseDriverSchedulesParams = {}) {
+  const { from, to, enabled = true } = params;
+
   return useQuery({
-    queryKey: ['drivers', driverId, 'schedules'],
-    queryFn: () => DriverService.getSchedules(driverId),
-    enabled: !!driverId,
+    queryKey: ['drivers', driverId, 'schedules', { from, to }],
+    queryFn: () => DriverService.getSchedules(driverId, { from, to }),
+    enabled: enabled && !!driverId,
   });
 }

--- a/hooks/orders/index.ts
+++ b/hooks/orders/index.ts
@@ -7,6 +7,7 @@ export { useCreateStop } from './useCreateStop';
 export { useChangeTier } from './useChangeTier';
 export { useOutsourceOrder } from './useOutsourceOrder';
 export { useRetryDispatch } from './useRetryDispatch';
+export { useAssignOrder } from './useAssignOrder';
 export { useNeedsAttention, useCancelOrder } from './useNeedsAttention';
 export { useNeedsAttentionBroadcast } from './useNeedsAttentionBroadcast';
 export { useReconcileOrder } from './useReconcileOrder';

--- a/hooks/orders/useAssignOrder.ts
+++ b/hooks/orders/useAssignOrder.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { OrderService } from '@/services/orderService';
+import { toast } from 'sonner';
+import { isApiError } from '@/lib/api/error';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+import i18next from '@/config/i18next';
+
+export function useAssignOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ orderPublicId, driverId }: { orderPublicId: string; driverId: number }) =>
+      OrderService.assign(orderPublicId, driverId),
+    onSuccess: ({ eligibility }) => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      queryClient.invalidateQueries({ queryKey: ['feasibility'] });
+
+      toast.success(crudSuccessMessage('updated', 'order'));
+
+      if (eligibility && !eligibility.eligible && eligibility.reason) {
+        toast.warning(i18next.t(`drivers:eligibility_reasons.${eligibility.reason}`));
+      }
+    },
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage('updating', 'order'));
+      }
+    },
+  });
+}

--- a/hooks/settings/index.ts
+++ b/hooks/settings/index.ts
@@ -1,3 +1,4 @@
 export * from './useExchangeRateMode';
 export * from './useServiceWindow';
 export * from './useServiceWindowMutations';
+export * from './useSupportedVehicleTypes';

--- a/hooks/settings/useSupportedVehicleTypes.ts
+++ b/hooks/settings/useSupportedVehicleTypes.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { SettingService } from '@/services/settingService';
+
+export function useSupportedVehicleTypes() {
+  return useQuery({
+    queryKey: ['settings', 'supported-vehicle-types'],
+    queryFn: () => SettingService.getSupportedVehicleTypes(),
+  });
+}
+
+export function useUpdateSupportedVehicleTypes() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (supportedVehicleTypes: string[]) =>
+      SettingService.updateSupportedVehicleTypes(supportedVehicleTypes),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings', 'supported-vehicle-types'] });
+    },
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from 'next';
 
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://api.mandados.test:60';
+
 const nextConfig: NextConfig = {
   // Use Node's native util module instead of Next.js's bundled polyfill
   // to avoid DEP0060 deprecation warning for util._extend
@@ -8,6 +10,13 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       util: 'node:util',
     },
+  },
+  // The API's static locale files are served by nginx without CORS headers, so
+  // the browser can't fetch them cross-origin. Serve them same-origin and let
+  // Next forward to the API server-side (works in dev AND prod). i18next's
+  // loadPath is the matching relative `/locales/...`.
+  async rewrites() {
+    return [{ source: '/locales/:path*', destination: `${apiBase}/locales/:path*` }];
   },
 };
 

--- a/services/driverService.ts
+++ b/services/driverService.ts
@@ -1,4 +1,5 @@
 import { api } from '@/lib/api/client';
+import { buildUrl } from '@/utils/http';
 
 export interface AffectedOrder {
   publicId: string;
@@ -54,14 +55,21 @@ export const DriverService = {
     return api.destroy<SuccessBasic>(`/drivers/${id}`);
   },
 
-  async getSchedules(driverId: string): Promise<{
+  async getSchedules(
+    driverId: string,
+    range: { from?: string; to?: string } = {}
+  ): Promise<{
     schedules: App.Data.Driver.DriverScheduleData[];
   }> {
+    const url = buildUrl(`/drivers/${driverId}/schedules`, {
+      from: range.from,
+      to: range.to,
+    });
     const response = await api.get<
       Api.Response.SuccessBasic & {
         schedules: App.Data.Driver.DriverScheduleData[];
       }
-    >(`/drivers/${driverId}/schedules`);
+    >(url);
     return { schedules: response.schedules };
   },
 

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -20,6 +20,8 @@ export interface NeedsAttentionOrder {
   reason: string;
   outsourceEligible: boolean;
   hoursUntilWindowEnd: number | null;
+  preferredDriverName?: string | null;
+  preferredDriverIssue?: string | null;
 }
 
 export interface NeedsAttentionSummary {

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -3,10 +3,16 @@ import { api } from '@/lib/api/client';
 type OrderData = App.Data.Order.OrderData;
 type QuoteData = App.Data.Quote.QuoteData;
 type RouteStopData = App.Data.Route.RouteStopData;
+type DispatchEligibility = App.Data.Dispatch.DispatchEligibility;
 type Single<T> = Api.Response.Single<T>;
 type Multiple<T> = Api.Response.Multiple<T>;
 type Paginated<T> = Api.Response.Paginated<T>;
 type SuccessBasic = Api.Response.SuccessBasic;
+
+export interface AssignOrderResult {
+  order: OrderData;
+  eligibility: DispatchEligibility;
+}
 
 export interface NeedsAttentionOrder {
   order: OrderData;
@@ -150,6 +156,19 @@ export const OrderService = {
   async retryDispatch(publicId: string): Promise<OrderData> {
     const response = await api.post<Single<OrderData>>(`/orders/${publicId}/dispatch`);
     return response.item;
+  },
+
+  /**
+   * Assign a driver to an order (admin only, human-in-the-loop assignment)
+   * Returns the updated order + dispatch eligibility feedback (still succeeds even when ineligible)
+   */
+  async assign(publicId: string, driverId: number): Promise<AssignOrderResult> {
+    const response = await api.post<Single<OrderData>>(`/orders/${publicId}/assign`, { driverId });
+    const extra = response.extra as { eligibility: DispatchEligibility };
+    return {
+      order: response.item,
+      eligibility: extra.eligibility,
+    };
   },
 
   /**

--- a/services/settingService.ts
+++ b/services/settingService.ts
@@ -5,6 +5,7 @@ type UpdateSettingData = App.Data.Setting.UpdateSettingData;
 type Single<T> = Api.Response.Single<T>;
 
 type ExchangeRateModeResponse = { exchangeRateMode: string };
+type SupportedVehicleTypesResponse = { supportedVehicleTypes: string[] };
 
 export const SettingService = {
   /**
@@ -42,5 +43,28 @@ export const SettingService = {
       { exchangeRateMode }
     );
     return { exchangeRateMode: response.exchangeRateMode };
+  },
+
+  /**
+   * Get supported vehicle types
+   */
+  async getSupportedVehicleTypes(): Promise<SupportedVehicleTypesResponse> {
+    const response = await api.get<SupportedVehicleTypesResponse & { message: string }>(
+      '/settings/supported-vehicle-types'
+    );
+    return { supportedVehicleTypes: response.supportedVehicleTypes };
+  },
+
+  /**
+   * Update supported vehicle types (admin only)
+   */
+  async updateSupportedVehicleTypes(
+    supportedVehicleTypes: string[]
+  ): Promise<SupportedVehicleTypesResponse> {
+    const response = await api.patch<SupportedVehicleTypesResponse & { message: string }>(
+      '/settings/supported-vehicle-types',
+      { supportedVehicleTypes }
+    );
+    return { supportedVehicleTypes: response.supportedVehicleTypes };
   },
 };

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -268,6 +268,12 @@ declare namespace App.Data.Currency {
     manualRate?: number | null;
   };
 }
+declare namespace App.Data.Dispatch {
+  export type DispatchEligibility = {
+    eligible: boolean;
+    reason: App.Enums.DispatchEligibilityReason | null;
+  };
+}
 declare namespace App.Data.Driver {
   export type DriverAddStopData = {
     orderId: number;
@@ -288,7 +294,8 @@ declare namespace App.Data.Driver {
     licensePhotoBack?: string;
     licenseExpirationDate?: string;
     active?: boolean;
-    isOutsourced?: boolean;
+    defaultVehicleType?: App.Enums.VehicleType;
+    dispatchPolicy?: App.Enums.DispatchPolicy;
     currentLatitude?: number | null;
     currentLongitude?: number | null;
     locationUpdatedAt?: string | null;
@@ -305,6 +312,7 @@ declare namespace App.Data.Driver {
     date: string;
     startTime: string;
     endTime: string;
+    vehicleType: App.Enums.VehicleType | null;
   };
   export type FailStopData = {
     reason: string;
@@ -336,6 +344,8 @@ declare namespace App.Data.Driver {
     licensePhotoFront: string;
     licensePhotoBack: string;
     licenseExpirationDate: string;
+    defaultVehicleType: App.Enums.VehicleType;
+    dispatchPolicy: App.Enums.DispatchPolicy;
   };
   export type SyncDriverScheduleData = {
     schedules: Array<App.Data.Driver.DriverScheduleData>;
@@ -350,6 +360,8 @@ declare namespace App.Data.Driver {
     baseLatitude?: number | null;
     baseLongitude?: number | null;
     baseAddress?: string | null;
+    defaultVehicleType?: App.Enums.VehicleType;
+    dispatchPolicy?: App.Enums.DispatchPolicy;
   };
   export type UpdateLocationData = {
     latitude: number;
@@ -379,6 +391,9 @@ declare namespace App.Data.Feasibility {
     suggestedDelivery: string | null;
     score: number;
     travelTimeMinutes: number | null;
+    vehicleType: App.Enums.VehicleType | null;
+    dispatchPolicy: App.Enums.DispatchPolicy | null;
+    onboardLoad: number;
   };
   export type FeasibilityResult = {
     level: App.Enums.FeasibilityLevel;
@@ -446,6 +461,9 @@ declare namespace App.Data.Location {
   };
 }
 declare namespace App.Data.Order {
+  export type AssignOrderData = {
+    driverId: number;
+  };
   export type NeedsAttentionOrderData = {
     order: App.Data.Order.OrderData;
     urgency: App.Enums.AttentionUrgency;
@@ -474,6 +492,9 @@ declare namespace App.Data.Order {
     timeSensitive?: boolean;
     totalDistanceKm?: number | null;
     totalEstimatedMinutes?: number | null;
+    requestedVehicleType?: App.Enums.VehicleType | null;
+    finalVehicleType?: App.Enums.VehicleType;
+    isExclusive?: boolean;
     status?: App.Enums.OrderStatus;
     paymentStatus?: App.Enums.PaymentStatus;
     createdAt?: string;
@@ -568,6 +589,7 @@ declare namespace App.Data.Order {
     isContactless: boolean;
     deliveryTier: App.Enums.DeliveryTier;
     timeSensitive: boolean;
+    requestedVehicleType: App.Enums.VehicleType | null;
     stops: Array<App.Data.Order.StoreOrderStopData>;
   };
   export type StoreOrderStopData = {
@@ -594,6 +616,10 @@ declare namespace App.Data.Order {
     instructions?: string | null;
     sequence?: number;
     type?: App.Enums.OrderStopType;
+  };
+  export type UpdateOrderVehicleData = {
+    finalVehicleType?: App.Enums.VehicleType;
+    isExclusive?: boolean;
   };
 }
 declare namespace App.Data.Payment {
@@ -927,6 +953,7 @@ declare namespace App.Data.Setting {
     unassignedEscalationHours?: number;
     unassignedAutoCancelEnabled?: boolean;
     exchangeRateMode?: string;
+    supportedVehicleTypes?: Array<any>;
   };
 }
 declare namespace App.Data.Shared {
@@ -1185,6 +1212,17 @@ declare namespace App.Enums {
     Cheapest = 'cheapest',
     Custom = 'custom',
   }
+  export enum DispatchEligibilityReason {
+    UnsupportedTier = 'unsupported_tier',
+    ManualOnlyPolicy = 'manual_only_policy',
+    CatchAllPolicy = 'catch_all_policy',
+    InsufficientVehicle = 'insufficient_vehicle',
+  }
+  export enum DispatchPolicy {
+    Auto = 'auto',
+    CatchAll = 'catch_all',
+    ManualOnly = 'manual_only',
+  }
   export enum ErrorAction {
     Retrieving = 'retrieving',
     Creating = 'creating',
@@ -1433,5 +1471,11 @@ declare namespace App.Enums {
     Succeeded = 'succeeded',
     Voided = 'voided',
     Failed = 'failed',
+  }
+  export enum VehicleType {
+    Motorcycle = 'motorcycle',
+    Car = 'car',
+    PickupVan = 'pickup_van',
+    Truck = 'truck',
   }
 }

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -471,6 +471,8 @@ declare namespace App.Data.Order {
     outsourceEligible: boolean;
     hoursUntilWindowEnd: number | null;
     workingHoursUnassigned: number | null;
+    preferredDriverName: string | null;
+    preferredDriverIssue: string | null;
   };
   export type OrderData = {
     id?: number;
@@ -809,7 +811,7 @@ declare namespace App.Data.Quote {
     pickupProposedFor: string | null;
     deliveryProposedFor: string | null;
     cancellationFee: number | null;
-    preferredDriverId: number | null;
+    preferredDriverId?: number | null;
     notes?: string | null;
     items?: { [key: number]: any };
     stopDurations?: { [key: number]: any };
@@ -1109,6 +1111,7 @@ declare namespace App.Enums {
     ScheduleConflict = 'schedule_conflict',
     WindowTooTight = 'window_too_tight',
     UnassignedTooLong = 'unassigned_too_long',
+    PreferredDriverUnavailable = 'preferred_driver_unavailable',
   }
   export enum AttentionUrgency {
     Critical = 'critical',

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -1218,6 +1218,7 @@ declare namespace App.Enums {
     Custom = 'custom',
   }
   export enum DispatchEligibilityReason {
+    Inactive = 'inactive',
     UnsupportedTier = 'unsupported_tier',
     ManualOnlyPolicy = 'manual_only_policy',
     CatchAllPolicy = 'catch_all_policy',

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -478,6 +478,7 @@ declare namespace App.Data.Order {
     userId?: number;
     businessId?: number | null;
     driverId?: number | null;
+    preferredDriverId?: number | null;
     deliveryAddressId?: number | null;
     contactName?: string | null;
     contactPhone?: string | null;
@@ -808,6 +809,7 @@ declare namespace App.Data.Quote {
     pickupProposedFor: string | null;
     deliveryProposedFor: string | null;
     cancellationFee: number | null;
+    preferredDriverId: number | null;
     notes?: string | null;
     items?: { [key: number]: any };
     stopDurations?: { [key: number]: any };

--- a/types/notifications.d.ts
+++ b/types/notifications.d.ts
@@ -4,227 +4,227 @@
  * Keep in sync with `api/app/Notifications/*.php`.
  */
 declare namespace Api.Broadcast {
-  /** Common fields present on most broadcast notifications. */
-  interface Base {
-    type: string;
-    action?: string;
-    model?: string;
-    translationKey?: string;
-    translationParams?: Record<string, string>;
-  }
+    /** Common fields present on most broadcast notifications. */
+    interface Base {
+        type: string;
+        action?: string;
+        model?: string;
+        translationKey?: string;
+        translationParams?: Record<string, string>;
+    }
 
-  /** quote.sent */
-  export interface QuoteSent extends Base {
-    orderId: number;
-    orderPublicId: string;
-    quoteId: number;
-    quoteTotal: number;
-    quoteCurrency: string;
-  }
+    /** quote.sent */
+    export interface QuoteSent extends Base {
+        orderId: number;
+        orderPublicId: string;
+        quoteId: number;
+        quoteTotal: number;
+        quoteCurrency: string;
+    }
 
-  /** quote.expired */
-  export interface QuoteExpired extends Base {
-    orderId: number;
-    orderPublicId: string;
-    quoteId: number;
-    quoteVersion: number;
-    isFinalCancellation: boolean;
-  }
+    /** quote.expired */
+    export interface QuoteExpired extends Base {
+        orderId: number;
+        orderPublicId: string;
+        quoteId: number;
+        quoteVersion: number;
+        isFinalCancellation: boolean;
+    }
 
-  /** quote.requested */
-  export interface QuoteRequested extends Base {
-    modelId: number;
-    modelName: string;
-    orderId: number;
-    orderPublicId: string;
-  }
+    /** quote.requested */
+    export interface QuoteRequested extends Base {
+        modelId: number;
+        modelName: string;
+        orderId: number;
+        orderPublicId: string;
+    }
 
-  /** order.confirmed */
-  export interface OrderConfirmed extends Base {
-    orderId: number;
-    orderPublicId: string;
-  }
+    /** order.confirmed */
+    export interface OrderConfirmed extends Base {
+        orderId: number;
+        orderPublicId: string;
+    }
 
-  /** order.cancelled */
-  export interface OrderCancelled extends Base {
-    orderId: number;
-    orderPublicId: string;
-    refundAmount: number | null;
-    cancelFee: number | null;
-  }
+    /** order.cancelled */
+    export interface OrderCancelled extends Base {
+        orderId: number;
+        orderPublicId: string;
+        refundAmount: number | null;
+        cancelFee: number | null;
+    }
 
-  /** order.pending_approval */
-  export interface OrderPendingApproval extends Base {
-    modelId: number;
-    modelName: string;
-    orderId: number;
-    orderPublicId: string;
-  }
+    /** order.pending_approval */
+    export interface OrderPendingApproval extends Base {
+        modelId: number;
+        modelName: string;
+        orderId: number;
+        orderPublicId: string;
+    }
 
-  /** order.updated */
-  export interface OrderUpdated extends Base {
-    modelId: number | null;
-    modelName: string | null;
-  }
+    /** order.updated */
+    export interface OrderUpdated extends Base {
+        modelId: number | null;
+        modelName: string | null;
+    }
 
-  /** delivery.completed */
-  export interface DeliveryCompleted extends Base {
-    orderId: number;
-    orderPublicId: string;
-  }
+    /** delivery.completed */
+    export interface DeliveryCompleted extends Base {
+        orderId: number;
+        orderPublicId: string;
+    }
 
-  /** stop.assigned */
-  export interface StopAssigned extends Base {
-    modelId: number;
-    stopId: number;
-    orderId: number;
-    stopType: string;
-    routeDate: string;
-  }
+    /** stop.assigned */
+    export interface StopAssigned extends Base {
+        modelId: number;
+        stopId: number;
+        orderId: number;
+        stopType: string;
+        routeDate: string;
+    }
 
-  /** stop.failed */
-  export interface StopFailed extends Base {
-    modelId: number;
-    stopId: number;
-    orderId: number;
-    driverName: string;
-    reason: string;
-    routeDate: string;
-  }
+    /** stop.failed */
+    export interface StopFailed extends Base {
+        modelId: number;
+        stopId: number;
+        orderId: number;
+        driverName: string;
+        reason: string;
+        routeDate: string;
+    }
 
-  /** stop.delay_flagged */
-  export interface StopDelayFlagged extends Base {
-    modelId: number;
-    stopId: number;
-    orderId: number;
-    driverName: string;
-    reason: string;
-    routeDate: string;
-  }
+    /** stop.delay_flagged */
+    export interface StopDelayFlagged extends Base {
+        modelId: number;
+        stopId: number;
+        orderId: number;
+        driverName: string;
+        reason: string;
+        routeDate: string;
+    }
 
-  /** schedule.changed */
-  export interface ScheduleChanged extends Base {
-    orderPublicId: string;
-    stopType: string;
-    oldTime: string | null;
-    newTime: string | null;
-    reason: string;
-  }
+    /** schedule.changed */
+    export interface ScheduleChanged extends Base {
+        orderPublicId: string;
+        stopType: string;
+        oldTime: string | null;
+        newTime: string | null;
+        reason: string;
+    }
 
-  /** chat.message_received */
-  export interface ChatMessageReceived extends Base {
-    orderId: number;
-    orderPublicId: string;
-    senderName: string;
-  }
+    /** chat.message_received */
+    export interface ChatMessageReceived extends Base {
+        orderId: number;
+        orderPublicId: string;
+        senderName: string;
+    }
 
-  /** payment.receipt */
-  export interface PaymentReceipt extends Base {
-    orderId: number;
-    orderPublicId: string;
-    paymentId: number;
-    amount: number;
-    currency: string;
-    invoicePublicId: string | null;
-  }
+    /** payment.receipt */
+    export interface PaymentReceipt extends Base {
+        orderId: number;
+        orderPublicId: string;
+        paymentId: number;
+        amount: number;
+        currency: string;
+        invoicePublicId: string | null;
+    }
 
-  /** final.receipt */
-  export interface FinalReceipt extends Base {
-    orderId: number;
-    orderPublicId: string;
-    invoicePublicId: string;
-    amount: number;
-    currency: string;
-  }
+    /** final.receipt */
+    export interface FinalReceipt extends Base {
+        orderId: number;
+        orderPublicId: string;
+        invoicePublicId: string;
+        amount: number;
+        currency: string;
+    }
 
-  /** surcharge.receipt */
-  export interface SurchargeReceipt extends Base {
-    orderId: number;
-    orderPublicId: string;
-    invoicePublicId: string;
-    amount: number;
-    currency: string;
-  }
+    /** surcharge.receipt */
+    export interface SurchargeReceipt extends Base {
+        orderId: number;
+        orderPublicId: string;
+        invoicePublicId: string;
+        amount: number;
+        currency: string;
+    }
 
-  /** refund.receipt */
-  export interface RefundReceipt extends Base {
-    orderId: number;
-    orderPublicId: string;
-    invoicePublicId: string;
-    amount: number;
-    currency: string;
-  }
+    /** refund.receipt */
+    export interface RefundReceipt extends Base {
+        orderId: number;
+        orderPublicId: string;
+        invoicePublicId: string;
+        amount: number;
+        currency: string;
+    }
 
-  /** payment.failed */
-  export interface PaymentFailed extends Base {
-    orderId: number;
-    orderPublicId: string;
-  }
+    /** payment.failed */
+    export interface PaymentFailed extends Base {
+        orderId: number;
+        orderPublicId: string;
+    }
 
-  /** catalog.updated */
-  export interface CatalogUpdated extends Base {
-    modelId: number | null;
-    modelName: string | null;
-    catalogId: number | null;
-  }
+    /** catalog.updated */
+    export interface CatalogUpdated extends Base {
+        modelId: number | null;
+        modelName: string | null;
+        catalogId: number | null;
+    }
 
-  /** user.updated / driver.updated / business.updated */
-  export interface EntityUpdated extends Base {
-    modelId: number | null;
-    modelPublicId: string | null;
-    modelName: string | null;
-  }
+    /** user.updated / driver.updated / business.updated */
+    export interface EntityUpdated extends Base {
+        modelId: number | null;
+        modelPublicId: string | null;
+        modelName: string | null;
+    }
 
-  /** unassigned_order.escalation */
-  export interface UnassignedOrderEscalation extends Base {
-    orderId: number;
-    orderPublicId: string;
-    workingHoursUnassigned: number;
-  }
+    /** unassigned_order.escalation */
+    export interface UnassignedOrderEscalation extends Base {
+        orderId: number;
+        orderPublicId: string;
+        workingHoursUnassigned: number;
+    }
 
-  /** refund-request.created */
-  export interface RefundRequestCreated extends Base {
-    orderId: number;
-    orderPublicId: string;
-    refundRequestId: number;
-    refundRequestPublicId: string;
-    reason: string;
-    customerName: string;
-  }
+    /** refund-request.created */
+    export interface RefundRequestCreated extends Base {
+        orderId: number;
+        orderPublicId: string;
+        refundRequestId: number;
+        refundRequestPublicId: string;
+        reason: string;
+        customerName: string;
+    }
 
-  /** refund-request.resolved */
-  export interface RefundRequestResolved extends Base {
-    orderId: number;
-    orderPublicId: string;
-    refundRequestId: number;
-    refundRequestPublicId: string;
-    status: string;
-    adminNotes: string | null;
-  }
+    /** refund-request.resolved */
+    export interface RefundRequestResolved extends Base {
+        orderId: number;
+        orderPublicId: string;
+        refundRequestId: number;
+        refundRequestPublicId: string;
+        status: string;
+        adminNotes: string | null;
+    }
 
-  /** Union of all broadcast notification payloads. */
-  export type AnyNotification =
-    | QuoteSent
-    | QuoteExpired
-    | QuoteRequested
-    | OrderConfirmed
-    | OrderCancelled
-    | OrderPendingApproval
-    | OrderUpdated
-    | DeliveryCompleted
-    | StopAssigned
-    | StopFailed
-    | StopDelayFlagged
-    | ScheduleChanged
-    | ChatMessageReceived
-    | PaymentReceipt
-    | FinalReceipt
-    | SurchargeReceipt
-    | RefundReceipt
-    | PaymentFailed
-    | CatalogUpdated
-    | EntityUpdated
-    | UnassignedOrderEscalation
-    | RefundRequestCreated
-    | RefundRequestResolved;
+    /** Union of all broadcast notification payloads. */
+    export type AnyNotification =
+        | QuoteSent
+        | QuoteExpired
+        | QuoteRequested
+        | OrderConfirmed
+        | OrderCancelled
+        | OrderPendingApproval
+        | OrderUpdated
+        | DeliveryCompleted
+        | StopAssigned
+        | StopFailed
+        | StopDelayFlagged
+        | ScheduleChanged
+        | ChatMessageReceived
+        | PaymentReceipt
+        | FinalReceipt
+        | SurchargeReceipt
+        | RefundReceipt
+        | PaymentFailed
+        | CatalogUpdated
+        | EntityUpdated
+        | UnassignedOrderEscalation
+        | RefundRequestCreated
+        | RefundRequestResolved;
 }

--- a/types/response.d.ts
+++ b/types/response.d.ts
@@ -1,82 +1,82 @@
 declare namespace Api.Response {
-  interface Common {
-    message: string;
-    status: number;
-    extra: Record<string, unknown>;
-  }
+    interface Common {
+        message: string;
+        status: number;
+        extra: Record<string, unknown>;
+    }
 
-  interface SimplePaginatorMeta {
-    from: number | null;
-    to: number | null;
-    path: string;
-    perPage: number;
-    firstPageUrl: string;
-    currentPageUrl: string;
-    currentPage: number;
-    nextPageUrl: string | null;
-    prevPageUrl: string | null;
-  }
+    interface SimplePaginatorMeta {
+        from: number | null;
+        to: number | null;
+        path: string;
+        perPage: number;
+        firstPageUrl: string;
+        currentPageUrl: string;
+        currentPage: number;
+        nextPageUrl: string | null;
+        prevPageUrl: string | null;
+    }
 
-  interface LengthAwarePaginatorMeta {
-    from: number | null;
-    to: number | null;
-    path: string;
-    perPage: number;
-    firstPageUrl: string;
-    prevPageUrl: string | null;
-    currentPage: number;
-    nextPageUrl: string | null;
-    lastPage: number;
-    lastPageUrl: string;
-    links: Array<{
-      url: string | null;
-      label: string;
-      active: boolean;
-    }>;
-    total: number;
-  }
+    interface LengthAwarePaginatorMeta {
+        from: number | null;
+        to: number | null;
+        path: string;
+        perPage: number;
+        firstPageUrl: string;
+        prevPageUrl: string | null;
+        currentPage: number;
+        nextPageUrl: string | null;
+        lastPage: number;
+        lastPageUrl: string;
+        links: Array<{
+            url: string | null;
+            label: string;
+            active: boolean;
+        }>;
+        total: number;
+    }
 
-  interface CursorPaginatorMeta {
-    path: string;
-    perPage: number;
-    nextCursor: string | null;
-    nextPageUrl: string | null;
-    prevCursor: string | null;
-    prevPageUrl: string | null;
-  }
+    interface CursorPaginatorMeta {
+        path: string;
+        perPage: number;
+        nextCursor: string | null;
+        nextPageUrl: string | null;
+        prevCursor: string | null;
+        prevPageUrl: string | null;
+    }
 
-  export interface SuccessBasic extends Common {}
+    export interface SuccessBasic extends Common {}
 
-  export interface Single<T> extends SuccessBasic {
-    item: T;
-  }
+    export interface Single<T> extends SuccessBasic {
+        item: T;
+    }
 
-  export interface Multiple<T> extends SuccessBasic {
-    items: T[];
-  }
+    export interface Multiple<T> extends SuccessBasic {
+        items: T[];
+    }
 
-  export interface SimplePaginated<T> extends SuccessBasic {
-    items: T[];
-    meta: SimplePaginatorMeta;
-  }
+    export interface SimplePaginated<T> extends SuccessBasic {
+        items: T[];
+        meta: SimplePaginatorMeta;
+    }
 
-  export interface Paginated<T> extends SuccessBasic {
-    items: T[];
-    meta: LengthAwarePaginatorMeta;
-  }
+    export interface Paginated<T> extends SuccessBasic {
+        items: T[];
+        meta: LengthAwarePaginatorMeta;
+    }
 
-  export interface CursorPaginated<T> extends SuccessBasic {
-    items: T[];
-    meta: CursorPaginatorMeta;
-  }
+    export interface CursorPaginated<T> extends SuccessBasic {
+        items: T[];
+        meta: CursorPaginatorMeta;
+    }
 
-  export interface Error extends Common {
-    details?: string | null;
-    errors?: Record<string, string[]>;
-  }
+    export interface Error extends Common {
+        details?: string | null;
+        errors?: Record<string, string[]>;
+    }
 
-  export interface Login extends SuccessBasic {
-    token: string;
-    mustChangePassword: boolean;
-  }
+    export interface Login extends SuccessBasic {
+        token: string;
+        mustChangePassword: boolean;
+    }
 }

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -77,6 +77,29 @@ export function getTodayAppTz(): Date {
   return new Date(`${c.year}-${padNumber(c.month)}-${padNumber(c.day)}T00:00:00${APP_UTC_OFFSET}`);
 }
 
+/**
+ * Add (or subtract) whole days to a bare `YYYY-MM-DD` string, returning `YYYY-MM-DD`.
+ * Parses at local midnight so day arithmetic never crosses a DST/UTC boundary.
+ */
+export function addDays(dateString: string, delta: number): string {
+  const d = new Date(`${dateString}T00:00:00`);
+  d.setDate(d.getDate() + delta);
+  return toDateString(d);
+}
+
+/**
+ * Format a bare `YYYY-MM-DD` as a localized `d MMM yyyy` label. Parses at local
+ * midnight, so — unlike {@link formatDate} — it never shifts a day in a
+ * negative-offset timezone.
+ */
+export function formatDateOnly(dateString: string, locale?: string): string {
+  return new Date(`${dateString}T00:00:00`).toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
 const getLocale = (): string => i18n.language || 'en';
 
 /**

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -96,3 +96,23 @@ export const actionLabel = (action: string, model?: string, toUpper = true): str
 export const modelLabel = (model: string, count = 1): string => {
   return i18next.t(`models:${model}`, { count, defaultValue: model });
 };
+
+/**
+ * Get translated vehicle type label (e.g., 'motorcycle', 'pickup_van').
+ * @param vehicleType - The vehicle type key
+ * @returns Translated vehicle type label
+ */
+export const vehicleTypeLabel = (vehicleType: string | null | undefined): string => {
+  if (!vehicleType) return i18next.t('common:none', { defaultValue: 'None' });
+  return i18next.t(`orders:vehicle_types.${vehicleType}`, { defaultValue: vehicleType });
+};
+
+/**
+ * Get translated dispatch policy label (e.g., 'auto', 'manual_only').
+ * @param dispatchPolicy - The dispatch policy key
+ * @returns Translated dispatch policy label
+ */
+export const dispatchPolicyLabel = (dispatchPolicy: string | null | undefined): string => {
+  if (!dispatchPolicy) return i18next.t('common:none', { defaultValue: 'None' });
+  return i18next.t(`drivers:dispatch_policies.${dispatchPolicy}`, { defaultValue: dispatchPolicy });
+};

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -91,10 +91,12 @@ export const actionLabel = (action: string, model?: string, toUpper = true): str
  * Get translated model label (e.g., 'catalog', 'catalog_element').
  * @param model - The model key
  * @param count - For pluralization (1 = singular, >1 = plural)
+ * @param toUpper - Capitalize the first letter (default true, matching actionLabel)
  * @returns Translated model label
  */
-export const modelLabel = (model: string, count = 1): string => {
-  return i18next.t(`models:${model}`, { count, defaultValue: model });
+export const modelLabel = (model: string, count = 1, toUpper = true): string => {
+  const label = i18next.t(`models:${model}`, { count, defaultValue: model });
+  return toUpper ? capitalize(label) : label;
 };
 
 /**

--- a/utils/scheduleEvents.ts
+++ b/utils/scheduleEvents.ts
@@ -1,5 +1,6 @@
 import type { EventInput } from '@fullcalendar/core';
 import { extractDatePart, getTodayAppTz } from '@/utils/format';
+import { capitalize, vehicleTypeLabel } from '@/utils/lang';
 
 type ScheduleEntry = App.Data.Driver.DriverScheduleData;
 
@@ -16,6 +17,7 @@ const COLORS = {
 export interface CalendarEventProps {
   _date: string;
   _startTime: string;
+  _vehicleType: App.Enums.VehicleType | null;
 }
 
 /**
@@ -39,10 +41,13 @@ export function buildCalendarEvents(schedules: ScheduleEntry[], title = 'Schedul
     const isPast = new Date(dateStr + 'T00:00:00') < today;
     const color = isPast ? COLORS.past : COLORS.scheduled;
     const normalizedStart = normalizeTime(schedule.startTime);
+    const eventTitle = schedule.vehicleType
+      ? `${title} · ${capitalize(vehicleTypeLabel(schedule.vehicleType))}`
+      : title;
 
     events.push({
       id: `schedule-${dateStr}-${index}`,
-      title,
+      title: eventTitle,
       start: `${dateStr}T${normalizedStart}`,
       end: `${dateStr}T${normalizeTime(schedule.endTime)}`,
       backgroundColor: color,
@@ -50,6 +55,7 @@ export function buildCalendarEvents(schedules: ScheduleEntry[], title = 'Schedul
       extendedProps: {
         _date: dateStr,
         _startTime: schedule.startTime,
+        _vehicleType: schedule.vehicleType,
       } satisfies CalendarEventProps,
     });
   }


### PR DESCRIPTION
Admin UI for driver vehicle types, dispatch policy, and preferred-driver selection.

## Changes

- **Vehicle type & dispatch policy admin UI.**
- **Driver selection inside the quote modal**, with a clearable selector and a surfaced reason when a preferred driver is dropped.
- **Inactive drivers excluded** from assignable pickers.
- Settings vehicle types guarded against a null response.
- Drivers: lowercase catalog codes for sex/language selects.
- i18n: locales fetched same-origin via a Next rewrite (fixes static-file CORS); `modelLabel` capitalizes by default.

## Verification

`npm run lint` and `npm run typecheck` — 0 errors.

## Follow-up

Manual QA still pending. Depends on the matching API PR.
