### PR TITLE
feat(orders): dispatcher filter on admin orders list

### DIFF
--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -88,7 +88,9 @@ export default function OrdersPage() {
   // powers the admin-only dispatcher filter below (`filter[dispatcher]`).
   const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
   const dispatchers = dispatchersData?.items ?? [];
-  const dispatcherNameById = new Map(dispatchers.map((dispatcher) => [dispatcher.id, dispatcher.name]));
+  const dispatcherNameById = new Map(
+    dispatchers.map((dispatcher) => [dispatcher.id, dispatcher.name])
+  );
 
   if (!ready) {
     return null;

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -57,6 +57,7 @@ export default function OrdersPage() {
   const { isAdmin, isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState<string>('all');
+  const [dispatcherFilter, setDispatcherFilter] = useState<string>('all');
   const [search, setSearch] = useState('');
   const [pickupFrom, setPickupFrom] = useState('');
   const [pickupTo, setPickupTo] = useState('');
@@ -69,6 +70,7 @@ export default function OrdersPage() {
     page,
     perPage: 15,
     status: status === 'all' ? undefined : status,
+    dispatcher: isAdmin && dispatcherFilter !== 'all' ? dispatcherFilter : undefined,
     search: search || undefined,
     pickupFrom: pickupFrom || undefined,
     pickupTo: pickupTo || undefined,
@@ -81,13 +83,12 @@ export default function OrdersPage() {
   const baseCurrencySymbol = currencyListData?.items?.find((c) => c.isBase)?.symbol || '₡';
   const meta = data?.meta;
 
-  // Dispatcher names are resolved client-side — OrderData only carries
-  // `dispatcherId`, not the related user. The orders list endpoint has no
-  // `filter[dispatcher]` param, so this column is display-only.
+  // Dispatcher names are resolved client-side for the table column — OrderData
+  // only carries `dispatcherId`, not the related user. The same list also
+  // powers the admin-only dispatcher filter below (`filter[dispatcher]`).
   const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
-  const dispatcherNameById = new Map(
-    (dispatchersData?.items ?? []).map((dispatcher) => [dispatcher.id, dispatcher.name])
-  );
+  const dispatchers = dispatchersData?.items ?? [];
+  const dispatcherNameById = new Map(dispatchers.map((dispatcher) => [dispatcher.id, dispatcher.name]));
 
   if (!ready) {
     return null;
@@ -160,6 +161,32 @@ export default function OrdersPage() {
                 ))}
               </SelectContent>
             </Select>
+            {isAdmin && (
+              <Select
+                value={dispatcherFilter}
+                onValueChange={(value) => {
+                  setDispatcherFilter(value);
+                  resetPage();
+                }}
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue
+                    placeholder={t('common:dispatcher.title', { defaultValue: 'Dispatcher' })}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t('common:all', { defaultValue: 'All' })}</SelectItem>
+                  {dispatchers.map((dispatcher) => (
+                    <SelectItem key={dispatcher.id} value={String(dispatcher.id)}>
+                      {dispatcher.name}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="unassigned">
+                    {t('orders:detail.unassigned', { defaultValue: 'Unassigned' })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
           </div>
           <div className="flex flex-wrap gap-4">
             <div className="grid gap-1">

--- a/hooks/orders/useOrderList.ts
+++ b/hooks/orders/useOrderList.ts
@@ -15,6 +15,8 @@ interface UseOrderListParams {
   pickupTo?: string;
   deliveryFrom?: string;
   deliveryTo?: string;
+  /** A dispatch user id, or `'unassigned'` for orders with no dispatcher */
+  dispatcher?: string;
   enabled?: boolean;
 }
 

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -66,6 +66,8 @@ interface ListParams {
   pickupTo?: string;
   deliveryFrom?: string;
   deliveryTo?: string;
+  /** A dispatch user id, or `'unassigned'` for orders with no dispatcher */
+  dispatcher?: string;
 }
 
 function buildQueryString(params: ListParams): string {
@@ -79,6 +81,7 @@ function buildQueryString(params: ListParams): string {
   if (typeof params.hasQuote === 'boolean') query.set('filter[has_quote]', String(params.hasQuote));
   if (typeof params.collectOnDelivery === 'boolean')
     query.set('filter[collect_on_delivery]', String(params.collectOnDelivery));
+  if (params.dispatcher) query.set('filter[dispatcher]', params.dispatcher);
   if (params.search) query.set('search', params.search);
   if (params.pickupFrom) query.set('pickupFrom', params.pickupFrom);
   if (params.pickupTo) query.set('pickupTo', params.pickupTo);


### PR DESCRIPTION
Admin-only dispatcher filter select on the orders list, wired to the API's filter[dispatcher]=<id|unassigned> param. Implementer completed the code (commits 4f8ff6e + c4c9364, pushed) through repeated machine-sleep interruptions; gate run and PR opened by the orchestrator as recovery.