### PR TITLE
feat(dispatch): dispatcher book UI on users, businesses, and orders

### DIFF
--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -7,12 +7,14 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { useBusiness, useDeleteBusiness, useUpdateBusiness } from '@/hooks/businesses';
+import { useRole } from '@/hooks/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Building2, User, MapPin, Calendar, Trash2 } from 'lucide-react';
 import { formatDate } from '@/utils/format';
 import { useBusinessTaxProfile } from '@/hooks/tax-profiles';
 import { TaxProfileCard } from '@/components/TaxProfileCard';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
+import { DispatcherPicker } from '@/components/dispatch/DispatcherPicker';
 
 export default function BusinessDetailPage() {
   const params = useParams();
@@ -24,11 +26,19 @@ export default function BusinessDetailPage() {
   const { data: taxProfile } = useBusinessTaxProfile(businessId);
   const deleteBusiness = useDeleteBusiness();
   const updateBusiness = useUpdateBusiness();
+  const { isAdmin } = useRole();
 
   const handleChangePaymentMethods = (next: string[]) => {
     updateBusiness.mutate({
       id: businessId,
       data: { allowedPaymentMethods: next as App.Enums.PaymentMethodType[] },
+    });
+  };
+
+  const handleChangeDispatcher = (next: number | null) => {
+    updateBusiness.mutate({
+      id: businessId,
+      data: { dispatcherId: next },
     });
   };
 
@@ -181,6 +191,15 @@ export default function BusinessDetailPage() {
           onChange={handleChangePaymentMethods}
           isPending={updateBusiness.isPending}
         />
+
+        {/* Dispatcher */}
+        {isAdmin && (
+          <DispatcherPicker
+            dispatcherId={business.dispatcherId}
+            onChange={handleChangeDispatcher}
+            isPending={updateBusiness.isPending}
+          />
+        )}
 
         <Card>
           <CardHeader>

--- a/app/[lang]/(dashboard)/businesses/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/page.tsx
@@ -10,16 +10,12 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import {
-  actionLabel,
-  modelLabel,
-  resourceMessage,
-  validationAttribute,
-} from '@/utils/lang';
+import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
+import { useRole } from '@/hooks/auth';
 import { useBusinessList } from '@/hooks/businesses';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Building2 } from 'lucide-react';
@@ -28,6 +24,7 @@ import { formatDate } from '@/utils/format';
 export default function BusinessesPage() {
   const { t, ready } = useTranslation();
   const router = useRouter();
+  const { isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
 
@@ -92,7 +89,13 @@ export default function BusinessesPage() {
           ) : businesses.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
               <Building2 className="mb-4 h-12 w-12" />
-              <p>{t('businesses:no_businesses', { defaultValue: 'No businesses found' })}</p>
+              <p>
+                {isDispatch
+                  ? t('businesses:no_businesses_dispatch', {
+                      defaultValue: 'No businesses in your book yet',
+                    })
+                  : t('businesses:no_businesses', { defaultValue: 'No businesses found' })}
+              </p>
             </div>
           ) : (
             <Table>

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   ExternalLink,
   Info,
   Loader2,
+  Headset,
 } from 'lucide-react';
 
 import { useMemo, useState } from 'react';
@@ -44,6 +45,7 @@ import { EditStopAddressDialog } from '@/components/orders/EditStopAddressDialog
 import { EditStopDetailsDialog } from '@/components/orders/EditStopDetailsDialog';
 import { AddStopDialog } from '@/components/orders/AddStopDialog';
 import { ReconciliationDialog } from '@/components/orders/ReconciliationDialog';
+import { ReassignDispatcherDialog } from '@/components/dispatch/ReassignDispatcherDialog';
 import { ChatTabs } from '@/components/chat/ChatTabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -62,6 +64,8 @@ import {
   useUpdateStop,
 } from '@/hooks/orders';
 import { useCurrencyList } from '@/hooks/currencies';
+import { useDispatchUsers } from '@/hooks/users';
+import { useRole } from '@/hooks/auth';
 import { Enums } from '@/data/app-enums';
 
 type QuoteStatus = App.Enums.QuoteStatus;
@@ -74,11 +78,14 @@ export default function OrderDetailPage() {
   const router = useLocalizedRouter();
   const orderId = params.id as string;
 
+  const { isAdmin } = useRole();
   const { data: order, isLoading, error } = useOrder({ id: orderId });
   const deleteOrder = useDeleteOrder();
   const calculateDistance = useCalculateDistance();
   const outsourceOrder = useOutsourceOrder();
   const updateStop = useUpdateStop();
+  const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
+  const dispatcherName = dispatchersData?.items?.find((d) => d.id === order?.dispatcherId)?.name;
   const { data: currencyListData } = useCurrencyList();
   const baseCurrencySymbol = currencyListData?.items?.find((c) => c.isBase)?.symbol || '₡';
   const currencySymbol = baseCurrencySymbol;
@@ -800,6 +807,28 @@ export default function OrderDetailPage() {
                   <p className="font-medium">{order.driver.licensePlateNumber}</p>
                 </div>
               )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Dispatcher */}
+        {isAdmin && order.publicId && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="flex items-center gap-2">
+                  <Headset className="h-5 w-5" />
+                  {t('orders:detail.dispatcher', { defaultValue: 'Dispatcher' })}
+                </CardTitle>
+                <ReassignDispatcherDialog
+                  order={{ publicId: order.publicId, dispatcherId: order.dispatcherId }}
+                />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="font-medium">
+                {dispatcherName || t('orders:detail.unassigned', { defaultValue: 'Unassigned' })}
+              </p>
             </CardContent>
           </Card>
         )}

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -28,7 +28,9 @@ import { Enums } from '@/data/app-enums';
 import { formatDate, formatCurrency } from '@/utils/format';
 import { Input } from '@/components/ui/input';
 import { useOrderList } from '@/hooks/orders';
+import { useDispatchUsers } from '@/hooks/users';
 import { useCurrencyList } from '@/hooks/currencies/useCurrencyList';
+import { useRole } from '@/hooks/auth';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
@@ -52,6 +54,7 @@ function formatAddress(address?: App.Data.Address.AddressData | null): string {
 export default function OrdersPage() {
   const { t, ready } = useTranslation();
   const router = useRouter();
+  const { isAdmin, isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState<string>('all');
   const [search, setSearch] = useState('');
@@ -77,6 +80,14 @@ export default function OrdersPage() {
   const { data: currencyListData } = useCurrencyList();
   const baseCurrencySymbol = currencyListData?.items?.find((c) => c.isBase)?.symbol || '₡';
   const meta = data?.meta;
+
+  // Dispatcher names are resolved client-side — OrderData only carries
+  // `dispatcherId`, not the related user. The orders list endpoint has no
+  // `filter[dispatcher]` param, so this column is display-only.
+  const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
+  const dispatcherNameById = new Map(
+    (dispatchersData?.items ?? []).map((dispatcher) => [dispatcher.id, dispatcher.name])
+  );
 
   if (!ready) {
     return null;
@@ -249,7 +260,13 @@ export default function OrdersPage() {
           ) : orders.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
               <Package className="mb-4 h-12 w-12" />
-              <p>{t('orders:no_orders', { defaultValue: 'No orders found' })}</p>
+              <p>
+                {isDispatch
+                  ? t('orders:no_orders_dispatch', {
+                      defaultValue: 'No orders in your book yet',
+                    })
+                  : t('orders:no_orders', { defaultValue: 'No orders found' })}
+              </p>
             </div>
           ) : (
             <Table>
@@ -263,6 +280,11 @@ export default function OrdersPage() {
                   <TableHead>{t('orders:detail.stops', { defaultValue: 'Stops' })}</TableHead>
                   <TableHead>{t('orders:to', { defaultValue: 'To' })}</TableHead>
                   <TableHead>{modelLabel('quote')}</TableHead>
+                  {isAdmin && (
+                    <TableHead>
+                      {t('orders:detail.dispatcher', { defaultValue: 'Dispatcher' })}
+                    </TableHead>
+                  )}
                   <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
@@ -295,6 +317,13 @@ export default function OrdersPage() {
                         ? formatCurrency(order.currentQuote.total, baseCurrencySymbol)
                         : '-'}
                     </TableCell>
+                    {isAdmin && (
+                      <TableCell>
+                        {(order.dispatcherId != null &&
+                          dispatcherNameById.get(order.dispatcherId)) ||
+                          '—'}
+                      </TableCell>
+                    )}
                     <TableCell>{formatDate(order.createdAt)}</TableCell>
                   </TableRow>
                 ))}

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useUser, useDeleteUser, useUpdateUser } from '@/hooks/users';
 import { useRole } from '@/hooks/auth';
 import { RoleBadge } from '@/components/users/RoleBadge';
+import { DispatcherPicker } from '@/components/dispatch/DispatcherPicker';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { useCatalogElement } from '@/hooks/catalogs/useCatalogStore';
@@ -58,6 +59,13 @@ export default function UserDetailPage() {
     updateUser.mutate({
       id: userId,
       data: { allowedPaymentMethods: next as App.Enums.PaymentMethodType[] },
+    });
+  };
+
+  const handleChangeDispatcher = (next: number | null) => {
+    updateUser.mutate({
+      id: userId,
+      data: { dispatcherId: next },
     });
   };
 
@@ -282,6 +290,15 @@ export default function UserDetailPage() {
           onChange={handleChangePaymentMethods}
           isPending={updateUser.isPending}
         />
+
+        {/* Dispatcher */}
+        {isAdmin && (
+          <DispatcherPicker
+            dispatcherId={user.dispatcherId}
+            onChange={handleChangeDispatcher}
+            isPending={updateUser.isPending}
+          />
+        )}
 
         {/* Timestamps */}
         <Card>

--- a/app/[lang]/(dashboard)/users/page.tsx
+++ b/app/[lang]/(dashboard)/users/page.tsx
@@ -17,18 +17,14 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import {
-  actionLabel,
-  modelLabel,
-  resourceMessage,
-  validationAttribute,
-} from '@/utils/lang';
+import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { formatDate } from '@/utils/format';
 import { useUserList } from '@/hooks/users';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
+import { useRole } from '@/hooks/auth';
 import { RoleBadge } from '@/components/users/RoleBadge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -49,6 +45,7 @@ function getInitials(name?: string): string {
 export default function UsersPage() {
   const { t, ready } = useTranslation();
   const router = useRouter();
+  const { isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [role, setRole] = useState<string>('all');
   const [search, setSearch] = useState('');
@@ -153,7 +150,11 @@ export default function UsersPage() {
           ) : users.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
               <Users className="mb-4 h-12 w-12" />
-              <p>{t('users:no_users', { defaultValue: 'No users found' })}</p>
+              <p>
+                {isDispatch
+                  ? t('users:no_users_dispatch', { defaultValue: 'No users in your book yet' })
+                  : t('users:no_users', { defaultValue: 'No users found' })}
+              </p>
             </div>
           ) : (
             <Table>

--- a/components/dispatch/DispatcherPicker.tsx
+++ b/components/dispatch/DispatcherPicker.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useTranslation } from 'react-i18next';
+import { Headset } from 'lucide-react';
+import { useDispatchUsers } from '@/hooks/users';
+
+const UNASSIGNED_VALUE = 'none';
+
+interface DispatcherPickerProps {
+  dispatcherId: number | null | undefined;
+  onChange: (dispatcherId: number | null) => void;
+  isPending?: boolean;
+}
+
+/**
+ * Admin-only card that assigns a user or business to a dispatcher's book.
+ * Callers gate rendering behind `useRole().isAdmin` — mirrors the API, where
+ * only an admin may set `dispatcherId` on a user or business.
+ */
+export function DispatcherPicker({ dispatcherId, onChange, isPending }: DispatcherPickerProps) {
+  const { t } = useTranslation();
+  const { data: dispatchersData, isLoading } = useDispatchUsers();
+  const dispatchers = dispatchersData?.items ?? [];
+
+  const value = dispatcherId != null ? String(dispatcherId) : UNASSIGNED_VALUE;
+
+  const handleChange = (next: string) => {
+    onChange(next === UNASSIGNED_VALUE ? null : Number(next));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Headset className="h-5 w-5" />
+          {t('common:dispatcher.title', { defaultValue: 'Dispatcher' })}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Select value={value} onValueChange={handleChange} disabled={isPending || isLoading}>
+          <SelectTrigger className="w-full">
+            <SelectValue
+              placeholder={t('common:dispatcher.placeholder', {
+                defaultValue: 'Select dispatcher',
+              })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNASSIGNED_VALUE}>
+              {t('common:none', { defaultValue: 'None' })}
+            </SelectItem>
+            {dispatchers.map((dispatcher) => (
+              <SelectItem key={dispatcher.id} value={String(dispatcher.id)}>
+                {dispatcher.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dispatch/ReassignDispatcherDialog.tsx
+++ b/components/dispatch/ReassignDispatcherDialog.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { useDispatchUsers } from '@/hooks/users';
+import { useChangeDispatcher } from '@/hooks/orders';
+import { actionLabel } from '@/utils/lang';
+import { Headset } from 'lucide-react';
+
+const UNASSIGNED_VALUE = 'none';
+
+interface ReassignDispatcherDialogOrder {
+  publicId: string;
+  dispatcherId?: number | null;
+}
+
+interface ReassignDispatcherDialogProps {
+  order: ReassignDispatcherDialogOrder;
+}
+
+/**
+ * Admin-only dialog that reassigns an order to a different dispatcher's book,
+ * or clears it back to unassigned. Calls PATCH /orders/{order}/dispatcher.
+ */
+export function ReassignDispatcherDialog({ order }: ReassignDispatcherDialogProps) {
+  const { t } = useTranslation('orders');
+  const [open, setOpen] = useState(false);
+  const [selectedValue, setSelectedValue] = useState<string>(UNASSIGNED_VALUE);
+
+  const { data: dispatchersData } = useDispatchUsers({ enabled: open });
+  const dispatchers = dispatchersData?.items ?? [];
+  const changeDispatcher = useChangeDispatcher();
+
+  const handleOpenChange = (val: boolean) => {
+    if (val) {
+      setSelectedValue(order.dispatcherId != null ? String(order.dispatcherId) : UNASSIGNED_VALUE);
+    }
+    setOpen(val);
+  };
+
+  const handleSubmit = () => {
+    const dispatcherId = selectedValue === UNASSIGNED_VALUE ? null : Number(selectedValue);
+    changeDispatcher.mutate(
+      { orderPublicId: order.publicId, dispatcherId },
+      { onSuccess: () => handleOpenChange(false) }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Headset className="mr-1 h-4 w-4" />
+          {t('reassign_dispatcher.button', { defaultValue: 'Reassign Dispatcher' })}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t('reassign_dispatcher.title', { defaultValue: 'Reassign Dispatcher' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('reassign_dispatcher.description', {
+              defaultValue: 'Move this order to a different dispatcher, or unassign it.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Select value={selectedValue} onValueChange={setSelectedValue}>
+          <SelectTrigger className="w-full">
+            <SelectValue
+              placeholder={t('reassign_dispatcher.placeholder', {
+                defaultValue: 'Select dispatcher',
+              })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNASSIGNED_VALUE}>
+              {t('common:none', { defaultValue: 'None' })}
+            </SelectItem>
+            {dispatchers.map((dispatcher) => (
+              <SelectItem key={dispatcher.id} value={String(dispatcher.id)}>
+                {dispatcher.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button type="button" disabled={changeDispatcher.isPending} onClick={handleSubmit}>
+            {changeDispatcher.isPending
+              ? t('common:loading', { defaultValue: 'Loading...' })
+              : actionLabel('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -17,12 +17,14 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { LogOut, Menu, User } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications';
 import { useSidebarStore } from '@/stores/useSidebarStore';
+import { useRole } from '@/hooks/auth';
 
 export function Header() {
   const { t } = useTranslation();
   const router = useLocalizedRouter();
   const { user } = useAuth();
   const { setOpen } = useSidebarStore();
+  const { isAdmin } = useRole();
 
   const handleLogout = async () => {
     await Auth.logout();
@@ -70,11 +72,15 @@ export function Header() {
                 </p>
               </div>
             </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => router.push('/settings')}>
-              <User className="mr-2 h-4 w-4" />
-              {t('common:profile', { defaultValue: 'Profile' })}
-            </DropdownMenuItem>
+            {isAdmin && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => router.push('/settings')}>
+                  <User className="mr-2 h-4 w-4" />
+                  {t('common:profile', { defaultValue: 'Profile' })}
+                </DropdownMenuItem>
+              </>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>
               <LogOut className="mr-2 h-4 w-4" />

--- a/hooks/orders/index.ts
+++ b/hooks/orders/index.ts
@@ -5,6 +5,7 @@ export { useCalculateDistance } from './useCalculateDistance';
 export { useUpdateStop } from './useUpdateStop';
 export { useCreateStop } from './useCreateStop';
 export { useChangeTier } from './useChangeTier';
+export { useChangeDispatcher } from './useChangeDispatcher';
 export { useOutsourceOrder } from './useOutsourceOrder';
 export { useRetryDispatch } from './useRetryDispatch';
 export { useAssignOrder } from './useAssignOrder';

--- a/hooks/orders/useChangeDispatcher.ts
+++ b/hooks/orders/useChangeDispatcher.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { OrderService } from '@/services/orderService';
+import { toast } from 'sonner';
+import { isApiError } from '@/lib/api/error';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+
+export function useChangeDispatcher() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      orderPublicId,
+      dispatcherId,
+    }: {
+      orderPublicId: string;
+      dispatcherId: number | null;
+    }) => OrderService.changeDispatcher(orderPublicId, dispatcherId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      toast.success(crudSuccessMessage('updated', 'order'));
+    },
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage('updating', 'order'));
+      }
+    },
+  });
+}

--- a/hooks/users/index.ts
+++ b/hooks/users/index.ts
@@ -1,3 +1,4 @@
 export { useUserList } from './useUserList';
 export { useUser } from './useUser';
 export { useUpdateUser, useDeleteUser } from './useUserMutations';
+export { useDispatchUsers } from './useDispatchUsers';

--- a/hooks/users/useDispatchUsers.ts
+++ b/hooks/users/useDispatchUsers.ts
@@ -1,0 +1,23 @@
+import { useUserList } from './useUserList';
+import { Enums } from '@/data/app-enums';
+
+interface UseDispatchUsersParams {
+  enabled?: boolean;
+}
+
+/**
+ * Lists every dispatch-role user (`filter[role]=dispatch`), for the
+ * admin-only dispatcher pickers on the user/business detail cards and the
+ * order reassignment dialog. Callers gate rendering behind `useRole().isAdmin`
+ * — the underlying list endpoint is available to any staff user, but only an
+ * admin can act on the result.
+ */
+export function useDispatchUsers(params: UseDispatchUsersParams = {}) {
+  const { enabled = true } = params;
+
+  return useUserList({
+    role: Enums.Role.DISPATCH,
+    perPage: 200,
+    enabled,
+  });
+}

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -148,6 +148,16 @@ export const OrderService = {
   },
 
   /**
+   * Reassign an order to a different dispatcher, or unassign it (admin only)
+   */
+  async changeDispatcher(publicId: string, dispatcherId: number | null): Promise<OrderData> {
+    const response = await api.patch<Single<OrderData>>(`/orders/${publicId}/dispatcher`, {
+      dispatcherId,
+    });
+    return response.item;
+  },
+
+  /**
    * Manually outsource an order to external provider (admin only)
    */
   async outsource(publicId: string): Promise<OrderData> {


### PR DESCRIPTION
## Summary
- Admin-only dispatcher picker (Card + Select, following `PaymentMethodsCard`) on the user and business detail pages, writing `dispatcherId` through the existing update mutations.
- Order detail page: admin-only "Dispatcher" card showing the current dispatcher (resolved client-side from the dispatch-user list, since `OrderData` only carries `dispatcherId`) plus a "Reassign Dispatcher" dialog (`PATCH /orders/{order}/dispatcher`, following the `useChangeTier`/`AssignDriverModal` pattern), supporting unassign.
- Orders list: admin-only dispatcher column (name or "—"), resolved the same client-side way. No dispatcher filter was added — the orders index endpoint has no `filter[dispatcher]` param (see Known gaps below).
- Book-aware empty states for dispatch users on the orders, users, and businesses listings ("No orders/users/businesses in your book yet" vs. the generic copy), since those endpoints already scope to the dispatcher's book server-side.
- `components/layout/Header.tsx`: hid the Profile menu entry for non-admins — it links to `/settings`, which is `RequireAdmin`-gated and was bouncing dispatch users back to the dashboard.

## Known gaps / needs follow-up
- **No orders dispatcher filter param on the API.** Checked `OrderController::index` / `OrderService::getPaginated` in the api repo — the only filters are `status`, `exclude_status`, `exclude_terminal`, `payment_status`, `collect_on_delivery`, `has_quote`, pickup/delivery date ranges, and `search`. No `dispatcher` filter exists, so I did not add a dispatcher filter select to the orders list (would have had no backend to call). The dispatcher **column** works regardless since it's just a client-side id→name lookup.
- **Missing translation keys** (lang files live in the api repo, out of scope here — all used with the repo's existing `t(key, { defaultValue })` convention so the UI reads correctly in English until synced):
  - `common:dispatcher.title` / `common:dispatcher.placeholder`
  - `orders:detail.dispatcher` / `orders:detail.unassigned`
  - `orders:reassign_dispatcher.button` / `.title` / `.description` / `.placeholder`
  - `orders:no_orders_dispatch`
  - `users:no_users_dispatch`
  - `businesses:no_businesses_dispatch`

## Docs checked
- `README.md` — generic structural doc, not affected.
- `CLAUDE.md` — general pattern reference, not affected.
- `docs/architecture.md` — its Service/Hooks/i18n-namespace listings are illustrative and already non-exhaustive/stale predating this change (e.g. the documented namespace list is missing more than half of the namespaces actually registered in `config/i18next.ts`, and the Order Service snippet already omits several existing methods like `changeTier`/`assign`/`outsource`). Nothing in this doc describes dispatcher-book behavior, so nothing became newly false; left unmodified as out of scope for this behavior PR, but flagging the namespace-list drift since it's a real gap.
- `docs/strict-rules.md`, `docs/pricing-rules-plan.md` — unrelated, not affected.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing unrelated `eslint-env` warning on `public/firebase-messaging-sw.js`)
- [x] `npm run test -- --run` — 154/154 passing (baseline)
- [x] `npm run build` — succeeds