### PR TITLE
feat(payments): refund method + evidence UI

### DIFF
--- a/components/orders/ApproveRefundRequestDialog.tsx
+++ b/components/orders/ApproveRefundRequestDialog.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Check, Loader2 } from 'lucide-react';
+import { useApproveRefundRequest } from '@/hooks/refundRequests';
+import { useOrderPayments } from '@/hooks/payments';
+import {
+  RefundMethodFields,
+  getDefaultRefundMethod,
+} from '@/components/payments/RefundMethodFields';
+import { actionLabel } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+interface ApproveRefundRequestDialogProps {
+  publicId: string;
+  orderPublicId: string;
+}
+
+export function ApproveRefundRequestDialog({
+  publicId,
+  orderPublicId,
+}: ApproveRefundRequestDialogProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const approveMutation = useApproveRefundRequest();
+  const { data: payments, isLoading: paymentsLoading } = useOrderPayments({
+    orderPublicId,
+    enabled: open,
+  });
+
+  // Mirror the server's target-payment resolution (order's most recently
+  // created succeeded payment) so the method defaults/locking shown here
+  // matches what the API will actually validate against.
+  const settledPayment = payments
+    ?.filter((p) => p.status === Enums.TransactionStatus.Succeeded)
+    .sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))[0];
+  const isManual = settledPayment?.provider === Enums.PaymentProvider.Manual;
+
+  // The method the admin hasn't explicitly overridden — recomputed from the
+  // loaded payment each render rather than synced via an effect.
+  const defaultMethod = getDefaultRefundMethod(isManual, settledPayment?.method);
+
+  const [formData, setFormData] = useState({
+    method: null as string | null,
+    reference: '',
+  });
+  const [proof, setProof] = useState<File | null>(null);
+  const [signature, setSignature] = useState<File | null>(null);
+
+  const method = formData.method ?? defaultMethod;
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setFormData({ method: null, reference: '' });
+      setProof(null);
+      setSignature(null);
+    }
+    setOpen(isOpen);
+  };
+
+  const handleConfirm = () => {
+    approveMutation.mutate(
+      {
+        publicId,
+        data: {
+          method,
+          reference: formData.reference || null,
+          proof,
+          signature,
+        },
+      },
+      {
+        onSuccess: () => {
+          setOpen(false);
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Check className="mr-1 h-4 w-4" />
+          {actionLabel('approve')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {actionLabel('approve')}{' '}
+            {t('models:refund_request', { count: 1, defaultValue: 'Refund Request' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('payments:refund.description', {
+              defaultValue: 'Enter the amount to refund. This cannot be undone.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <RefundMethodFields
+            isManual={isManual}
+            method={method}
+            onMethodChange={(value) => setFormData((prev) => ({ ...prev, method: value }))}
+            reference={formData.reference}
+            onReferenceChange={(value) => setFormData((prev) => ({ ...prev, reference: value }))}
+            onProofChange={setProof}
+            onSignatureChange={setSignature}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button onClick={handleConfirm} disabled={approveMutation.isPending || paymentsLoading}>
+            {(approveMutation.isPending || paymentsLoading) && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            {actionLabel('approve')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/orders/ApproveRefundRequestDialog.tsx
+++ b/components/orders/ApproveRefundRequestDialog.tsx
@@ -103,8 +103,8 @@ export function ApproveRefundRequestDialog({
             {t('models:refund_request', { count: 1, defaultValue: 'Refund Request' })}
           </DialogTitle>
           <DialogDescription>
-            {t('payments:refund.description', {
-              defaultValue: 'Enter the amount to refund. This cannot be undone.',
+            {t('payments:refund_request.approve_description', {
+              defaultValue: 'Choose how the refund will be settled. This cannot be undone.',
             })}
           </DialogDescription>
         </DialogHeader>

--- a/components/orders/RefundRequestCard.tsx
+++ b/components/orders/RefundRequestCard.tsx
@@ -5,14 +5,14 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { DenyRefundRequestDialog } from './DenyRefundRequestDialog';
-import { useApproveRefundRequest } from '@/hooks/refundRequests';
+import { ApproveRefundRequestDialog } from './ApproveRefundRequestDialog';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { PaymentStatusBadge } from './PaymentStatusBadge';
 import { getDateLocale } from '@/utils/format';
 import { actionLabel } from '@/utils/lang';
 import { formatCurrency } from '@/utils/format';
 import { useCurrencyList } from '@/hooks/currencies/useCurrencyList';
-import { Eye, Clock, Check, Building2 } from 'lucide-react';
+import { Eye, Clock, Building2 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
 type RefundRequestData = App.Data.RefundRequest.RefundRequestData;
@@ -24,7 +24,6 @@ interface RefundRequestCardProps {
 export function RefundRequestCard({ refundRequest }: RefundRequestCardProps) {
   const { t, i18n } = useTranslation('orders');
   const router = useLocalizedRouter();
-  const approveMutation = useApproveRefundRequest();
 
   const order = refundRequest.order;
   const user = refundRequest.user;
@@ -87,19 +86,10 @@ export function RefundRequestCard({ refundRequest }: RefundRequestCardProps) {
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              if (refundRequest.publicId) {
-                approveMutation.mutate(refundRequest.publicId as string);
-              }
-            }}
-            disabled={approveMutation.isPending}
-          >
-            <Check className="mr-1 h-4 w-4" />
-            {actionLabel('approve')}
-          </Button>
+          <ApproveRefundRequestDialog
+            publicId={refundRequest.publicId as string}
+            orderPublicId={orderPublicId}
+          />
 
           <DenyRefundRequestDialog publicId={refundRequest.publicId as string} />
 

--- a/components/payments/PaymentSection.tsx
+++ b/components/payments/PaymentSection.tsx
@@ -11,6 +11,7 @@ import { useOrderCurrencySymbol } from '@/hooks/currencies';
 import { RefundDialog } from './RefundDialog';
 import { RecordPaymentDialog } from './RecordPaymentDialog';
 import { VoidPaymentDialog } from './VoidPaymentDialog';
+import { getRefundMethodLabel } from './RefundMethodFields';
 import { formatDate, formatCurrency } from '@/utils/format';
 import { capitalize, statusLabel, validationAttribute } from '@/utils/lang';
 import { Enums } from '@/data/app-enums';
@@ -66,26 +67,67 @@ export function getPaymentMethodLabel(
   }
 }
 
+function EvidenceLinkButton({ href, label }: { href: string; label: string }) {
+  return (
+    <Button variant="outline" size="sm" asChild>
+      <a href={href} target="_blank" rel="noopener noreferrer">
+        <ExternalLink className="mr-2 h-4 w-4" />
+        {label}
+      </a>
+    </Button>
+  );
+}
+
 function RefundCard({ refund }: { refund: RefundData }) {
+  const { t } = useTranslation();
   const currencySymbol = useOrderCurrencySymbol(refund.currencyCode);
 
   return (
-    <div className="bg-destructive/5 flex items-center justify-between rounded-md border border-red-200 px-3 py-2">
-      <div className="space-y-0.5">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-xs">{refund.publicId}</span>
-          <Badge variant="outline">{statusLabel('refunded')}</Badge>
+    <div className="bg-destructive/5 space-y-2 rounded-md border border-red-200 px-3 py-2">
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-xs">{refund.publicId}</span>
+            <Badge variant="outline">{statusLabel('refunded')}</Badge>
+            {refund.method && (
+              <Badge variant="outline">{getRefundMethodLabel(t, refund.method)}</Badge>
+            )}
+          </div>
+          {refund.reason && <p className="text-muted-foreground text-xs">{refund.reason}</p>}
+          {refund.reference && (
+            <p className="text-muted-foreground text-xs">
+              {validationAttribute('reference', true)}: {refund.reference}
+            </p>
+          )}
         </div>
-        {refund.reason && <p className="text-muted-foreground text-xs">{refund.reason}</p>}
+        <div className="text-right">
+          <p className="text-destructive text-sm font-semibold">
+            -{formatCurrency(refund.amount || 0, currencySymbol)}
+          </p>
+          {refund.refundedAt && (
+            <p className="text-muted-foreground text-xs">{formatDate(refund.refundedAt)}</p>
+          )}
+        </div>
       </div>
-      <div className="text-right">
-        <p className="text-destructive text-sm font-semibold">
-          -{formatCurrency(refund.amount || 0, currencySymbol)}
-        </p>
-        {refund.refundedAt && (
-          <p className="text-muted-foreground text-xs">{formatDate(refund.refundedAt)}</p>
-        )}
-      </div>
+
+      {(refund.proofUrl || refund.signatureUrl) && (
+        <div className="flex gap-2">
+          {refund.proofUrl && (
+            <EvidenceLinkButton
+              href={refund.proofUrl}
+              label={t('payments:proof', { defaultValue: 'Proof' })}
+            />
+          )}
+          {refund.signatureUrl && (
+            <EvidenceLinkButton
+              href={refund.signatureUrl}
+              label={t('payments:refund.signature_label', {
+                defaultValue: 'Signed handover slip',
+              })}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -171,20 +213,16 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
         </div>
         <div className="flex gap-2">
           {payment.proofUrl && (
-            <Button variant="outline" size="sm" asChild>
-              <a href={payment.proofUrl} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="mr-2 h-4 w-4" />
-                {t('payments:proof', { defaultValue: 'Proof' })}
-              </a>
-            </Button>
+            <EvidenceLinkButton
+              href={payment.proofUrl}
+              label={t('payments:proof', { defaultValue: 'Proof' })}
+            />
           )}
           {payment.receiptUrl && (
-            <Button variant="outline" size="sm" asChild>
-              <a href={payment.receiptUrl} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="mr-2 h-4 w-4" />
-                {t('payments:receipt', { defaultValue: 'Receipt' })}
-              </a>
-            </Button>
+            <EvidenceLinkButton
+              href={payment.receiptUrl}
+              label={t('payments:receipt', { defaultValue: 'Receipt' })}
+            />
           )}
           {canRefund && <RefundDialog payment={payment} />}
           {canVoid && payment.publicId && <VoidPaymentDialog paymentPublicId={payment.publicId} />}

--- a/components/payments/RefundDialog.tsx
+++ b/components/payments/RefundDialog.tsx
@@ -21,6 +21,8 @@ import { useProcessRefund } from '@/hooks/payments';
 import { useOrderCurrencySymbol } from '@/hooks/currencies';
 import { actionLabel, validationAttribute } from '@/utils/lang';
 import { formatCurrency } from '@/utils/format';
+import { Enums } from '@/data/app-enums';
+import { RefundMethodFields, getDefaultRefundMethod } from './RefundMethodFields';
 
 type PaymentData = App.Data.Payment.PaymentData;
 
@@ -36,18 +38,27 @@ export function RefundDialog({ payment, onSuccess }: RefundDialogProps) {
   const processRefund = useProcessRefund();
 
   const maxAmount = (payment.amount || 0) - (payment.totalRefunded || 0);
+  const isManual = payment.provider === Enums.PaymentProvider.Manual;
 
   const [formData, setFormData] = useState({
     amount: '',
     reason: '',
+    method: Enums.RefundMethod.Gateway as string,
+    reference: '',
   });
+  const [proof, setProof] = useState<File | null>(null);
+  const [signature, setSignature] = useState<File | null>(null);
 
   const handleOpenChange = (isOpen: boolean) => {
     if (isOpen) {
       setFormData({
         amount: maxAmount.toString(),
         reason: '',
+        method: getDefaultRefundMethod(isManual, payment.method),
+        reference: '',
       });
+      setProof(null);
+      setSignature(null);
     }
     setOpen(isOpen);
   };
@@ -75,7 +86,11 @@ export function RefundDialog({ payment, onSuccess }: RefundDialogProps) {
         paymentPublicId: payment.publicId,
         data: {
           amount,
+          method: formData.method,
           reason: formData.reason || null,
+          reference: formData.reference || null,
+          proof,
+          signature,
         },
       },
       {
@@ -156,6 +171,17 @@ export function RefundDialog({ payment, onSuccess }: RefundDialogProps) {
               </p>
             )}
           </div>
+
+          {/* Refund Method + Evidence */}
+          <RefundMethodFields
+            isManual={isManual}
+            method={formData.method}
+            onMethodChange={(value) => handleChange('method', value)}
+            reference={formData.reference}
+            onReferenceChange={(value) => handleChange('reference', value)}
+            onProofChange={setProof}
+            onSignatureChange={setSignature}
+          />
 
           {/* Reason Input */}
           <div className="grid gap-2">

--- a/components/payments/RefundMethodFields.tsx
+++ b/components/payments/RefundMethodFields.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { validationAttribute } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+const MANUAL_METHOD_OPTIONS = [
+  Enums.RefundMethod.SinpeTransfer,
+  Enums.RefundMethod.Cash,
+  Enums.RefundMethod.Credit,
+];
+
+/** Accepted evidence image types for the proof / signed-slip uploads. */
+export const REFUND_EVIDENCE_ACCEPT = 'image/jpeg,image/png,image/webp';
+
+/** Translated label for a RefundMethod value (how the refund was settled). */
+export function getRefundMethodLabel(t: TFunction, method?: string | null): string {
+  if (!method) return t('payments:unknown_method', { defaultValue: 'Unknown' });
+  return t(`payments:refund_method.${method}`, { defaultValue: method });
+}
+
+/**
+ * Sensible default refund method for a manually-settled payment: mirror the
+ * channel the customer originally paid through, falling back to cash.
+ */
+export function getDefaultManualRefundMethod(paymentMethod?: string | null): string {
+  if (paymentMethod === Enums.PaymentMethodType.SinpeMobile) {
+    return Enums.RefundMethod.SinpeTransfer;
+  }
+  return Enums.RefundMethod.Cash;
+}
+
+/**
+ * Default refund method for a payment: the manual channel matching how the
+ * customer paid, or Gateway for gateway-settled payments (the only method
+ * the server accepts for those).
+ */
+export function getDefaultRefundMethod(isManual: boolean, paymentMethod?: string | null): string {
+  return isManual ? getDefaultManualRefundMethod(paymentMethod) : Enums.RefundMethod.Gateway;
+}
+
+interface RefundMethodFieldsProps {
+  /** Whether the underlying payment was settled manually (provider === Manual). */
+  isManual: boolean;
+  method: string;
+  onMethodChange: (method: string) => void;
+  reference: string;
+  onReferenceChange: (value: string) => void;
+  onProofChange: (file: File | null) => void;
+  onSignatureChange: (file: File | null) => void;
+}
+
+/**
+ * RefundMethod select + evidence fields, shared by RefundDialog (processing a
+ * payment refund) and ApproveRefundRequestDialog (approving a refund
+ * request). Gateway payments can only be reversed through the gateway, so
+ * the select locks to Gateway and evidence fields are hidden; manually
+ * settled payments pick among SINPE transfer / cash / credit and can attach
+ * a reference plus proof/signature evidence.
+ */
+export function RefundMethodFields({
+  isManual,
+  method,
+  onMethodChange,
+  reference,
+  onReferenceChange,
+  onProofChange,
+  onSignatureChange,
+}: RefundMethodFieldsProps) {
+  const { t } = useTranslation();
+  const options = isManual ? MANUAL_METHOD_OPTIONS : [Enums.RefundMethod.Gateway];
+
+  return (
+    <>
+      <div className="grid gap-2">
+        <Label htmlFor="refund-method">
+          {t('payments:refund.method_label', { defaultValue: 'Refund method' })} *
+        </Label>
+        <Select value={method} onValueChange={onMethodChange} disabled={!isManual}>
+          <SelectTrigger id="refund-method" className="w-full">
+            <SelectValue
+              placeholder={t('payments:refund.method_placeholder', {
+                defaultValue: 'How was this refunded?',
+              })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option} value={option}>
+                {getRefundMethodLabel(t, option)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isManual && (
+        <>
+          <div className="grid gap-2">
+            <Label htmlFor="refund-reference">{validationAttribute('reference', true)}</Label>
+            <Input
+              id="refund-reference"
+              placeholder={t('payments:refund.reference_placeholder', {
+                defaultValue: 'Transfer or SINPE reference (optional)',
+              })}
+              value={reference}
+              onChange={(e) => onReferenceChange(e.target.value)}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="refund-proof">
+              {t('payments:refund.proof_label', { defaultValue: 'Proof of refund' })}
+            </Label>
+            <Input
+              id="refund-proof"
+              type="file"
+              accept={REFUND_EVIDENCE_ACCEPT}
+              onChange={(e) => onProofChange(e.target.files?.[0] ?? null)}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="refund-signature">
+              {t('payments:refund.signature_label', { defaultValue: 'Signed handover slip' })}
+            </Label>
+            <Input
+              id="refund-signature"
+              type="file"
+              accept={REFUND_EVIDENCE_ACCEPT}
+              onChange={(e) => onSignatureChange(e.target.files?.[0] ?? null)}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -328,6 +328,12 @@ export const Enums = {
     Standard: "standard",
     Reconciliation: "reconciliation",
   },
+  RefundMethod: {
+    Gateway: "gateway",
+    SinpeTransfer: "sinpe_transfer",
+    Cash: "cash",
+    Credit: "credit",
+  },
   RefundRequestStatus: {
     Pending: "pending",
     Approved: "approved",

--- a/hooks/payments/useProcessRefund.ts
+++ b/hooks/payments/useProcessRefund.ts
@@ -1,21 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { PaymentService } from '@/services/paymentService';
+import { PaymentService, type RefundParams } from '@/services/paymentService';
 import { toast } from 'sonner';
 import { isApiError } from '@/lib/api/error';
 import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
 
-type StoreRefundData = App.Data.Payment.StoreRefundData;
-
-interface RefundParams {
+interface RefundArgs {
   paymentPublicId: string;
-  data: StoreRefundData;
+  data: RefundParams;
 }
 
 export function useProcessRefund() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ paymentPublicId, data }: RefundParams) =>
+    mutationFn: ({ paymentPublicId, data }: RefundArgs) =>
       PaymentService.refund(paymentPublicId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['payments'] });

--- a/hooks/refundRequests/useApproveRefundRequest.ts
+++ b/hooks/refundRequests/useApproveRefundRequest.ts
@@ -1,29 +1,29 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { RefundRequestService } from '@/services/refundRequestService';
+import {
+  RefundRequestService,
+  type ApproveRefundRequestParams,
+} from '@/services/refundRequestService';
 import { toast } from 'sonner';
-import { useTranslation } from 'react-i18next';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+
+interface ApproveRefundRequestArgs {
+  publicId: string;
+  data: ApproveRefundRequestParams;
+}
 
 export function useApproveRefundRequest() {
-  const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (publicId: string) => RefundRequestService.approve(publicId),
+    mutationFn: ({ publicId, data }: ApproveRefundRequestArgs) =>
+      RefundRequestService.approve(publicId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['refund-requests'] });
       queryClient.invalidateQueries({ queryKey: ['orders'] });
-      toast.success(
-        t('payments:refund_request.approved', { defaultValue: 'Refund request approved' })
-      );
+      toast.success(crudSuccessMessage('approved', 'refund_request'));
     },
     onError: () => {
-      toast.error(
-        t('resource:error.updating', {
-          count: 1,
-          resource: t('models:refund_request', { count: 1 }),
-          defaultValue: 'Failed to approve refund request',
-        })
-      );
+      toast.error(crudErrorMessage('approving', 'refund_request'));
     },
   });
 }

--- a/services/paymentService.ts
+++ b/services/paymentService.ts
@@ -1,8 +1,8 @@
 import { api } from '@/lib/api/client';
+import { appendRefundEvidence, type RefundEvidenceParams } from './refundEvidence';
 
 type PaymentData = App.Data.Payment.PaymentData;
 type RefundData = App.Data.Payment.RefundData;
-type StoreRefundData = App.Data.Payment.StoreRefundData;
 type Single<T> = Api.Response.Single<T>;
 type Paginated<T> = Api.Response.Paginated<T>;
 
@@ -12,6 +12,11 @@ export interface RecordPaymentParams {
   reference?: string | null;
   notes?: string | null;
   proof?: File | null;
+}
+
+export interface RefundParams extends RefundEvidenceParams {
+  amount: number;
+  reason?: string | null;
 }
 
 interface ListParams {
@@ -57,12 +62,18 @@ export const PaymentService = {
   },
 
   /**
-   * Process a refund for a payment (admin only)
+   * Process a refund for a payment (admin only). Multipart because of the
+   * optional proof / signed-handover-slip evidence images.
    */
-  async refund(paymentPublicId: string, data: StoreRefundData): Promise<RefundData> {
-    const response = await api.post<Single<RefundData>>(
+  async refund(paymentPublicId: string, data: RefundParams): Promise<RefundData> {
+    const formData = new FormData();
+    formData.append('amount', String(data.amount));
+    appendRefundEvidence(formData, data);
+    if (data.reason) formData.append('reason', data.reason);
+
+    const response = await api.postMultipart<Single<RefundData>>(
       `/payments/${paymentPublicId}/refund`,
-      data
+      formData
     );
     return response.item;
   },

--- a/services/refundEvidence.ts
+++ b/services/refundEvidence.ts
@@ -1,0 +1,17 @@
+export interface RefundEvidenceParams {
+  method: string;
+  reference?: string | null;
+  proof?: File | null;
+  signature?: File | null;
+}
+
+/**
+ * Append the refund-evidence fields shared by "process a refund" and
+ * "approve a refund request" to a multipart form body.
+ */
+export function appendRefundEvidence(formData: FormData, data: RefundEvidenceParams): void {
+  formData.append('method', data.method);
+  if (data.reference) formData.append('reference', data.reference);
+  if (data.proof) formData.append('proof', data.proof);
+  if (data.signature) formData.append('signature', data.signature);
+}

--- a/services/refundRequestService.ts
+++ b/services/refundRequestService.ts
@@ -1,16 +1,32 @@
 import { api } from '@/lib/api/client';
+import { appendRefundEvidence, type RefundEvidenceParams } from './refundEvidence';
 
 type RefundRequestData = App.Data.RefundRequest.RefundRequestData;
 type Single<T> = Api.Response.Single<T>;
 type Multiple<T> = Api.Response.Multiple<T>;
+
+export type ApproveRefundRequestParams = RefundEvidenceParams;
 
 export const RefundRequestService = {
   async list(): Promise<Multiple<RefundRequestData>> {
     return api.get<Multiple<RefundRequestData>>('/refund-requests');
   },
 
-  async approve(publicId: string): Promise<Single<RefundRequestData>> {
-    return api.post<Single<RefundRequestData>>(`/refund-requests/${publicId}/approve`);
+  /**
+   * Approve a refund request (admin only). Multipart because of the
+   * optional proof / signed-handover-slip evidence images.
+   */
+  async approve(
+    publicId: string,
+    data: ApproveRefundRequestParams
+  ): Promise<Single<RefundRequestData>> {
+    const formData = new FormData();
+    appendRefundEvidence(formData, data);
+
+    return api.postMultipart<Single<RefundRequestData>>(
+      `/refund-requests/${publicId}/approve`,
+      formData
+    );
   },
 
   async deny(publicId: string, adminNotes?: string | null): Promise<Single<RefundRequestData>> {

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -697,6 +697,10 @@ declare namespace App.Data.Payment {
     orderId?: number | null;
     amount?: number;
     currencyCode?: string;
+    method?: App.Enums.RefundMethod;
+    reference?: string | null;
+    proofUrl?: string | null;
+    signatureUrl?: string | null;
     reason?: string | null;
     refundedAt?: string | null;
     createdAt?: string;
@@ -704,7 +708,11 @@ declare namespace App.Data.Payment {
   };
   export type StoreRefundData = {
     amount: number;
+    method: App.Enums.RefundMethod;
     reason: string | null;
+    reference: string | null;
+    proof: any | null;
+    signature: any | null;
   };
 }
 declare namespace App.Data.Pricing {
@@ -847,6 +855,12 @@ declare namespace App.Data.Quote {
   };
 }
 declare namespace App.Data.RefundRequest {
+  export type ApproveRefundRequestData = {
+    method: App.Enums.RefundMethod;
+    reference: string | null;
+    proof: any | null;
+    signature: any | null;
+  };
   export type RefundRequestData = {
     id?: number;
     publicId?: string;
@@ -1453,6 +1467,12 @@ declare namespace App.Enums {
   export enum QuoteType {
     Standard = 'standard',
     Reconciliation = 'reconciliation',
+  }
+  export enum RefundMethod {
+    Gateway = 'gateway',
+    SinpeTransfer = 'sinpe_transfer',
+    Cash = 'cash',
+    Credit = 'credit',
   }
   export enum RefundRequestStatus {
     Pending = 'pending',


### PR DESCRIPTION
## Summary
- Adds a RefundMethod select (gateway/sinpe_transfer/cash/credit) plus reference and proof/signed-slip evidence uploads to `RefundDialog`, wired through `PaymentService.refund()` (now multipart).
- Adds `ApproveRefundRequestDialog` with the same method + evidence fields, replacing the old one-click Approve button on `RefundRequestCard`; resolves the order's target payment the same way the server does (latest succeeded payment) to decide whether to lock to Gateway or offer manual channels.
- `RefundCard` (in `PaymentSection`) now shows the refund method badge, reference, and proof/signature links.
- Extracts shared `RefundMethodFields` (UI) and `appendRefundEvidence` (multipart body builder) used by both flows.
- Syncs `types/generated.d.ts` / `data/app-enums.ts` for the `RefundMethod` enum and the new `RefundData`/`StoreRefundData`/`ApproveRefundRequestData` fields landed in api#59.

## Missing i18n keys (reported per plan; not hardcoded — used with `defaultValue` in the meantime)
- `payments:refund_request.approve_description` — no existing key describes the refund-request approval dialog (the closest, `payments:refund.description`, mentions an amount input this dialog doesn't have).

## Docs checked (see hand-back for full verdicts)
- `README.md`, `CLAUDE.md`, `docs/strict-rules.md`, `docs/architecture.md`, `docs/pricing-rules-plan.md`, `docs/plans/notifications.md` — none describe the refund/payment UI flow; no updates needed.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] Manual QA: process a refund on a gateway payment (method locked to Gateway, no evidence fields) and on a manual payment (method defaults to the paid channel, evidence fields shown); approve a refund request with evidence attached.