### PR TITLE
feat(dispatch): gate admin-only UI from the dispatch role

### DIFF
--- a/app/[lang]/(dashboard)/audit-logs/layout.tsx
+++ b/app/[lang]/(dashboard)/audit-logs/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function AuditLogsLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -26,6 +26,7 @@ import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useDriver, useDeleteDriver, useUpdateDriver } from '@/hooks/drivers';
+import { useRole } from '@/hooks/auth';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -62,6 +63,7 @@ export default function DriverDetailPage() {
   const params = useParams();
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
+  const { isAdmin } = useRole();
   const driverId = params.id as string;
 
   const { data: driver, isLoading, error } = useDriver(driverId);
@@ -168,21 +170,31 @@ export default function DriverDetailPage() {
         </div>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <Switch
-              checked={driver.active !== false}
-              onCheckedChange={(checked) =>
-                updateDriver.mutate({ id: driverId, data: { active: checked } })
-              }
-              disabled={updateDriver.isPending}
-            />
-            <Label className="text-sm font-medium">
-              {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
-            </Label>
+            {isAdmin ? (
+              <>
+                <Switch
+                  checked={driver.active !== false}
+                  onCheckedChange={(checked) =>
+                    updateDriver.mutate({ id: driverId, data: { active: checked } })
+                  }
+                  disabled={updateDriver.isPending}
+                />
+                <Label className="text-sm font-medium">
+                  {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
+                </Label>
+              </>
+            ) : (
+              <Badge variant={driver.active !== false ? 'default' : 'secondary'}>
+                {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
+              </Badge>
+            )}
           </div>
-          <Button variant="destructive" onClick={handleDelete} disabled={deleteDriver.isPending}>
-            <Trash2 className="mr-2 h-4 w-4" />
-            {actionLabel('delete')}
-          </Button>
+          {isAdmin && (
+            <Button variant="destructive" onClick={handleDelete} disabled={deleteDriver.isPending}>
+              <Trash2 className="mr-2 h-4 w-4" />
+              {actionLabel('delete')}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -289,54 +301,66 @@ export default function DriverDetailPage() {
                   <Label className="text-muted-foreground text-sm">
                     {t('drivers:default_vehicle_type', { defaultValue: 'Default Vehicle' })}
                   </Label>
-                  <Select
-                    value={driver.defaultVehicleType}
-                    onValueChange={(value) =>
-                      updateDriver.mutate({
-                        id: driverId,
-                        data: { defaultVehicleType: value as App.Enums.VehicleType },
-                      })
-                    }
-                    disabled={updateDriver.isPending}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.values(Enums.VehicleType).map((vt) => (
-                        <SelectItem key={vt} value={vt}>
-                          {capitalize(vehicleTypeLabel(vt))}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {isAdmin ? (
+                    <Select
+                      value={driver.defaultVehicleType}
+                      onValueChange={(value) =>
+                        updateDriver.mutate({
+                          id: driverId,
+                          data: { defaultVehicleType: value as App.Enums.VehicleType },
+                        })
+                      }
+                      disabled={updateDriver.isPending}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.values(Enums.VehicleType).map((vt) => (
+                          <SelectItem key={vt} value={vt}>
+                            {capitalize(vehicleTypeLabel(vt))}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <span className="font-medium">
+                      {capitalize(vehicleTypeLabel(driver.defaultVehicleType))}
+                    </span>
+                  )}
                 </div>
 
                 <div className="grid gap-2">
                   <Label className="text-muted-foreground text-sm">
                     {t('drivers:dispatch_policy', { defaultValue: 'Dispatch Policy' })}
                   </Label>
-                  <Select
-                    value={driver.dispatchPolicy}
-                    onValueChange={(value) =>
-                      updateDriver.mutate({
-                        id: driverId,
-                        data: { dispatchPolicy: value as App.Enums.DispatchPolicy },
-                      })
-                    }
-                    disabled={updateDriver.isPending}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.values(Enums.DispatchPolicy).map((policy) => (
-                        <SelectItem key={policy} value={policy}>
-                          {capitalize(dispatchPolicyLabel(policy))}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {isAdmin ? (
+                    <Select
+                      value={driver.dispatchPolicy}
+                      onValueChange={(value) =>
+                        updateDriver.mutate({
+                          id: driverId,
+                          data: { dispatchPolicy: value as App.Enums.DispatchPolicy },
+                        })
+                      }
+                      disabled={updateDriver.isPending}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.values(Enums.DispatchPolicy).map((policy) => (
+                          <SelectItem key={policy} value={policy}>
+                            {capitalize(dispatchPolicyLabel(policy))}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <span className="font-medium">
+                      {capitalize(dispatchPolicyLabel(driver.dispatchPolicy))}
+                    </span>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -384,10 +408,12 @@ export default function DriverDetailPage() {
                       })}
                     </p>
                   )}
-                  <Button variant="outline" size="sm" onClick={() => setMapOpen(true)}>
-                    <Pencil className="mr-2 h-3.5 w-3.5" />
-                    {baseCenter ? actionLabel('edit') : actionLabel('set')}
-                  </Button>
+                  {isAdmin && (
+                    <Button variant="outline" size="sm" onClick={() => setMapOpen(true)}>
+                      <Pencil className="mr-2 h-3.5 w-3.5" />
+                      {baseCenter ? actionLabel('edit') : actionLabel('set')}
+                    </Button>
+                  )}
 
                   <Dialog open={mapOpen} onOpenChange={setMapOpen}>
                     <DialogContent className="sm:max-w-3xl">
@@ -424,7 +450,7 @@ export default function DriverDetailPage() {
 
         {!isOutsourced && (
           <TabsContent value="schedule">
-            <DriverScheduleTab driverId={driverId} />
+            <DriverScheduleTab driverId={driverId} readOnly={!isAdmin} />
           </TabsContent>
         )}
       </Tabs>

--- a/app/[lang]/(dashboard)/drivers/create/layout.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function DriverCreateLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useDriverList } from '@/hooks/drivers';
+import { useRole } from '@/hooks/auth';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
@@ -44,6 +45,7 @@ function getInitials(name?: string): string {
 export default function DriversPage() {
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
+  const { isAdmin } = useRole();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
 
@@ -69,10 +71,12 @@ export default function DriversPage() {
             {t('drivers:manage_description', { defaultValue: 'Manage driver accounts' })}
           </p>
         </div>
-        <Button onClick={() => router.push('/drivers/create')}>
-          <Plus className="mr-2 h-4 w-4" />
-          {resourceMessage('create_one', 'driver')}
-        </Button>
+        {isAdmin && (
+          <Button onClick={() => router.push('/drivers/create')}>
+            <Plus className="mr-2 h-4 w-4" />
+            {resourceMessage('create_one', 'driver')}
+          </Button>
+        )}
       </div>
 
       <Card>

--- a/app/[lang]/(dashboard)/pricing/layout.tsx
+++ b/app/[lang]/(dashboard)/pricing/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/settings/layout.tsx
+++ b/app/[lang]/(dashboard)/settings/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useUser, useDeleteUser, useUpdateUser } from '@/hooks/users';
+import { useRole } from '@/hooks/auth';
 import { RoleBadge } from '@/components/users/RoleBadge';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
@@ -45,6 +46,7 @@ export default function UserDetailPage() {
   const params = useParams();
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
+  const { isAdmin } = useRole();
   const userId = params.id as string;
 
   const { data: user, isLoading, error } = useUser(userId);
@@ -114,10 +116,12 @@ export default function UserDetailPage() {
             </p>
           </div>
         </div>
-        <Button variant="destructive" onClick={handleDelete} disabled={deleteUser.isPending}>
-          <Trash2 className="mr-2 h-4 w-4" />
-          {actionLabel('delete')}
-        </Button>
+        {isAdmin && (
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteUser.isPending}>
+            <Trash2 className="mr-2 h-4 w-4" />
+            {actionLabel('delete')}
+          </Button>
+        )}
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">

--- a/components/auth/RequireAdmin.tsx
+++ b/components/auth/RequireAdmin.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useRole } from '@/hooks/auth';
+
+interface RequireAdminProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Gates an admin-only route segment (settings, pricing, audit logs, driver
+ * creation) from the `dispatch` staff role. Mirrors the API's authorization
+ * split so a dispatch user never lands on a page whose requests the API
+ * would 403 — once the auth store has hydrated, a non-admin user is bounced
+ * to the dashboard.
+ */
+export function RequireAdmin({ children }: RequireAdminProps) {
+  const router = useLocalizedRouter();
+  const hydrated = useAuthStore((state) => state.hydrated);
+  const user = useAuthStore((state) => state.user);
+  const { isAdmin } = useRole();
+
+  const blocked = hydrated && !!user && !isAdmin;
+
+  useEffect(() => {
+    if (blocked) {
+      router.replace('/');
+    }
+  }, [blocked, router]);
+
+  if (!hydrated || blocked) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/components/drivers/DriverScheduleTab.tsx
+++ b/components/drivers/DriverScheduleTab.tsx
@@ -43,9 +43,11 @@ function formatTimeHHMM(date: Date): string {
 
 interface Props {
   driverId: string;
+  /** When true, renders the calendar as view-only — no create/edit/delete/save. */
+  readOnly?: boolean;
 }
 
-export function DriverScheduleTab({ driverId }: Props) {
+export function DriverScheduleTab({ driverId, readOnly = false }: Props) {
   const { t, i18n } = useTranslation();
   const { data, isLoading } = useDriverSchedules(driverId);
   const syncSchedules = useSyncSchedules(driverId);
@@ -187,11 +189,13 @@ export function DriverScheduleTab({ driverId }: Props) {
               defaultValue: 'Availability Calendar',
             })}
           </CardTitle>
-          <Button onClick={handleSaveSchedules} disabled={syncSchedules.isPending} size="sm">
-            {syncSchedules.isPending
-              ? t('common:saving', { defaultValue: 'Saving...' })
-              : actionLabel('save')}
-          </Button>
+          {!readOnly && (
+            <Button onClick={handleSaveSchedules} disabled={syncSchedules.isPending} size="sm">
+              {syncSchedules.isPending
+                ? t('common:saving', { defaultValue: 'Saving...' })
+                : actionLabel('save')}
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           <FullCalendar
@@ -207,24 +211,26 @@ export function DriverScheduleTab({ driverId }: Props) {
             slotLabelFormat={{ hour: 'numeric', minute: '2-digit', hour12: true }}
             height={800}
             events={calendarEvents}
-            dateClick={handleDateClick}
-            eventClick={handleEventClick}
+            dateClick={readOnly ? undefined : handleDateClick}
+            eventClick={readOnly ? undefined : handleEventClick}
           />
         </CardContent>
       </Card>
 
-      <ScheduleEventDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        mode={dialogMode}
-        date={dialogDate}
-        startTime={dialogStartTime}
-        endTime={dialogEndTime}
-        vehicleType={dialogVehicleType}
-        isSaving={syncSchedules.isPending}
-        onSave={handleSaveEntry}
-        onDelete={handleDeleteEntry}
-      />
+      {!readOnly && (
+        <ScheduleEventDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          mode={dialogMode}
+          date={dialogDate}
+          startTime={dialogStartTime}
+          endTime={dialogEndTime}
+          vehicleType={dialogVehicleType}
+          isSaving={syncSchedules.isPending}
+          onSave={handleSaveEntry}
+          onDelete={handleDeleteEntry}
+        />
+      )}
     </div>
   );
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 import { useNeedsAttention } from '@/hooks/orders/useNeedsAttention';
 import { usePendingReconciliation } from '@/hooks/orders/usePendingReconciliation';
+import { useRole } from '@/hooks/auth';
 
 const navigation = [
   { modelKey: 'dashboard', href: '/', icon: LayoutDashboard, isModel: false },
@@ -51,9 +52,16 @@ const navigation = [
     icon: DollarSign,
     isModel: false,
     translationKey: 'pricing:title',
+    adminOnly: true,
   },
   { modelKey: 'notification', href: '/notifications', icon: Bell, isModel: true },
-  { modelKey: 'audit_log', href: '/audit-logs', icon: ScrollText, isModel: true },
+  {
+    modelKey: 'audit_log',
+    href: '/audit-logs',
+    icon: ScrollText,
+    isModel: true,
+    adminOnly: true,
+  },
   { modelKey: 'guide', href: '/guide', icon: BookOpen, isModel: false },
 ];
 
@@ -64,9 +72,12 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const lang = (params?.lang as string) || 'en';
   const { data: needsAttentionData } = useNeedsAttention();
   const { data: pendingReconciliationData } = usePendingReconciliation();
+  const { isAdmin } = useRole();
   const urgentCount =
     (needsAttentionData?.summary?.critical ?? 0) + (needsAttentionData?.summary?.high ?? 0);
   const reconciliationCount = pendingReconciliationData?.summary?.count ?? 0;
+
+  const visibleNavigation = navigation.filter((item) => !item.adminOnly || isAdmin);
 
   const withLang = (href: string) => `/${lang}${href === '/' ? '' : href}`;
   const pathWithoutLang = pathname.replace(new RegExp(`^/${lang}`), '') || '/';
@@ -96,7 +107,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 overflow-y-auto p-4">
-        {navigation.map((item) => {
+        {visibleNavigation.map((item) => {
           const isActive =
             pathWithoutLang === item.href ||
             (item.href !== '/' && pathWithoutLang.startsWith(item.href));
@@ -131,21 +142,23 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       </nav>
 
       {/* Settings at bottom */}
-      <div className="border-t p-4">
-        <Link
-          href={withLang('/settings')}
-          onClick={onNavigate}
-          className={cn(
-            'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-            pathWithoutLang === '/settings'
-              ? 'bg-primary text-primary-foreground'
-              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-          )}
-        >
-          <Settings className="h-5 w-5" />
-          {ready ? capitalize(t('common:settings', { count: 2 })) : ''}
-        </Link>
-      </div>
+      {isAdmin && (
+        <div className="border-t p-4">
+          <Link
+            href={withLang('/settings')}
+            onClick={onNavigate}
+            className={cn(
+              'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              pathWithoutLang === '/settings'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            )}
+          >
+            <Settings className="h-5 w-5" />
+            {ready ? capitalize(t('common:settings', { count: 2 })) : ''}
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/users/RoleBadge.tsx
+++ b/components/users/RoleBadge.tsx
@@ -11,6 +11,7 @@ const roleConfig: Record<
   'business.user': { label: 'Business User', variant: 'secondary' },
   client: { label: 'Client', variant: 'outline' },
   driver: { label: 'Driver', variant: 'default' },
+  dispatch: { label: 'Dispatch', variant: 'secondary' },
 };
 
 interface RoleBadgeProps {

--- a/hooks/auth/index.ts
+++ b/hooks/auth/index.ts
@@ -1,1 +1,2 @@
 export { useLoginMutation } from './useLoginMutation';
+export { useRole } from './useRole';

--- a/hooks/auth/useRole.ts
+++ b/hooks/auth/useRole.ts
@@ -1,0 +1,21 @@
+import { useAuthStore } from '@/stores/useAuthStore';
+import { Enums } from '@/data/app-enums';
+
+/**
+ * Role-derived flags for the current admin-panel user.
+ *
+ * Mirrors the API's authorization split between the two roles allowed into
+ * the admin panel: `admin` (full access) and `dispatch` (operational
+ * access only — the API 403s dispatch on settings, pricing rules,
+ * currencies/exchange-rate management, audit logs, driver mutations +
+ * schedule editing, and user create/delete/role changes). UI gating
+ * should key off `isAdmin`; `isStaff` is true for either role.
+ */
+export function useRole() {
+  const role = useAuthStore((state) => state.user?.role);
+  const isAdmin = useAuthStore((state) => state.isAdmin());
+  const isDispatch = role === Enums.Role.DISPATCH;
+  const isStaff = isAdmin || isDispatch;
+
+  return { role, isAdmin, isDispatch, isStaff };
+}


### PR DESCRIPTION
## Summary

Makes the admin panel role-aware for the new `dispatch` staff role so a
dispatch user never lands on a page or sees a control whose request the
API would 403.

- **`hooks/auth/useRole.ts`** — `isAdmin` / `isDispatch` / `isStaff` derived
  from `useAuthStore`'s user + the generated `Enums.Role`, reusing the
  store's existing `isAdmin()` selector rather than re-deriving it.
- **`components/auth/RequireAdmin.tsx`** — client guard that redirects a
  hydrated, non-admin session to `/`. Applied via new `layout.tsx` files on
  `settings/*` (covers the `currencies` and `service-window` subpages),
  `pricing/*`, `audit-logs/*`, and `drivers/create`.
- **Sidebar** — Pricing and Audit logs nav entries, and the bottom Settings
  link, are hidden for non-admins. Everything else stays visible.
- **Drivers** — list page hides "Create driver"; detail page hides delete,
  and swaps the active-status switch, vehicle-type/dispatch-policy selects,
  and base-location editor for read-only text/badges when not admin. The
  schedule tab (`DriverScheduleTab`) gained a `readOnly` prop that drops
  the calendar's create/edit click handlers and the Save button — the
  calendar view itself (a GET) stays for dispatch.
- **Users** — detail page hides the delete button for non-admins. No
  create-user button or role selector exists in the UI today, so there was
  nothing else to gate there (see note below).
- **`components/users/RoleBadge.tsx`** — fixed a pre-existing typecheck
  break: its `Record<Role, ...>` config wasn't updated when `DISPATCH` was
  added to the `Role` enum on this branch's base commit, so `npm run
  typecheck` failed before any of my changes. One-line fix, its own commit.

## How the auth/role plumbing works (for the sibling slice)

- `stores/useAuthStore.ts` persists `{ user, token }` via zustand +
  localStorage, with a `hydrated` flag flipped true after rehydration.
  `user` is `App.Data.User.UserData`, which has `role: App.Enums.Role`.
  The store already had an `isAdmin()` selector (`role === Role.ADMIN`);
  `useRole()` builds on it rather than re-deriving.
- `providers/AuthProvider.tsx` calls `Auth.refresh()` (from
  `services/authService.ts`) once hydrated+token, which re-fetches
  `/auth/token/user` and calls `store.setUser`.
- There is no existing unauthenticated-route guard anywhere in the app
  (no `middleware.ts`/`proxy.ts` auth check, no client guard) — `proxy.ts`
  only handles locale routing. `RequireAdmin` intentionally only guards
  the admin-vs-dispatch split and does not attempt to fix that unrelated,
  pre-existing gap.
- Use `useRole()` (`hooks/auth/useRole.ts`) or `RequireAdmin`
  (`components/auth/RequireAdmin.tsx`) for any other role-gated UI.

## Not touched / out of scope

- No create-user button or role selector/editor exists in the current
  Users UI, so there was nothing to hide there beyond the delete button.
- `components/layout/Header.tsx`'s "Profile" menu item still links to
  `/settings` (there's no separate profile page). For a dispatch user this
  now just bounces back to the dashboard via `RequireAdmin` — functionally
  correct, if not the smoothest UX. Flagging in case the sibling slice (or
  a follow-up) wants a dedicated profile destination.
- Left the existing `PaymentMethodsCard` editing on the user detail page
  untouched — per the brief, operational edits stay for dispatch.

## Docs checked

- `CLAUDE.md` (admin) — no nav/access/role content; not falsified, not
  updated.
- `README.md` — generic scaffold description, no role/access content; not
  falsified, not updated.
- `docs/architecture.md` — only lists "Sidebar, Header" as a directory
  comment, doesn't describe visibility rules; not falsified, not updated.
- `docs/strict-rules.md` — states "All pull requests must target
  release/0.1.0". This PR intentionally targets the `feature/dispatch-ui-epic`
  branch per explicit task instructions (epic-branch convention); not a
  doc bug, just flagging the deliberate deviation.

## Missing translation keys

None — every change hides/shows existing UI (existing `t()` calls), so no
new strings were needed.

## Gate verdict (override mode — run in worktree, no queue)

Ran locally, worktree config `gate` == `scopedCheck` == `npm run build`
(single-tier project); ran the fuller sequence requested in the brief:

- `npm run typecheck` — **PASS** (0 errors; fixed 1 pre-existing baseline
  error in `RoleBadge.tsx`, see above)
- `npm run lint` — **PASS** (0 errors/warnings; one pre-existing unrelated
  ESLintEnvWarning on `public/firebase-messaging-sw.js`)
- `npm run test -- --run` — **PASS** (10 files, 154/154 tests; baseline was
  already 154/154 green, no regressions, no new test files needed since
  none of the touched areas have existing test coverage)
- `npm run build` — **PASS** (`next build` compiles and generates all
  routes, including the new `settings/`, `pricing/`, `audit-logs/`, and
  `drivers/create` layouts)

All four green on the exact commits in this PR.