### PR TITLE
feat(payments): manual payments admin UI (entitlements, record/void, Sin Pagar split)

### DIFF
--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -1,22 +1,18 @@
 'use client';
 
-import {
-  actionLabel,
-  modelLabel,
-  resourceMessage,
-  validationAttribute,
-} from '@/utils/lang';
+import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
-import { useBusiness, useDeleteBusiness } from '@/hooks/businesses';
+import { useBusiness, useDeleteBusiness, useUpdateBusiness } from '@/hooks/businesses';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Building2, User, MapPin, Calendar, Trash2 } from 'lucide-react';
 import { formatDate } from '@/utils/format';
 import { useBusinessTaxProfile } from '@/hooks/tax-profiles';
 import { TaxProfileCard } from '@/components/TaxProfileCard';
+import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 
 export default function BusinessDetailPage() {
   const params = useParams();
@@ -27,6 +23,14 @@ export default function BusinessDetailPage() {
   const { data: business, isLoading, error } = useBusiness(businessId);
   const { data: taxProfile } = useBusinessTaxProfile(businessId);
   const deleteBusiness = useDeleteBusiness();
+  const updateBusiness = useUpdateBusiness();
+
+  const handleChangePaymentMethods = (next: string[]) => {
+    updateBusiness.mutate({
+      id: businessId,
+      data: { allowedPaymentMethods: next as App.Enums.PaymentMethodType[] },
+    });
+  };
 
   const formatAddress = (address?: App.Data.Address.AddressData | null): string => {
     const notSpecified = t('businesses:detail.not_specified', { defaultValue: 'Not specified' });
@@ -170,6 +174,13 @@ export default function BusinessDetailPage() {
             <p className="font-medium">{formatAddress(business.primaryAddress)}</p>
           </CardContent>
         </Card>
+
+        {/* Payment Methods */}
+        <PaymentMethodsCard
+          allowedMethods={business.allowedPaymentMethods}
+          onChange={handleChangePaymentMethods}
+          isPending={updateBusiness.isPending}
+        />
 
         <Card>
           <CardHeader>

--- a/app/[lang]/(dashboard)/needs-attention/page.tsx
+++ b/app/[lang]/(dashboard)/needs-attention/page.tsx
@@ -6,11 +6,14 @@ import { useOrderList } from '@/hooks/orders';
 import { useNeedsAttention } from '@/hooks/orders/useNeedsAttention';
 import { usePendingReconciliation } from '@/hooks/orders/usePendingReconciliation';
 import { usePendingRefundRequests } from '@/hooks/refundRequests';
+import { useCurrencyList } from '@/hooks/currencies';
 import { NeedsAttentionCard } from '@/components/orders/NeedsAttentionCard';
 import { PendingReconciliationCard } from '@/components/orders/PendingReconciliationCard';
 import { RefundRequestCard } from '@/components/orders/RefundRequestCard';
 import { OrderStatusBadge } from '@/components/orders/OrderStatusBadge';
 import { PaymentStatusBadge } from '@/components/orders/PaymentStatusBadge';
+import { RecordPaymentDialog } from '@/components/payments/RecordPaymentDialog';
+import { getPaymentMethodLabel, getOrderDueAmount } from '@/components/payments/PaymentSection';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -20,6 +23,8 @@ import { RefreshCw, AlertTriangle, Eye, Clock, User, Building2 } from 'lucide-re
 import { formatDateTime } from '@/utils/format';
 import { Enums } from '@/data/app-enums';
 import { actionLabel } from '@/utils/lang';
+
+type OrderData = App.Data.Order.OrderData;
 
 const { AttentionUrgency } = Enums;
 
@@ -31,6 +36,38 @@ const summaryStyles: Record<string, string> = {
   [AttentionUrgency.Medium]: 'bg-amber-100 text-amber-800',
   [AttentionUrgency.Low]: 'bg-gray-100 text-gray-800',
 };
+
+function OrderSummaryCardHeader({ order }: { order: OrderData }) {
+  return (
+    <CardHeader className="pb-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-sm font-semibold">#{order.publicId}</span>
+        <OrderStatusBadge
+          status={(order.status ?? Enums.OrderStatus.PENDING) as App.Enums.OrderStatus}
+        />
+        <PaymentStatusBadge status={order.paymentStatus} />
+      </div>
+      <div className="text-muted-foreground mt-1 flex flex-col gap-1 text-sm">
+        {order.user && (
+          <span className="flex items-center gap-1">
+            <User className="h-3.5 w-3.5" />
+            {order.user.name}
+          </span>
+        )}
+        {order.business && (
+          <span className="flex items-center gap-1">
+            <Building2 className="h-3.5 w-3.5" />
+            {order.business.name}
+          </span>
+        )}
+        <span className="flex items-center gap-1">
+          <Clock className="h-3.5 w-3.5" />
+          {formatDateTime(order.createdAt)}
+        </span>
+      </div>
+    </CardHeader>
+  );
+}
 
 export default function NeedsAttentionPage() {
   const { t } = useTranslation('orders');
@@ -49,16 +86,30 @@ export default function NeedsAttentionPage() {
     excludeTerminal: true,
   });
   const {
-    data: unpaidData,
-    isLoading: unpaidLoading,
-    refetch: refetchUnpaid,
-    isRefetching: isRefetchingUnpaid,
+    data: unpaidPrepaymentData,
+    isLoading: unpaidPrepaymentLoading,
+    refetch: refetchUnpaidPrepayment,
+    isRefetching: isRefetchingUnpaidPrepayment,
   } = useOrderList({
     page: 1,
     perPage: 100,
     paymentStatus: Enums.PaymentStatus.UNPAID,
     hasQuote: true,
     excludeTerminal: true,
+    collectOnDelivery: false,
+  });
+  const {
+    data: unpaidCollectData,
+    isLoading: unpaidCollectLoading,
+    refetch: refetchUnpaidCollect,
+    isRefetching: isRefetchingUnpaidCollect,
+  } = useOrderList({
+    page: 1,
+    perPage: 100,
+    paymentStatus: Enums.PaymentStatus.UNPAID,
+    hasQuote: true,
+    excludeTerminal: true,
+    collectOnDelivery: true,
   });
   const {
     data: reconciliationData,
@@ -73,6 +124,7 @@ export default function NeedsAttentionPage() {
     isRefetching: isRefetchingRefundRequests,
   } = usePendingRefundRequests();
   const [filter, setFilter] = useState<string>('all');
+  const { data: currencyListData } = useCurrencyList();
 
   const items = data?.data ?? [];
   const summary = (data?.summary ?? {}) as Record<string, number>;
@@ -82,16 +134,23 @@ export default function NeedsAttentionPage() {
   const refundRequests = refundRequestsData?.items ?? [];
   const reconciliationOrders = reconciliationData?.data ?? [];
   const unquotedOrders = unquotedData?.items ?? [];
-  const unpaidOrders = unpaidData?.items ?? [];
+  const unpaidPrepaymentOrders = unpaidPrepaymentData?.items ?? [];
+  const unpaidCollectOrders = unpaidCollectData?.items ?? [];
   const unquotedCount = unquotedData?.meta?.total ?? unquotedOrders.length;
-  const unpaidCount = unpaidData?.meta?.total ?? unpaidOrders.length;
+  const unpaidPrepaymentCount = unpaidPrepaymentData?.meta?.total ?? unpaidPrepaymentOrders.length;
+  const unpaidCollectCount = unpaidCollectData?.meta?.total ?? unpaidCollectOrders.length;
+  const unpaidCount = unpaidPrepaymentCount + unpaidCollectCount;
 
   const urgentCount = (summary.critical ?? 0) + (summary.high ?? 0);
+
+  const currencySymbolFor = (code?: string | null) =>
+    currencyListData?.items?.find((c) => c.code === code)?.symbol || code || '₡';
 
   const handleRefreshAll = () => {
     refetch();
     refetchUnquoted();
-    refetchUnpaid();
+    refetchUnpaidPrepayment();
+    refetchUnpaidCollect();
     refetchReconciliation();
     refetchRefundRequests();
   };
@@ -99,7 +158,8 @@ export default function NeedsAttentionPage() {
   const anyRefetching =
     isRefetching ||
     isRefetchingUnquoted ||
-    isRefetchingUnpaid ||
+    isRefetchingUnpaidPrepayment ||
+    isRefetchingUnpaidCollect ||
     isRefetchingReconciliation ||
     isRefetchingRefundRequests;
 
@@ -298,66 +358,100 @@ export default function NeedsAttentionPage() {
           )}
         </TabsContent>
 
-        <TabsContent value="not-paid" className="space-y-4">
-          {unpaidLoading ? (
-            <div className="text-muted-foreground py-12 text-center">
-              {t('common:loading', { defaultValue: 'Loading...' })}
-            </div>
-          ) : unpaidOrders.length === 0 ? (
-            <div className="text-muted-foreground py-12 text-center">
-              {t('needs_attention.no_unpaid', {
-                defaultValue: 'No unpaid orders pending payment',
+        <TabsContent value="not-paid" className="space-y-8">
+          {/* Awaiting prepayment */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">
+              {t('needs_attention.awaiting_prepayment_heading', {
+                defaultValue: 'Awaiting Prepayment',
               })}
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {unpaidOrders.map((order) => (
-                <Card key={order.publicId}>
-                  <CardHeader className="pb-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-mono text-sm font-semibold">#{order.publicId}</span>
-                      <OrderStatusBadge
-                        status={
-                          (order.status ?? Enums.OrderStatus.PENDING) as App.Enums.OrderStatus
-                        }
-                      />
-                      <PaymentStatusBadge status={order.paymentStatus} />
-                    </div>
-                    <div className="text-muted-foreground mt-1 flex flex-col gap-1 text-sm">
-                      {order.user && (
-                        <span className="flex items-center gap-1">
-                          <User className="h-3.5 w-3.5" />
-                          {order.user.name}
-                        </span>
-                      )}
-                      {order.business && (
-                        <span className="flex items-center gap-1">
-                          <Building2 className="h-3.5 w-3.5" />
-                          {order.business.name}
-                        </span>
-                      )}
-                      <span className="flex items-center gap-1">
-                        <Clock className="h-3.5 w-3.5" />
-                        {formatDateTime(order.createdAt)}
-                      </span>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => router.push(`/orders/${order.publicId}`)}
-                      >
-                        <Eye className="mr-1 h-4 w-4" />
-                        {actionLabel('view')}
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
+            </h3>
+            {unpaidPrepaymentLoading ? (
+              <div className="text-muted-foreground py-12 text-center">
+                {t('common:loading', { defaultValue: 'Loading...' })}
+              </div>
+            ) : unpaidPrepaymentOrders.length === 0 ? (
+              <div className="text-muted-foreground py-12 text-center">
+                {t('needs_attention.no_unpaid', {
+                  defaultValue: 'No unpaid orders pending payment',
+                })}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {unpaidPrepaymentOrders.map((order) => (
+                  <Card key={order.publicId}>
+                    <OrderSummaryCardHeader order={order} />
+                    <CardContent>
+                      <div className="flex flex-wrap items-center gap-2">
+                        {order.publicId && (
+                          <RecordPaymentDialog
+                            orderPublicId={order.publicId}
+                            currencySymbol={currencySymbolFor(order.currencyCode)}
+                            defaultAmount={getOrderDueAmount(order)}
+                            onSuccess={refetchUnpaidPrepayment}
+                          />
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => router.push(`/orders/${order.publicId}`)}
+                        >
+                          <Eye className="mr-1 h-4 w-4" />
+                          {actionLabel('view')}
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Collect on delivery, in progress */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">
+              {t('needs_attention.collect_on_delivery_heading', {
+                defaultValue: 'Collect on Delivery — In Progress',
+              })}
+            </h3>
+            {unpaidCollectLoading ? (
+              <div className="text-muted-foreground py-12 text-center">
+                {t('common:loading', { defaultValue: 'Loading...' })}
+              </div>
+            ) : unpaidCollectOrders.length === 0 ? (
+              <div className="text-muted-foreground py-12 text-center">
+                {t('needs_attention.no_collect_on_delivery', {
+                  defaultValue: 'No orders currently collecting payment on delivery',
+                })}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {unpaidCollectOrders.map((order) => (
+                  <Card key={order.publicId}>
+                    <OrderSummaryCardHeader order={order} />
+                    <CardContent className="space-y-3">
+                      <p className="text-muted-foreground text-sm">
+                        {t('needs_attention.collect_method_label', {
+                          method: getPaymentMethodLabel(t, order.collectOnDeliveryMethod),
+                          defaultValue: 'Collecting via {{method}}',
+                        })}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => router.push(`/orders/${order.publicId}`)}
+                        >
+                          <Eye className="mr-1 h-4 w-4" />
+                          {actionLabel('view')}
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
         </TabsContent>
 
         <TabsContent value="refund-requests" className="space-y-4">

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -741,7 +741,12 @@ export default function OrderDetailPage() {
                 {t('orders:detail.payment_status', { defaultValue: 'Payment Status' })}
               </span>
               <Badge
-                variant={order.paymentStatus === Enums.PaymentStatus.PAID || order.paymentStatus === Enums.PaymentStatus.AUTHORIZED ? 'default' : 'secondary'}
+                variant={
+                  order.paymentStatus === Enums.PaymentStatus.PAID ||
+                  order.paymentStatus === Enums.PaymentStatus.AUTHORIZED
+                    ? 'default'
+                    : 'secondary'
+                }
               >
                 {statusLabel(order.paymentStatus || Enums.PaymentStatus.UNPAID)}
               </Badge>
@@ -750,7 +755,7 @@ export default function OrderDetailPage() {
         </Card>
 
         {/* Payments Section */}
-        {order.publicId && <PaymentSection orderPublicId={order.publicId} />}
+        {order.publicId && <PaymentSection order={order} />}
 
         {/* Invoices Section */}
         {order.publicId && <InvoiceSection orderPublicId={order.publicId} />}

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import {
-  actionLabel,
-  modelLabel,
-  resourceMessage,
-  validationAttribute,
-} from '@/utils/lang';
+import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { formatDate } from '@/utils/format';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
-import { useUser, useDeleteUser } from '@/hooks/users';
+import { useUser, useDeleteUser, useUpdateUser } from '@/hooks/users';
 import { RoleBadge } from '@/components/users/RoleBadge';
+import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { useCatalogElement } from '@/hooks/catalogs/useCatalogStore';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -53,7 +49,15 @@ export default function UserDetailPage() {
 
   const { data: user, isLoading, error } = useUser(userId);
   const deleteUser = useDeleteUser();
+  const updateUser = useUpdateUser();
   const sexElement = useCatalogElement(user?.sexId);
+
+  const handleChangePaymentMethods = (next: string[]) => {
+    updateUser.mutate({
+      id: userId,
+      data: { allowedPaymentMethods: next as App.Enums.PaymentMethodType[] },
+    });
+  };
 
   const handleDelete = () => {
     if (
@@ -267,6 +271,13 @@ export default function UserDetailPage() {
             </CardContent>
           </Card>
         )}
+
+        {/* Payment Methods */}
+        <PaymentMethodsCard
+          allowedMethods={user.allowedPaymentMethods}
+          onChange={handleChangePaymentMethods}
+          isPending={updateUser.isPending}
+        />
 
         {/* Timestamps */}
         <Card>

--- a/components/payments/PaymentMethodsCard.tsx
+++ b/components/payments/PaymentMethodsCard.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { useTranslation } from 'react-i18next';
+import { Wallet } from 'lucide-react';
+import { Enums } from '@/data/app-enums';
+import { validationAttribute } from '@/utils/lang';
+import { getPaymentMethodLabel } from './PaymentSection';
+
+const TOGGLEABLE_METHODS = [Enums.PaymentMethodType.Cash, Enums.PaymentMethodType.SinpeMobile];
+
+interface PaymentMethodsCardProps {
+  allowedMethods: string[] | undefined;
+  onChange: (nextMethods: string[]) => void;
+  isPending?: boolean;
+}
+
+export function PaymentMethodsCard({
+  allowedMethods,
+  onChange,
+  isPending,
+}: PaymentMethodsCardProps) {
+  const { t } = useTranslation();
+  const methods = allowedMethods ?? [];
+
+  const handleToggle = (method: string, checked: boolean) => {
+    onChange(
+      checked ? Array.from(new Set([...methods, method])) : methods.filter((m) => m !== method)
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Wallet className="h-5 w-5" />
+          {validationAttribute('allowedPaymentMethods', true)}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">
+            {getPaymentMethodLabel(t, Enums.PaymentMethodType.Card)}
+          </span>
+          <Badge variant="secondary">
+            {t('payments:entitlements.always_enabled', { defaultValue: 'Always enabled' })}
+          </Badge>
+        </div>
+        {TOGGLEABLE_METHODS.map((method) => (
+          <div key={method} className="flex items-center justify-between">
+            <Label htmlFor={`payment-method-${method}`} className="text-sm font-medium">
+              {getPaymentMethodLabel(t, method)}
+            </Label>
+            <Checkbox
+              id={`payment-method-${method}`}
+              checked={methods.includes(method)}
+              disabled={isPending}
+              onCheckedChange={(checked) => handleToggle(method, checked === true)}
+            />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/payments/PaymentSection.tsx
+++ b/components/payments/PaymentSection.tsx
@@ -9,16 +9,19 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useOrderPayments } from '@/hooks/payments';
 import { useOrderCurrencySymbol } from '@/hooks/currencies';
 import { RefundDialog } from './RefundDialog';
+import { RecordPaymentDialog } from './RecordPaymentDialog';
+import { VoidPaymentDialog } from './VoidPaymentDialog';
 import { formatDate, formatCurrency } from '@/utils/format';
-import { capitalize, statusLabel } from '@/utils/lang';
+import { capitalize, statusLabel, validationAttribute } from '@/utils/lang';
 import { Enums } from '@/data/app-enums';
 import type { TFunction } from 'i18next';
 
 type PaymentData = App.Data.Payment.PaymentData;
 type RefundData = App.Data.Payment.RefundData;
+type OrderData = App.Data.Order.OrderData;
 
 interface PaymentSectionProps {
-  orderPublicId: string;
+  order: OrderData;
 }
 
 function getStatusBadgeVariant(
@@ -38,7 +41,11 @@ function getStatusBadgeVariant(
   }
 }
 
-function getPaymentMethodLabel(
+export function getOrderDueAmount(order: OrderData): number | null {
+  return order.currentQuote?.customerTotal ?? order.currentQuote?.total ?? null;
+}
+
+export function getPaymentMethodLabel(
   t: TFunction,
   method?: string | null,
   brand?: string | null
@@ -51,7 +58,7 @@ function getPaymentMethodLabel(
     case Enums.PaymentMethodType.ApplePay:
       return 'Apple Pay';
     case Enums.PaymentMethodType.SinpeMobile:
-      return 'SINPE Movil';
+      return t('payments:sinpe_mobile', { defaultValue: 'SINPE Móvil' });
     case Enums.PaymentMethodType.Cash:
       return t('payments:cash', { defaultValue: 'Cash' });
     default:
@@ -89,6 +96,9 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
   const refundableAmount = (payment.amount || 0) - (payment.totalRefunded || 0);
   const canRefund = payment.status === Enums.TransactionStatus.Succeeded && refundableAmount > 0;
   const isAuthorized = payment.status === Enums.TransactionStatus.Authorized;
+  const canVoid =
+    payment.provider === Enums.PaymentProvider.Manual &&
+    payment.status === Enums.TransactionStatus.Succeeded;
 
   return (
     <div className="bg-muted/30 rounded-lg border p-4">
@@ -148,6 +158,11 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
               {t('payments:charge_id', { defaultValue: 'Charge' })}: {payment.providerChargeId}
             </span>
           )}
+          {payment.reference && (
+            <span>
+              {validationAttribute('reference', true)}: {payment.reference}
+            </span>
+          )}
           {payment.fxRate && payment.fxRate !== 1 && (
             <span>
               {t('payments:fx_rate', { defaultValue: 'FX Rate' })}: {payment.fxRate.toFixed(4)}
@@ -155,6 +170,14 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
           )}
         </div>
         <div className="flex gap-2">
+          {payment.proofUrl && (
+            <Button variant="outline" size="sm" asChild>
+              <a href={payment.proofUrl} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                {t('payments:proof', { defaultValue: 'Proof' })}
+              </a>
+            </Button>
+          )}
           {payment.receiptUrl && (
             <Button variant="outline" size="sm" asChild>
               <a href={payment.receiptUrl} target="_blank" rel="noopener noreferrer">
@@ -164,8 +187,15 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
             </Button>
           )}
           {canRefund && <RefundDialog payment={payment} />}
+          {canVoid && payment.publicId && <VoidPaymentDialog paymentPublicId={payment.publicId} />}
         </div>
       </div>
+
+      {payment.notes && (
+        <p className="text-muted-foreground mt-2 text-xs">
+          {validationAttribute('notes', true)}: {payment.notes}
+        </p>
+      )}
 
       {/* Refunds */}
       {payment.refunds && payment.refunds.length > 0 && (
@@ -184,17 +214,30 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
   );
 }
 
-export function PaymentSection({ orderPublicId }: PaymentSectionProps) {
+export function PaymentSection({ order }: PaymentSectionProps) {
   const { t } = useTranslation();
+  const orderPublicId = order.publicId as string;
   const { data: payments, isLoading, error } = useOrderPayments({ orderPublicId });
   const summaryCurrencySymbol = useOrderCurrencySymbol(payments?.[0]?.currencyCode);
+  const orderCurrencySymbol = useOrderCurrencySymbol(order.currencyCode);
+  const isUnpaid = order.paymentStatus === Enums.PaymentStatus.UNPAID;
+  const defaultAmount = getOrderDueAmount(order);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <CreditCard className="h-5 w-5" />
-          {t('payments:section_title', { defaultValue: 'Payments' })}
+        <CardTitle className="flex items-center justify-between gap-2">
+          <span className="flex items-center gap-2">
+            <CreditCard className="h-5 w-5" />
+            {t('payments:section_title', { defaultValue: 'Payments' })}
+          </span>
+          {isUnpaid && (
+            <RecordPaymentDialog
+              orderPublicId={orderPublicId}
+              currencySymbol={orderCurrencySymbol}
+              defaultAmount={defaultAmount}
+            />
+          )}
         </CardTitle>
       </CardHeader>
       <CardContent>

--- a/components/payments/RecordPaymentDialog.tsx
+++ b/components/payments/RecordPaymentDialog.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import {
+  DialogDescription,
+  DialogTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Dialog,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { HandCoins, Loader2 } from 'lucide-react';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useTranslation } from 'react-i18next';
+import { useRecordPayment } from '@/hooks/payments';
+import { actionLabel, validationAttribute } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+import { getPaymentMethodLabel } from './PaymentSection';
+
+interface RecordPaymentDialogProps {
+  orderPublicId: string;
+  currencySymbol: string;
+  defaultAmount?: number | null;
+  onSuccess?: () => void;
+}
+
+const METHOD_OPTIONS = [Enums.PaymentMethodType.Cash, Enums.PaymentMethodType.SinpeMobile];
+
+export function RecordPaymentDialog({
+  orderPublicId,
+  currencySymbol,
+  defaultAmount,
+  onSuccess,
+}: RecordPaymentDialogProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const recordPayment = useRecordPayment();
+
+  const [formData, setFormData] = useState({
+    method: Enums.PaymentMethodType.Cash as string,
+    amount: '',
+    reference: '',
+    notes: '',
+  });
+  const [proof, setProof] = useState<File | null>(null);
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setFormData({
+        method: Enums.PaymentMethodType.Cash,
+        amount: defaultAmount != null ? String(defaultAmount) : '',
+        reference: '',
+        notes: '',
+      });
+      setProof(null);
+    }
+    setOpen(isOpen);
+  };
+
+  const handleChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const parsedAmount = parseFloat(formData.amount);
+  const isValidAmount = !isNaN(parsedAmount) && parsedAmount > 0;
+
+  const handleSubmit = () => {
+    if (!isValidAmount) return;
+
+    recordPayment.mutate(
+      {
+        orderPublicId,
+        data: {
+          method: formData.method,
+          amount: parsedAmount,
+          reference: formData.reference || null,
+          notes: formData.notes || null,
+          proof,
+        },
+      },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          onSuccess?.();
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <HandCoins className="mr-2 h-4 w-4" />
+          {t('payments:record.button', { defaultValue: 'Record Payment' })}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t('payments:record.title', { defaultValue: 'Record Manual Payment' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('payments:record.description', {
+              defaultValue: 'Record a cash or SINPE Móvil payment collected for this order.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {/* Method */}
+          <div className="grid gap-2">
+            <Label htmlFor="method">{validationAttribute('method', true)} *</Label>
+            <Select
+              value={formData.method}
+              onValueChange={(value) => handleChange('method', value)}
+            >
+              <SelectTrigger id="method" className="w-full">
+                <SelectValue
+                  placeholder={t('payments:record.method_placeholder', {
+                    defaultValue: 'Select a method',
+                  })}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {METHOD_OPTIONS.map((method) => (
+                  <SelectItem key={method} value={method}>
+                    {getPaymentMethodLabel(t, method)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Amount */}
+          <div className="grid gap-2">
+            <Label htmlFor="amount">{validationAttribute('amount', true)} *</Label>
+            <div className="relative">
+              <span className="text-muted-foreground absolute top-1/2 left-3 -translate-y-1/2 text-sm">
+                {currencySymbol}
+              </span>
+              <Input
+                id="amount"
+                type="number"
+                step="0.01"
+                min="0.01"
+                placeholder="0.00"
+                value={formData.amount}
+                onChange={(e) => handleChange('amount', e.target.value)}
+                className="pl-8"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          {/* Reference */}
+          <div className="grid gap-2">
+            <Label htmlFor="reference">{validationAttribute('reference', true)}</Label>
+            <Input
+              id="reference"
+              value={formData.reference}
+              onChange={(e) => handleChange('reference', e.target.value)}
+            />
+          </div>
+
+          {/* Notes */}
+          <div className="grid gap-2">
+            <Label htmlFor="notes">{validationAttribute('notes', true)}</Label>
+            <Textarea
+              id="notes"
+              value={formData.notes}
+              onChange={(e) => handleChange('notes', e.target.value)}
+              rows={3}
+            />
+          </div>
+
+          {/* Proof */}
+          <div className="grid gap-2">
+            <Label htmlFor="proof">
+              {t('payments:record.proof_label', { defaultValue: 'Proof of payment (optional)' })}
+            </Label>
+            <Input
+              id="proof"
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              onChange={(e) => setProof(e.target.files?.[0] ?? null)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={recordPayment.isPending || !isValidAmount}>
+            {recordPayment.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t('payments:record.submit', { defaultValue: 'Record Payment' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/payments/VoidPaymentDialog.tsx
+++ b/components/payments/VoidPaymentDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { useVoidPayment } from '@/hooks/payments';
+import { Ban } from 'lucide-react';
+import { actionLabel } from '@/utils/lang';
+
+interface VoidPaymentDialogProps {
+  paymentPublicId: string;
+  onSuccess?: () => void;
+}
+
+export function VoidPaymentDialog({ paymentPublicId, onSuccess }: VoidPaymentDialogProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const voidPayment = useVoidPayment();
+
+  const handleConfirm = () => {
+    voidPayment.mutate(paymentPublicId, {
+      onSuccess: () => {
+        setOpen(false);
+        onSuccess?.();
+      },
+    });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Ban className="mr-2 h-4 w-4" />
+          {t('payments:void.button', { defaultValue: 'Void' })}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t('payments:void.confirm_title', { defaultValue: 'Void this payment?' })}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('payments:void.confirm_description', {
+              defaultValue:
+                'This will reverse the manual payment and mark the order as unpaid again. This cannot be undone.',
+            })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={voidPayment.isPending}>
+            {actionLabel('cancel')}
+          </AlertDialogCancel>
+          <Button variant="destructive" onClick={handleConfirm} disabled={voidPayment.isPending}>
+            {voidPayment.isPending
+              ? t('common:loading', { defaultValue: 'Loading...' })
+              : t('payments:void.button', { defaultValue: 'Void' })}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -290,7 +290,7 @@ export const Enums = {
   PaymentProvider: {
     Tilopay: "tilopay",
     Onvo: "onvo",
-    Cash: "cash",
+    Manual: "manual",
   },
   PaymentStatus: {
     UNPAID: "unpaid",

--- a/hooks/orders/useOrderList.ts
+++ b/hooks/orders/useOrderList.ts
@@ -9,6 +9,7 @@ interface UseOrderListParams {
   excludeTerminal?: boolean;
   paymentStatus?: string;
   hasQuote?: boolean;
+  collectOnDelivery?: boolean;
   search?: string;
   pickupFrom?: string;
   pickupTo?: string;

--- a/hooks/payments/index.ts
+++ b/hooks/payments/index.ts
@@ -1,2 +1,4 @@
 export { useOrderPayments } from './useOrderPayments';
 export { useProcessRefund } from './useProcessRefund';
+export { useRecordPayment } from './useRecordPayment';
+export { useVoidPayment } from './useVoidPayment';

--- a/hooks/payments/useRecordPayment.ts
+++ b/hooks/payments/useRecordPayment.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PaymentService, type RecordPaymentParams } from '@/services/paymentService';
+import { toast } from 'sonner';
+import { isApiError } from '@/lib/api/error';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+
+interface RecordPaymentArgs {
+  orderPublicId: string;
+  data: RecordPaymentParams;
+}
+
+export function useRecordPayment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ orderPublicId, data }: RecordPaymentArgs) =>
+      PaymentService.recordPayment(orderPublicId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['payments'] });
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      toast.success(crudSuccessMessage('created', 'payment'));
+    },
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage('creating', 'payment'));
+      }
+    },
+  });
+}

--- a/hooks/payments/useVoidPayment.ts
+++ b/hooks/payments/useVoidPayment.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PaymentService } from '@/services/paymentService';
+import { toast } from 'sonner';
+import { isApiError } from '@/lib/api/error';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+
+export function useVoidPayment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (paymentPublicId: string) => PaymentService.voidPayment(paymentPublicId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['payments'] });
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      toast.success(crudSuccessMessage('updated', 'payment'));
+    },
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage('updating', 'payment'));
+      }
+    },
+  });
+}

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -75,6 +75,37 @@ function buildRequestOptions(
 }
 
 /**
+ * Build request options for a multipart/form-data body. Omits Content-Type
+ * so the browser sets the correct `multipart/form-data; boundary=...` value.
+ */
+function buildMultipartRequestOptions(formData: FormData, options: FetchOptions = {}): RequestInit {
+  const token = getToken();
+  const lang = getLang();
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Accept-Language': lang,
+    ...options.headers,
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const requestInit: RequestInit = {
+    method: 'POST',
+    headers,
+    credentials: 'include',
+    body: formData,
+  };
+
+  if (options.signal) {
+    requestInit.signal = options.signal;
+  }
+
+  return requestInit;
+}
+
+/**
  * Handle API response
  */
 async function handleResponse<T>(response: Response): Promise<T> {
@@ -149,6 +180,20 @@ export const api = {
   async destroy<T>(endpoint: string, body?: unknown, options: FetchOptions = {}): Promise<T> {
     const url = `${API_URL}${endpoint}`;
     const response = await fetch(url, buildRequestOptions('DELETE', body, options));
+    return handleResponse<T>(response);
+  },
+
+  /**
+   * POST a multipart/form-data body (e.g. file uploads). Bypasses the JSON
+   * `post()` above, which always JSON.stringifies and sets Content-Type.
+   */
+  async postMultipart<T>(
+    endpoint: string,
+    formData: FormData,
+    options: FetchOptions = {}
+  ): Promise<T> {
+    const url = `${API_URL}${endpoint}`;
+    const response = await fetch(url, buildMultipartRequestOptions(formData, options));
     return handleResponse<T>(response);
   },
 };

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -60,6 +60,7 @@ interface ListParams {
   excludeTerminal?: boolean;
   paymentStatus?: string;
   hasQuote?: boolean;
+  collectOnDelivery?: boolean;
   search?: string;
   pickupFrom?: string;
   pickupTo?: string;
@@ -76,6 +77,8 @@ function buildQueryString(params: ListParams): string {
   if (params.excludeTerminal) query.set('filter[exclude_terminal]', '1');
   if (params.paymentStatus) query.set('filter[payment_status]', params.paymentStatus);
   if (typeof params.hasQuote === 'boolean') query.set('filter[has_quote]', String(params.hasQuote));
+  if (typeof params.collectOnDelivery === 'boolean')
+    query.set('filter[collect_on_delivery]', String(params.collectOnDelivery));
   if (params.search) query.set('search', params.search);
   if (params.pickupFrom) query.set('pickupFrom', params.pickupFrom);
   if (params.pickupTo) query.set('pickupTo', params.pickupTo);

--- a/services/paymentService.ts
+++ b/services/paymentService.ts
@@ -6,6 +6,14 @@ type StoreRefundData = App.Data.Payment.StoreRefundData;
 type Single<T> = Api.Response.Single<T>;
 type Paginated<T> = Api.Response.Paginated<T>;
 
+export interface RecordPaymentParams {
+  method: string;
+  amount: number;
+  reference?: string | null;
+  notes?: string | null;
+  proof?: File | null;
+}
+
 interface ListParams {
   page?: number;
   perPage?: number;
@@ -67,5 +75,33 @@ export const PaymentService = {
       `/payments/${paymentPublicId}/refunds?perPage=100`
     );
     return response.items;
+  },
+
+  /**
+   * Record a manual (cash / SINPE Móvil) payment for an order (admin only).
+   * Multipart because of the optional proof image.
+   */
+  async recordPayment(orderPublicId: string, data: RecordPaymentParams): Promise<PaymentData> {
+    const formData = new FormData();
+    formData.append('method', data.method);
+    formData.append('amount', String(data.amount));
+    if (data.reference) formData.append('reference', data.reference);
+    if (data.notes) formData.append('notes', data.notes);
+    if (data.proof) formData.append('proof', data.proof);
+
+    const response = await api.postMultipart<Single<PaymentData>>(
+      `/orders/${orderPublicId}/payments/record`,
+      formData
+    );
+    return response.item;
+  },
+
+  /**
+   * Void a manual payment (admin only). Order reverts to unpaid and a fresh
+   * collect-on-delivery intent is recreated if the order isn't terminal.
+   */
+  async voidPayment(paymentPublicId: string): Promise<PaymentData> {
+    const response = await api.post<Single<PaymentData>>(`/payments/${paymentPublicId}/void`);
+    return response.item;
   },
 };

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -150,6 +150,7 @@ declare namespace App.Data.Business {
     typeId: number;
     typeName?: string;
     usersCanApproveOwnOrders?: boolean;
+    allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     createdAt?: string;
     updatedAt?: string;
     deletedAt?: string | null;
@@ -168,6 +169,7 @@ declare namespace App.Data.Business {
     name?: string;
     typeId?: number;
     usersCanApproveOwnOrders?: boolean;
+    allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
   };
 }
 declare namespace App.Data.Catalog {
@@ -518,6 +520,7 @@ declare namespace App.Data.Order {
     cancelFee?: number | null;
     totalPaid?: number;
     hasFailedPayment?: boolean;
+    collectOnDeliveryMethod?: App.Enums.PaymentMethodType | null;
     user?: App.Data.User.UserData;
     business?: App.Data.Business.BusinessData | null;
     driver?: App.Data.Driver.DriverData | null;
@@ -650,7 +653,10 @@ declare namespace App.Data.Payment {
     currencyCode?: string;
     fxRate?: number | null;
     providerChargeId?: string | null;
+    reference?: string | null;
     receiptUrl?: string | null;
+    proofUrl?: string | null;
+    notes?: string | null;
     paidAt?: string | null;
     authorizedAt?: string | null;
     authExpiresAt?: string | null;
@@ -676,6 +682,13 @@ declare namespace App.Data.Payment {
     active?: boolean;
     createdAt?: string;
     updatedAt?: string;
+  };
+  export type RecordPaymentData = {
+    method: App.Enums.PaymentMethodType;
+    amount: number;
+    reference: string | null;
+    notes: string | null;
+    proof: any | null;
   };
   export type RefundData = {
     id?: number;
@@ -1079,6 +1092,7 @@ declare namespace App.Data.User {
     avatar?: string;
     sexId?: number;
     langCode?: string;
+    allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     preferredCurrency?: string | null;
   };
   export type UserData = {
@@ -1091,6 +1105,7 @@ declare namespace App.Data.User {
     avatar?: string;
     langCode: string;
     preferredCurrency?: string | null;
+    allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     businessId?: number | null;
     sexId?: number | null;
     isAdmin: boolean;
@@ -1401,7 +1416,7 @@ declare namespace App.Enums {
   export enum PaymentProvider {
     Tilopay = 'tilopay',
     Onvo = 'onvo',
-    Cash = 'cash',
+    Manual = 'manual',
   }
   export enum PaymentStatus {
     UNPAID = 'unpaid',


### PR DESCRIPTION
## Summary

Slice 5 of mandados-api#35 — admin dashboard support for the driver-collected-payments epic. Depends on the API's Slice 1 (entitlement foundation) + Slice 3 (admin settlement endpoints), both merged on this epic branch.

- **Entitlement toggles**: `PaymentMethodsCard` on the user and business detail pages — checkboxes for Cash and SINPE Móvil (Card is always-on, non-toggleable), writing `allowedPaymentMethods` through the existing `useUpdateUser`/`useUpdateBusiness` mutations.
- **Record payment**: `RecordPaymentDialog` (method, amount, reference, notes, optional proof image) posts to `POST orders/{order}/payments/record` via a new `api.postMultipart()` client method. Surfaced on `PaymentSection` when the order is unpaid, and inline on "awaiting prepayment" Sin Pagar cards.
- **Void payment**: `VoidPaymentDialog` confirms then calls `POST payments/{payment}/void` on manual `Succeeded` payments. `PaymentCard` now also renders `reference` / `notes` / `proofUrl` when present.
- **Sin Pagar split**: the Not Yet Paid tab now runs two `useOrderList` queries against a new `collectOnDelivery` filter (`filter[collect_on_delivery]`) — "awaiting prepayment" (with the Record button) and "collect on delivery, in progress" (informational, shows `collectOnDeliveryMethod`). Tab badge sums both counts.
- **Types**: synced `generated.d.ts` from the api epic branch (`PaymentProvider.Manual` replaces `Cash`, `allowedPaymentMethods`, `collectOnDeliveryMethod`, `RecordPaymentData`) and regenerated `data/app-enums.ts`.

## Checks

- `npm run build` — ✓ passes (includes typecheck)
- `npm run lint` — ✓ clean
- `npx tsc --noEmit` — ✓ clean
- `npx prettier --check .` — ✓ clean on all files this PR touches (21 pre-existing unrelated warnings elsewhere in the repo, untouched by this PR)

## Missing i18n keys (translations are served from the API — cannot add here)

All under existing registered namespaces. `en` / `es` / `fr` suggested copy:

**`payments` namespace:**
| Key | en | es | fr |
|---|---|---|---|
| `sinpe_mobile` | SINPE Móvil | SINPE Móvil | SINPE Mobile |
| `proof` | Proof | Comprobante | Justificatif |
| `record.button` | Record Payment | Registrar pago | Enregistrer le paiement |
| `record.title` | Record Manual Payment | Registrar pago manual | Enregistrer un paiement manuel |
| `record.description` | Record a cash or SINPE Móvil payment collected for this order. | Registra un pago en efectivo o SINPE Móvil recibido para este pedido. | Enregistrez un paiement en espèces ou SINPE Móvil reçu pour cette commande. |
| `record.method_placeholder` | Select a method | Selecciona un método | Sélectionnez une méthode |
| `record.proof_label` | Proof of payment (optional) | Comprobante de pago (opcional) | Justificatif de paiement (facultatif) |
| `record.submit` | Record Payment | Registrar pago | Enregistrer le paiement |
| `void.button` | Void | Anular | Annuler |
| `void.confirm_title` | Void this payment? | ¿Anular este pago? | Annuler ce paiement ? |
| `void.confirm_description` | This will reverse the manual payment and mark the order as unpaid again. This cannot be undone. | Esto revertirá el pago manual y marcará el pedido como no pagado nuevamente. Esta acción no se puede deshacer. | Cela annulera le paiement manuel et marquera à nouveau la commande comme impayée. Cette action est irréversible. |
| `entitlements.always_enabled` | Always enabled | Siempre habilitado | Toujours activé |

**`orders` namespace (`needs_attention.*`):**
| Key | en | es | fr |
|---|---|---|---|
| `awaiting_prepayment_heading` | Awaiting Prepayment | Esperando prepago | En attente de prépaiement |
| `collect_on_delivery_heading` | Collect on Delivery — In Progress | Cobro contra entrega — En curso | Paiement à la livraison — En cours |
| `no_collect_on_delivery` | No orders currently collecting payment on delivery | No hay pedidos cobrando pago contra entrega actualmente | Aucune commande n'encaisse actuellement de paiement à la livraison |
| `collect_method_label` | Collecting via {{method}} | Cobrando vía {{method}} | Encaissement via {{method}} |

**`validation.attributes` namespace:**
| Key | en | es | fr |
|---|---|---|---|
| `allowedPaymentMethods` | allowed payment methods | métodos de pago permitidos | moyens de paiement autorisés |
| `method` | method | método | méthode |
| `reference` | reference | referencia | référence |
| `proof` | proof | comprobante | justificatif |

## Docs checked

- `README.md` — not affected, purely generic tech-stack/getting-started doc.
- `docs/architecture.md` — not affected; its one payment mention is a generic type-reference list (`App.Enums.PaymentStatus`), not payment-flow behavior.
- `docs/strict-rules.md`, `docs/pricing-rules-plan.md`, `CLAUDE.md` — not affected, general workflow/pricing docs unrelated to this feature.

## Test plan

- [ ] Grant/revoke Cash and SINPE Móvil on a user, confirm round-trip
- [ ] Grant/revoke Cash and SINPE Móvil on a business, confirm round-trip
- [ ] Record a cash payment on an unpaid order, confirm order flips to PAID and query invalidation refreshes both order and payments views
- [ ] Record a SINPE payment with reference + proof image, confirm both render on the PaymentCard
- [ ] Void a manual Succeeded payment, confirm order reverts to UNPAID
- [ ] Confirm Sin Pagar tab splits correctly and badge count is the sum of both sections