### PR TITLE
feat: dispatch role UI — gating, dispatcher books, filter

### DIFF
--- a/app/[lang]/(dashboard)/audit-logs/layout.tsx
+++ b/app/[lang]/(dashboard)/audit-logs/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function AuditLogsLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -7,12 +7,14 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { useBusiness, useDeleteBusiness, useUpdateBusiness } from '@/hooks/businesses';
+import { useRole } from '@/hooks/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Building2, User, MapPin, Calendar, Trash2 } from 'lucide-react';
 import { formatDate } from '@/utils/format';
 import { useBusinessTaxProfile } from '@/hooks/tax-profiles';
 import { TaxProfileCard } from '@/components/TaxProfileCard';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
+import { DispatcherPicker } from '@/components/dispatch/DispatcherPicker';
 
 export default function BusinessDetailPage() {
   const params = useParams();
@@ -24,11 +26,19 @@ export default function BusinessDetailPage() {
   const { data: taxProfile } = useBusinessTaxProfile(businessId);
   const deleteBusiness = useDeleteBusiness();
   const updateBusiness = useUpdateBusiness();
+  const { isAdmin } = useRole();
 
   const handleChangePaymentMethods = (next: string[]) => {
     updateBusiness.mutate({
       id: businessId,
       data: { allowedPaymentMethods: next as App.Enums.PaymentMethodType[] },
+    });
+  };
+
+  const handleChangeDispatcher = (next: number | null) => {
+    updateBusiness.mutate({
+      id: businessId,
+      data: { dispatcherId: next },
     });
   };
 
@@ -181,6 +191,15 @@ export default function BusinessDetailPage() {
           onChange={handleChangePaymentMethods}
           isPending={updateBusiness.isPending}
         />
+
+        {/* Dispatcher */}
+        {isAdmin && (
+          <DispatcherPicker
+            dispatcherId={business.dispatcherId}
+            onChange={handleChangeDispatcher}
+            isPending={updateBusiness.isPending}
+          />
+        )}
 
         <Card>
           <CardHeader>

--- a/app/[lang]/(dashboard)/businesses/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/page.tsx
@@ -10,16 +10,12 @@ import {
 } from '@/components/ui/table';
 
 import { useState } from 'react';
-import {
-  actionLabel,
-  modelLabel,
-  resourceMessage,
-  validationAttribute,
-} from '@/utils/lang';
+import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
+import { useRole } from '@/hooks/auth';
 import { useBusinessList } from '@/hooks/businesses';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Building2 } from 'lucide-react';
@@ -28,6 +24,7 @@ import { formatDate } from '@/utils/format';
 export default function BusinessesPage() {
   const { t, ready } = useTranslation();
   const router = useRouter();
+  const { isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
 
@@ -92,7 +89,13 @@ export default function BusinessesPage() {
           ) : businesses.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
               <Building2 className="mb-4 h-12 w-12" />
-              <p>{t('businesses:no_businesses', { defaultValue: 'No businesses found' })}</p>
+              <p>
+                {isDispatch
+                  ? t('businesses:no_businesses_dispatch', {
+                      defaultValue: 'No businesses in your book yet',
+                    })
+                  : t('businesses:no_businesses', { defaultValue: 'No businesses found' })}
+              </p>
             </div>
           ) : (
             <Table>

--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -26,6 +26,7 @@ import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useDriver, useDeleteDriver, useUpdateDriver } from '@/hooks/drivers';
+import { useRole } from '@/hooks/auth';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -62,6 +63,7 @@ export default function DriverDetailPage() {
   const params = useParams();
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
+  const { isAdmin } = useRole();
   const driverId = params.id as string;
 
   const { data: driver, isLoading, error } = useDriver(driverId);
@@ -168,21 +170,31 @@ export default function DriverDetailPage() {
         </div>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <Switch
-              checked={driver.active !== false}
-              onCheckedChange={(checked) =>
-                updateDriver.mutate({ id: driverId, data: { active: checked } })
-              }
-              disabled={updateDriver.isPending}
-            />
-            <Label className="text-sm font-medium">
-              {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
-            </Label>
+            {isAdmin ? (
+              <>
+                <Switch
+                  checked={driver.active !== false}
+                  onCheckedChange={(checked) =>
+                    updateDriver.mutate({ id: driverId, data: { active: checked } })
+                  }
+                  disabled={updateDriver.isPending}
+                />
+                <Label className="text-sm font-medium">
+                  {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
+                </Label>
+              </>
+            ) : (
+              <Badge variant={driver.active !== false ? 'default' : 'secondary'}>
+                {driver.active !== false ? statusLabel('active') : statusLabel('inactive')}
+              </Badge>
+            )}
           </div>
-          <Button variant="destructive" onClick={handleDelete} disabled={deleteDriver.isPending}>
-            <Trash2 className="mr-2 h-4 w-4" />
-            {actionLabel('delete')}
-          </Button>
+          {isAdmin && (
+            <Button variant="destructive" onClick={handleDelete} disabled={deleteDriver.isPending}>
+              <Trash2 className="mr-2 h-4 w-4" />
+              {actionLabel('delete')}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -289,54 +301,66 @@ export default function DriverDetailPage() {
                   <Label className="text-muted-foreground text-sm">
                     {t('drivers:default_vehicle_type', { defaultValue: 'Default Vehicle' })}
                   </Label>
-                  <Select
-                    value={driver.defaultVehicleType}
-                    onValueChange={(value) =>
-                      updateDriver.mutate({
-                        id: driverId,
-                        data: { defaultVehicleType: value as App.Enums.VehicleType },
-                      })
-                    }
-                    disabled={updateDriver.isPending}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.values(Enums.VehicleType).map((vt) => (
-                        <SelectItem key={vt} value={vt}>
-                          {capitalize(vehicleTypeLabel(vt))}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {isAdmin ? (
+                    <Select
+                      value={driver.defaultVehicleType}
+                      onValueChange={(value) =>
+                        updateDriver.mutate({
+                          id: driverId,
+                          data: { defaultVehicleType: value as App.Enums.VehicleType },
+                        })
+                      }
+                      disabled={updateDriver.isPending}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.values(Enums.VehicleType).map((vt) => (
+                          <SelectItem key={vt} value={vt}>
+                            {capitalize(vehicleTypeLabel(vt))}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <span className="font-medium">
+                      {capitalize(vehicleTypeLabel(driver.defaultVehicleType))}
+                    </span>
+                  )}
                 </div>
 
                 <div className="grid gap-2">
                   <Label className="text-muted-foreground text-sm">
                     {t('drivers:dispatch_policy', { defaultValue: 'Dispatch Policy' })}
                   </Label>
-                  <Select
-                    value={driver.dispatchPolicy}
-                    onValueChange={(value) =>
-                      updateDriver.mutate({
-                        id: driverId,
-                        data: { dispatchPolicy: value as App.Enums.DispatchPolicy },
-                      })
-                    }
-                    disabled={updateDriver.isPending}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.values(Enums.DispatchPolicy).map((policy) => (
-                        <SelectItem key={policy} value={policy}>
-                          {capitalize(dispatchPolicyLabel(policy))}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {isAdmin ? (
+                    <Select
+                      value={driver.dispatchPolicy}
+                      onValueChange={(value) =>
+                        updateDriver.mutate({
+                          id: driverId,
+                          data: { dispatchPolicy: value as App.Enums.DispatchPolicy },
+                        })
+                      }
+                      disabled={updateDriver.isPending}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.values(Enums.DispatchPolicy).map((policy) => (
+                          <SelectItem key={policy} value={policy}>
+                            {capitalize(dispatchPolicyLabel(policy))}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <span className="font-medium">
+                      {capitalize(dispatchPolicyLabel(driver.dispatchPolicy))}
+                    </span>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -384,10 +408,12 @@ export default function DriverDetailPage() {
                       })}
                     </p>
                   )}
-                  <Button variant="outline" size="sm" onClick={() => setMapOpen(true)}>
-                    <Pencil className="mr-2 h-3.5 w-3.5" />
-                    {baseCenter ? actionLabel('edit') : actionLabel('set')}
-                  </Button>
+                  {isAdmin && (
+                    <Button variant="outline" size="sm" onClick={() => setMapOpen(true)}>
+                      <Pencil className="mr-2 h-3.5 w-3.5" />
+                      {baseCenter ? actionLabel('edit') : actionLabel('set')}
+                    </Button>
+                  )}
 
                   <Dialog open={mapOpen} onOpenChange={setMapOpen}>
                     <DialogContent className="sm:max-w-3xl">
@@ -424,7 +450,7 @@ export default function DriverDetailPage() {
 
         {!isOutsourced && (
           <TabsContent value="schedule">
-            <DriverScheduleTab driverId={driverId} />
+            <DriverScheduleTab driverId={driverId} readOnly={!isAdmin} />
           </TabsContent>
         )}
       </Tabs>

--- a/app/[lang]/(dashboard)/drivers/create/layout.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function DriverCreateLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/utils/lang';
 import { Input } from '@/components/ui/input';
 import { useDriverList } from '@/hooks/drivers';
+import { useRole } from '@/hooks/auth';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
@@ -44,6 +45,7 @@ function getInitials(name?: string): string {
 export default function DriversPage() {
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
+  const { isAdmin } = useRole();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
 
@@ -69,10 +71,12 @@ export default function DriversPage() {
             {t('drivers:manage_description', { defaultValue: 'Manage driver accounts' })}
           </p>
         </div>
-        <Button onClick={() => router.push('/drivers/create')}>
-          <Plus className="mr-2 h-4 w-4" />
-          {resourceMessage('create_one', 'driver')}
-        </Button>
+        {isAdmin && (
+          <Button onClick={() => router.push('/drivers/create')}>
+            <Plus className="mr-2 h-4 w-4" />
+            {resourceMessage('create_one', 'driver')}
+          </Button>
+        )}
       </div>
 
       <Card>

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   ExternalLink,
   Info,
   Loader2,
+  Headset,
 } from 'lucide-react';
 
 import { useMemo, useState } from 'react';
@@ -44,6 +45,7 @@ import { EditStopAddressDialog } from '@/components/orders/EditStopAddressDialog
 import { EditStopDetailsDialog } from '@/components/orders/EditStopDetailsDialog';
 import { AddStopDialog } from '@/components/orders/AddStopDialog';
 import { ReconciliationDialog } from '@/components/orders/ReconciliationDialog';
+import { ReassignDispatcherDialog } from '@/components/dispatch/ReassignDispatcherDialog';
 import { ChatTabs } from '@/components/chat/ChatTabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -62,6 +64,8 @@ import {
   useUpdateStop,
 } from '@/hooks/orders';
 import { useCurrencyList } from '@/hooks/currencies';
+import { useDispatchUsers } from '@/hooks/users';
+import { useRole } from '@/hooks/auth';
 import { Enums } from '@/data/app-enums';
 
 type QuoteStatus = App.Enums.QuoteStatus;
@@ -74,11 +78,14 @@ export default function OrderDetailPage() {
   const router = useLocalizedRouter();
   const orderId = params.id as string;
 
+  const { isAdmin } = useRole();
   const { data: order, isLoading, error } = useOrder({ id: orderId });
   const deleteOrder = useDeleteOrder();
   const calculateDistance = useCalculateDistance();
   const outsourceOrder = useOutsourceOrder();
   const updateStop = useUpdateStop();
+  const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
+  const dispatcherName = dispatchersData?.items?.find((d) => d.id === order?.dispatcherId)?.name;
   const { data: currencyListData } = useCurrencyList();
   const baseCurrencySymbol = currencyListData?.items?.find((c) => c.isBase)?.symbol || '₡';
   const currencySymbol = baseCurrencySymbol;
@@ -800,6 +807,28 @@ export default function OrderDetailPage() {
                   <p className="font-medium">{order.driver.licensePlateNumber}</p>
                 </div>
               )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Dispatcher */}
+        {isAdmin && order.publicId && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="flex items-center gap-2">
+                  <Headset className="h-5 w-5" />
+                  {t('orders:detail.dispatcher', { defaultValue: 'Dispatcher' })}
+                </CardTitle>
+                <ReassignDispatcherDialog
+                  order={{ publicId: order.publicId, dispatcherId: order.dispatcherId }}
+                />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="font-medium">
+                {dispatcherName || t('orders:detail.unassigned', { defaultValue: 'Unassigned' })}
+              </p>
             </CardContent>
           </Card>
         )}

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -88,7 +88,9 @@ export default function OrdersPage() {
   // powers the admin-only dispatcher filter below (`filter[dispatcher]`).
   const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
   const dispatchers = dispatchersData?.items ?? [];
-  const dispatcherNameById = new Map(dispatchers.map((dispatcher) => [dispatcher.id, dispatcher.name]));
+  const dispatcherNameById = new Map(
+    dispatchers.map((dispatcher) => [dispatcher.id, dispatcher.name])
+  );
 
   if (!ready) {
     return null;

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -28,7 +28,9 @@ import { Enums } from '@/data/app-enums';
 import { formatDate, formatCurrency } from '@/utils/format';
 import { Input } from '@/components/ui/input';
 import { useOrderList } from '@/hooks/orders';
+import { useDispatchUsers } from '@/hooks/users';
 import { useCurrencyList } from '@/hooks/currencies/useCurrencyList';
+import { useRole } from '@/hooks/auth';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
@@ -52,6 +54,7 @@ function formatAddress(address?: App.Data.Address.AddressData | null): string {
 export default function OrdersPage() {
   const { t, ready } = useTranslation();
   const router = useRouter();
+  const { isAdmin, isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState<string>('all');
   const [search, setSearch] = useState('');
@@ -77,6 +80,14 @@ export default function OrdersPage() {
   const { data: currencyListData } = useCurrencyList();
   const baseCurrencySymbol = currencyListData?.items?.find((c) => c.isBase)?.symbol || '₡';
   const meta = data?.meta;
+
+  // Dispatcher names are resolved client-side — OrderData only carries
+  // `dispatcherId`, not the related user. The orders list endpoint has no
+  // `filter[dispatcher]` param, so this column is display-only.
+  const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
+  const dispatcherNameById = new Map(
+    (dispatchersData?.items ?? []).map((dispatcher) => [dispatcher.id, dispatcher.name])
+  );
 
   if (!ready) {
     return null;
@@ -249,7 +260,13 @@ export default function OrdersPage() {
           ) : orders.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
               <Package className="mb-4 h-12 w-12" />
-              <p>{t('orders:no_orders', { defaultValue: 'No orders found' })}</p>
+              <p>
+                {isDispatch
+                  ? t('orders:no_orders_dispatch', {
+                      defaultValue: 'No orders in your book yet',
+                    })
+                  : t('orders:no_orders', { defaultValue: 'No orders found' })}
+              </p>
             </div>
           ) : (
             <Table>
@@ -263,6 +280,11 @@ export default function OrdersPage() {
                   <TableHead>{t('orders:detail.stops', { defaultValue: 'Stops' })}</TableHead>
                   <TableHead>{t('orders:to', { defaultValue: 'To' })}</TableHead>
                   <TableHead>{modelLabel('quote')}</TableHead>
+                  {isAdmin && (
+                    <TableHead>
+                      {t('orders:detail.dispatcher', { defaultValue: 'Dispatcher' })}
+                    </TableHead>
+                  )}
                   <TableHead>{actionLabel('created')}</TableHead>
                 </TableRow>
               </TableHeader>
@@ -295,6 +317,13 @@ export default function OrdersPage() {
                         ? formatCurrency(order.currentQuote.total, baseCurrencySymbol)
                         : '-'}
                     </TableCell>
+                    {isAdmin && (
+                      <TableCell>
+                        {(order.dispatcherId != null &&
+                          dispatcherNameById.get(order.dispatcherId)) ||
+                          '—'}
+                      </TableCell>
+                    )}
                     <TableCell>{formatDate(order.createdAt)}</TableCell>
                   </TableRow>
                 ))}

--- a/app/[lang]/(dashboard)/orders/page.tsx
+++ b/app/[lang]/(dashboard)/orders/page.tsx
@@ -57,6 +57,7 @@ export default function OrdersPage() {
   const { isAdmin, isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState<string>('all');
+  const [dispatcherFilter, setDispatcherFilter] = useState<string>('all');
   const [search, setSearch] = useState('');
   const [pickupFrom, setPickupFrom] = useState('');
   const [pickupTo, setPickupTo] = useState('');
@@ -69,6 +70,7 @@ export default function OrdersPage() {
     page,
     perPage: 15,
     status: status === 'all' ? undefined : status,
+    dispatcher: isAdmin && dispatcherFilter !== 'all' ? dispatcherFilter : undefined,
     search: search || undefined,
     pickupFrom: pickupFrom || undefined,
     pickupTo: pickupTo || undefined,
@@ -81,13 +83,12 @@ export default function OrdersPage() {
   const baseCurrencySymbol = currencyListData?.items?.find((c) => c.isBase)?.symbol || '₡';
   const meta = data?.meta;
 
-  // Dispatcher names are resolved client-side — OrderData only carries
-  // `dispatcherId`, not the related user. The orders list endpoint has no
-  // `filter[dispatcher]` param, so this column is display-only.
+  // Dispatcher names are resolved client-side for the table column — OrderData
+  // only carries `dispatcherId`, not the related user. The same list also
+  // powers the admin-only dispatcher filter below (`filter[dispatcher]`).
   const { data: dispatchersData } = useDispatchUsers({ enabled: isAdmin });
-  const dispatcherNameById = new Map(
-    (dispatchersData?.items ?? []).map((dispatcher) => [dispatcher.id, dispatcher.name])
-  );
+  const dispatchers = dispatchersData?.items ?? [];
+  const dispatcherNameById = new Map(dispatchers.map((dispatcher) => [dispatcher.id, dispatcher.name]));
 
   if (!ready) {
     return null;
@@ -160,6 +161,32 @@ export default function OrdersPage() {
                 ))}
               </SelectContent>
             </Select>
+            {isAdmin && (
+              <Select
+                value={dispatcherFilter}
+                onValueChange={(value) => {
+                  setDispatcherFilter(value);
+                  resetPage();
+                }}
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue
+                    placeholder={t('common:dispatcher.title', { defaultValue: 'Dispatcher' })}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t('common:all', { defaultValue: 'All' })}</SelectItem>
+                  {dispatchers.map((dispatcher) => (
+                    <SelectItem key={dispatcher.id} value={String(dispatcher.id)}>
+                      {dispatcher.name}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="unassigned">
+                    {t('orders:detail.unassigned', { defaultValue: 'Unassigned' })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
           </div>
           <div className="flex flex-wrap gap-4">
             <div className="grid gap-1">

--- a/app/[lang]/(dashboard)/pricing/layout.tsx
+++ b/app/[lang]/(dashboard)/pricing/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/settings/layout.tsx
+++ b/app/[lang]/(dashboard)/settings/layout.tsx
@@ -1,0 +1,5 @@
+import { RequireAdmin } from '@/components/auth/RequireAdmin';
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useUser, useDeleteUser, useUpdateUser } from '@/hooks/users';
+import { useRole } from '@/hooks/auth';
 import { RoleBadge } from '@/components/users/RoleBadge';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
@@ -45,6 +46,7 @@ export default function UserDetailPage() {
   const params = useParams();
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
+  const { isAdmin } = useRole();
   const userId = params.id as string;
 
   const { data: user, isLoading, error } = useUser(userId);
@@ -114,10 +116,12 @@ export default function UserDetailPage() {
             </p>
           </div>
         </div>
-        <Button variant="destructive" onClick={handleDelete} disabled={deleteUser.isPending}>
-          <Trash2 className="mr-2 h-4 w-4" />
-          {actionLabel('delete')}
-        </Button>
+        {isAdmin && (
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteUser.isPending}>
+            <Trash2 className="mr-2 h-4 w-4" />
+            {actionLabel('delete')}
+          </Button>
+        )}
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useUser, useDeleteUser, useUpdateUser } from '@/hooks/users';
 import { useRole } from '@/hooks/auth';
 import { RoleBadge } from '@/components/users/RoleBadge';
+import { DispatcherPicker } from '@/components/dispatch/DispatcherPicker';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { useCatalogElement } from '@/hooks/catalogs/useCatalogStore';
@@ -58,6 +59,13 @@ export default function UserDetailPage() {
     updateUser.mutate({
       id: userId,
       data: { allowedPaymentMethods: next as App.Enums.PaymentMethodType[] },
+    });
+  };
+
+  const handleChangeDispatcher = (next: number | null) => {
+    updateUser.mutate({
+      id: userId,
+      data: { dispatcherId: next },
     });
   };
 
@@ -282,6 +290,15 @@ export default function UserDetailPage() {
           onChange={handleChangePaymentMethods}
           isPending={updateUser.isPending}
         />
+
+        {/* Dispatcher */}
+        {isAdmin && (
+          <DispatcherPicker
+            dispatcherId={user.dispatcherId}
+            onChange={handleChangeDispatcher}
+            isPending={updateUser.isPending}
+          />
+        )}
 
         {/* Timestamps */}
         <Card>

--- a/app/[lang]/(dashboard)/users/page.tsx
+++ b/app/[lang]/(dashboard)/users/page.tsx
@@ -17,18 +17,14 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import {
-  actionLabel,
-  modelLabel,
-  resourceMessage,
-  validationAttribute,
-} from '@/utils/lang';
+import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
 import { formatDate } from '@/utils/format';
 import { useUserList } from '@/hooks/users';
 import { Input } from '@/components/ui/input';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
+import { useRole } from '@/hooks/auth';
 import { RoleBadge } from '@/components/users/RoleBadge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -49,6 +45,7 @@ function getInitials(name?: string): string {
 export default function UsersPage() {
   const { t, ready } = useTranslation();
   const router = useRouter();
+  const { isDispatch } = useRole();
   const [page, setPage] = useState(1);
   const [role, setRole] = useState<string>('all');
   const [search, setSearch] = useState('');
@@ -153,7 +150,11 @@ export default function UsersPage() {
           ) : users.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
               <Users className="mb-4 h-12 w-12" />
-              <p>{t('users:no_users', { defaultValue: 'No users found' })}</p>
+              <p>
+                {isDispatch
+                  ? t('users:no_users_dispatch', { defaultValue: 'No users in your book yet' })
+                  : t('users:no_users', { defaultValue: 'No users found' })}
+              </p>
             </div>
           ) : (
             <Table>

--- a/components/auth/RequireAdmin.tsx
+++ b/components/auth/RequireAdmin.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useRole } from '@/hooks/auth';
+
+interface RequireAdminProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Gates an admin-only route segment (settings, pricing, audit logs, driver
+ * creation) from the `dispatch` staff role. Mirrors the API's authorization
+ * split so a dispatch user never lands on a page whose requests the API
+ * would 403 — once the auth store has hydrated, a non-admin user is bounced
+ * to the dashboard.
+ */
+export function RequireAdmin({ children }: RequireAdminProps) {
+  const router = useLocalizedRouter();
+  const hydrated = useAuthStore((state) => state.hydrated);
+  const user = useAuthStore((state) => state.user);
+  const { isAdmin } = useRole();
+
+  const blocked = hydrated && !!user && !isAdmin;
+
+  useEffect(() => {
+    if (blocked) {
+      router.replace('/');
+    }
+  }, [blocked, router]);
+
+  if (!hydrated || blocked) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/components/dispatch/DispatcherPicker.tsx
+++ b/components/dispatch/DispatcherPicker.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useTranslation } from 'react-i18next';
+import { Headset } from 'lucide-react';
+import { useDispatchUsers } from '@/hooks/users';
+
+const UNASSIGNED_VALUE = 'none';
+
+interface DispatcherPickerProps {
+  dispatcherId: number | null | undefined;
+  onChange: (dispatcherId: number | null) => void;
+  isPending?: boolean;
+}
+
+/**
+ * Admin-only card that assigns a user or business to a dispatcher's book.
+ * Callers gate rendering behind `useRole().isAdmin` — mirrors the API, where
+ * only an admin may set `dispatcherId` on a user or business.
+ */
+export function DispatcherPicker({ dispatcherId, onChange, isPending }: DispatcherPickerProps) {
+  const { t } = useTranslation();
+  const { data: dispatchersData, isLoading } = useDispatchUsers();
+  const dispatchers = dispatchersData?.items ?? [];
+
+  const value = dispatcherId != null ? String(dispatcherId) : UNASSIGNED_VALUE;
+
+  const handleChange = (next: string) => {
+    onChange(next === UNASSIGNED_VALUE ? null : Number(next));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Headset className="h-5 w-5" />
+          {t('common:dispatcher.title', { defaultValue: 'Dispatcher' })}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Select value={value} onValueChange={handleChange} disabled={isPending || isLoading}>
+          <SelectTrigger className="w-full">
+            <SelectValue
+              placeholder={t('common:dispatcher.placeholder', {
+                defaultValue: 'Select dispatcher',
+              })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNASSIGNED_VALUE}>
+              {t('common:none', { defaultValue: 'None' })}
+            </SelectItem>
+            {dispatchers.map((dispatcher) => (
+              <SelectItem key={dispatcher.id} value={String(dispatcher.id)}>
+                {dispatcher.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dispatch/ReassignDispatcherDialog.tsx
+++ b/components/dispatch/ReassignDispatcherDialog.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { useDispatchUsers } from '@/hooks/users';
+import { useChangeDispatcher } from '@/hooks/orders';
+import { actionLabel } from '@/utils/lang';
+import { Headset } from 'lucide-react';
+
+const UNASSIGNED_VALUE = 'none';
+
+interface ReassignDispatcherDialogOrder {
+  publicId: string;
+  dispatcherId?: number | null;
+}
+
+interface ReassignDispatcherDialogProps {
+  order: ReassignDispatcherDialogOrder;
+}
+
+/**
+ * Admin-only dialog that reassigns an order to a different dispatcher's book,
+ * or clears it back to unassigned. Calls PATCH /orders/{order}/dispatcher.
+ */
+export function ReassignDispatcherDialog({ order }: ReassignDispatcherDialogProps) {
+  const { t } = useTranslation('orders');
+  const [open, setOpen] = useState(false);
+  const [selectedValue, setSelectedValue] = useState<string>(UNASSIGNED_VALUE);
+
+  const { data: dispatchersData } = useDispatchUsers({ enabled: open });
+  const dispatchers = dispatchersData?.items ?? [];
+  const changeDispatcher = useChangeDispatcher();
+
+  const handleOpenChange = (val: boolean) => {
+    if (val) {
+      setSelectedValue(order.dispatcherId != null ? String(order.dispatcherId) : UNASSIGNED_VALUE);
+    }
+    setOpen(val);
+  };
+
+  const handleSubmit = () => {
+    const dispatcherId = selectedValue === UNASSIGNED_VALUE ? null : Number(selectedValue);
+    changeDispatcher.mutate(
+      { orderPublicId: order.publicId, dispatcherId },
+      { onSuccess: () => handleOpenChange(false) }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Headset className="mr-1 h-4 w-4" />
+          {t('reassign_dispatcher.button', { defaultValue: 'Reassign Dispatcher' })}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t('reassign_dispatcher.title', { defaultValue: 'Reassign Dispatcher' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('reassign_dispatcher.description', {
+              defaultValue: 'Move this order to a different dispatcher, or unassign it.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Select value={selectedValue} onValueChange={setSelectedValue}>
+          <SelectTrigger className="w-full">
+            <SelectValue
+              placeholder={t('reassign_dispatcher.placeholder', {
+                defaultValue: 'Select dispatcher',
+              })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNASSIGNED_VALUE}>
+              {t('common:none', { defaultValue: 'None' })}
+            </SelectItem>
+            {dispatchers.map((dispatcher) => (
+              <SelectItem key={dispatcher.id} value={String(dispatcher.id)}>
+                {dispatcher.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button type="button" disabled={changeDispatcher.isPending} onClick={handleSubmit}>
+            {changeDispatcher.isPending
+              ? t('common:loading', { defaultValue: 'Loading...' })
+              : actionLabel('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/drivers/DriverScheduleTab.tsx
+++ b/components/drivers/DriverScheduleTab.tsx
@@ -43,9 +43,11 @@ function formatTimeHHMM(date: Date): string {
 
 interface Props {
   driverId: string;
+  /** When true, renders the calendar as view-only — no create/edit/delete/save. */
+  readOnly?: boolean;
 }
 
-export function DriverScheduleTab({ driverId }: Props) {
+export function DriverScheduleTab({ driverId, readOnly = false }: Props) {
   const { t, i18n } = useTranslation();
   const { data, isLoading } = useDriverSchedules(driverId);
   const syncSchedules = useSyncSchedules(driverId);
@@ -187,11 +189,13 @@ export function DriverScheduleTab({ driverId }: Props) {
               defaultValue: 'Availability Calendar',
             })}
           </CardTitle>
-          <Button onClick={handleSaveSchedules} disabled={syncSchedules.isPending} size="sm">
-            {syncSchedules.isPending
-              ? t('common:saving', { defaultValue: 'Saving...' })
-              : actionLabel('save')}
-          </Button>
+          {!readOnly && (
+            <Button onClick={handleSaveSchedules} disabled={syncSchedules.isPending} size="sm">
+              {syncSchedules.isPending
+                ? t('common:saving', { defaultValue: 'Saving...' })
+                : actionLabel('save')}
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           <FullCalendar
@@ -207,24 +211,26 @@ export function DriverScheduleTab({ driverId }: Props) {
             slotLabelFormat={{ hour: 'numeric', minute: '2-digit', hour12: true }}
             height={800}
             events={calendarEvents}
-            dateClick={handleDateClick}
-            eventClick={handleEventClick}
+            dateClick={readOnly ? undefined : handleDateClick}
+            eventClick={readOnly ? undefined : handleEventClick}
           />
         </CardContent>
       </Card>
 
-      <ScheduleEventDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        mode={dialogMode}
-        date={dialogDate}
-        startTime={dialogStartTime}
-        endTime={dialogEndTime}
-        vehicleType={dialogVehicleType}
-        isSaving={syncSchedules.isPending}
-        onSave={handleSaveEntry}
-        onDelete={handleDeleteEntry}
-      />
+      {!readOnly && (
+        <ScheduleEventDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          mode={dialogMode}
+          date={dialogDate}
+          startTime={dialogStartTime}
+          endTime={dialogEndTime}
+          vehicleType={dialogVehicleType}
+          isSaving={syncSchedules.isPending}
+          onSave={handleSaveEntry}
+          onDelete={handleDeleteEntry}
+        />
+      )}
     </div>
   );
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -17,12 +17,14 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { LogOut, Menu, User } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications';
 import { useSidebarStore } from '@/stores/useSidebarStore';
+import { useRole } from '@/hooks/auth';
 
 export function Header() {
   const { t } = useTranslation();
   const router = useLocalizedRouter();
   const { user } = useAuth();
   const { setOpen } = useSidebarStore();
+  const { isAdmin } = useRole();
 
   const handleLogout = async () => {
     await Auth.logout();
@@ -70,11 +72,15 @@ export function Header() {
                 </p>
               </div>
             </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => router.push('/settings')}>
-              <User className="mr-2 h-4 w-4" />
-              {t('common:profile', { defaultValue: 'Profile' })}
-            </DropdownMenuItem>
+            {isAdmin && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => router.push('/settings')}>
+                  <User className="mr-2 h-4 w-4" />
+                  {t('common:profile', { defaultValue: 'Profile' })}
+                </DropdownMenuItem>
+              </>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>
               <LogOut className="mr-2 h-4 w-4" />

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 import { useNeedsAttention } from '@/hooks/orders/useNeedsAttention';
 import { usePendingReconciliation } from '@/hooks/orders/usePendingReconciliation';
+import { useRole } from '@/hooks/auth';
 
 const navigation = [
   { modelKey: 'dashboard', href: '/', icon: LayoutDashboard, isModel: false },
@@ -51,9 +52,16 @@ const navigation = [
     icon: DollarSign,
     isModel: false,
     translationKey: 'pricing:title',
+    adminOnly: true,
   },
   { modelKey: 'notification', href: '/notifications', icon: Bell, isModel: true },
-  { modelKey: 'audit_log', href: '/audit-logs', icon: ScrollText, isModel: true },
+  {
+    modelKey: 'audit_log',
+    href: '/audit-logs',
+    icon: ScrollText,
+    isModel: true,
+    adminOnly: true,
+  },
   { modelKey: 'guide', href: '/guide', icon: BookOpen, isModel: false },
 ];
 
@@ -64,9 +72,12 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const lang = (params?.lang as string) || 'en';
   const { data: needsAttentionData } = useNeedsAttention();
   const { data: pendingReconciliationData } = usePendingReconciliation();
+  const { isAdmin } = useRole();
   const urgentCount =
     (needsAttentionData?.summary?.critical ?? 0) + (needsAttentionData?.summary?.high ?? 0);
   const reconciliationCount = pendingReconciliationData?.summary?.count ?? 0;
+
+  const visibleNavigation = navigation.filter((item) => !item.adminOnly || isAdmin);
 
   const withLang = (href: string) => `/${lang}${href === '/' ? '' : href}`;
   const pathWithoutLang = pathname.replace(new RegExp(`^/${lang}`), '') || '/';
@@ -96,7 +107,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 overflow-y-auto p-4">
-        {navigation.map((item) => {
+        {visibleNavigation.map((item) => {
           const isActive =
             pathWithoutLang === item.href ||
             (item.href !== '/' && pathWithoutLang.startsWith(item.href));
@@ -131,21 +142,23 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       </nav>
 
       {/* Settings at bottom */}
-      <div className="border-t p-4">
-        <Link
-          href={withLang('/settings')}
-          onClick={onNavigate}
-          className={cn(
-            'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-            pathWithoutLang === '/settings'
-              ? 'bg-primary text-primary-foreground'
-              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-          )}
-        >
-          <Settings className="h-5 w-5" />
-          {ready ? capitalize(t('common:settings', { count: 2 })) : ''}
-        </Link>
-      </div>
+      {isAdmin && (
+        <div className="border-t p-4">
+          <Link
+            href={withLang('/settings')}
+            onClick={onNavigate}
+            className={cn(
+              'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              pathWithoutLang === '/settings'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            )}
+          >
+            <Settings className="h-5 w-5" />
+            {ready ? capitalize(t('common:settings', { count: 2 })) : ''}
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/users/RoleBadge.tsx
+++ b/components/users/RoleBadge.tsx
@@ -11,6 +11,7 @@ const roleConfig: Record<
   'business.user': { label: 'Business User', variant: 'secondary' },
   client: { label: 'Client', variant: 'outline' },
   driver: { label: 'Driver', variant: 'default' },
+  dispatch: { label: 'Dispatch', variant: 'secondary' },
 };
 
 interface RoleBadgeProps {

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -345,6 +345,7 @@ export const Enums = {
     CLIENT: "client",
     DRIVER: "driver",
     ADMIN: "admin",
+    DISPATCH: "dispatch",
   },
   RouteDateMode: {
     TODAY: "today",

--- a/hooks/auth/index.ts
+++ b/hooks/auth/index.ts
@@ -1,1 +1,2 @@
 export { useLoginMutation } from './useLoginMutation';
+export { useRole } from './useRole';

--- a/hooks/auth/useRole.ts
+++ b/hooks/auth/useRole.ts
@@ -1,0 +1,21 @@
+import { useAuthStore } from '@/stores/useAuthStore';
+import { Enums } from '@/data/app-enums';
+
+/**
+ * Role-derived flags for the current admin-panel user.
+ *
+ * Mirrors the API's authorization split between the two roles allowed into
+ * the admin panel: `admin` (full access) and `dispatch` (operational
+ * access only — the API 403s dispatch on settings, pricing rules,
+ * currencies/exchange-rate management, audit logs, driver mutations +
+ * schedule editing, and user create/delete/role changes). UI gating
+ * should key off `isAdmin`; `isStaff` is true for either role.
+ */
+export function useRole() {
+  const role = useAuthStore((state) => state.user?.role);
+  const isAdmin = useAuthStore((state) => state.isAdmin());
+  const isDispatch = role === Enums.Role.DISPATCH;
+  const isStaff = isAdmin || isDispatch;
+
+  return { role, isAdmin, isDispatch, isStaff };
+}

--- a/hooks/orders/index.ts
+++ b/hooks/orders/index.ts
@@ -5,6 +5,7 @@ export { useCalculateDistance } from './useCalculateDistance';
 export { useUpdateStop } from './useUpdateStop';
 export { useCreateStop } from './useCreateStop';
 export { useChangeTier } from './useChangeTier';
+export { useChangeDispatcher } from './useChangeDispatcher';
 export { useOutsourceOrder } from './useOutsourceOrder';
 export { useRetryDispatch } from './useRetryDispatch';
 export { useAssignOrder } from './useAssignOrder';

--- a/hooks/orders/useChangeDispatcher.ts
+++ b/hooks/orders/useChangeDispatcher.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { OrderService } from '@/services/orderService';
+import { toast } from 'sonner';
+import { isApiError } from '@/lib/api/error';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+
+export function useChangeDispatcher() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      orderPublicId,
+      dispatcherId,
+    }: {
+      orderPublicId: string;
+      dispatcherId: number | null;
+    }) => OrderService.changeDispatcher(orderPublicId, dispatcherId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      toast.success(crudSuccessMessage('updated', 'order'));
+    },
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage('updating', 'order'));
+      }
+    },
+  });
+}

--- a/hooks/orders/useOrderList.ts
+++ b/hooks/orders/useOrderList.ts
@@ -15,6 +15,8 @@ interface UseOrderListParams {
   pickupTo?: string;
   deliveryFrom?: string;
   deliveryTo?: string;
+  /** A dispatch user id, or `'unassigned'` for orders with no dispatcher */
+  dispatcher?: string;
   enabled?: boolean;
 }
 

--- a/hooks/users/index.ts
+++ b/hooks/users/index.ts
@@ -1,3 +1,4 @@
 export { useUserList } from './useUserList';
 export { useUser } from './useUser';
 export { useUpdateUser, useDeleteUser } from './useUserMutations';
+export { useDispatchUsers } from './useDispatchUsers';

--- a/hooks/users/useDispatchUsers.ts
+++ b/hooks/users/useDispatchUsers.ts
@@ -1,0 +1,23 @@
+import { useUserList } from './useUserList';
+import { Enums } from '@/data/app-enums';
+
+interface UseDispatchUsersParams {
+  enabled?: boolean;
+}
+
+/**
+ * Lists every dispatch-role user (`filter[role]=dispatch`), for the
+ * admin-only dispatcher pickers on the user/business detail cards and the
+ * order reassignment dialog. Callers gate rendering behind `useRole().isAdmin`
+ * — the underlying list endpoint is available to any staff user, but only an
+ * admin can act on the result.
+ */
+export function useDispatchUsers(params: UseDispatchUsersParams = {}) {
+  const { enabled = true } = params;
+
+  return useUserList({
+    role: Enums.Role.DISPATCH,
+    perPage: 200,
+    enabled,
+  });
+}

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -66,6 +66,8 @@ interface ListParams {
   pickupTo?: string;
   deliveryFrom?: string;
   deliveryTo?: string;
+  /** A dispatch user id, or `'unassigned'` for orders with no dispatcher */
+  dispatcher?: string;
 }
 
 function buildQueryString(params: ListParams): string {
@@ -79,6 +81,7 @@ function buildQueryString(params: ListParams): string {
   if (typeof params.hasQuote === 'boolean') query.set('filter[has_quote]', String(params.hasQuote));
   if (typeof params.collectOnDelivery === 'boolean')
     query.set('filter[collect_on_delivery]', String(params.collectOnDelivery));
+  if (params.dispatcher) query.set('filter[dispatcher]', params.dispatcher);
   if (params.search) query.set('search', params.search);
   if (params.pickupFrom) query.set('pickupFrom', params.pickupFrom);
   if (params.pickupTo) query.set('pickupTo', params.pickupTo);

--- a/services/orderService.ts
+++ b/services/orderService.ts
@@ -148,6 +148,16 @@ export const OrderService = {
   },
 
   /**
+   * Reassign an order to a different dispatcher, or unassign it (admin only)
+   */
+  async changeDispatcher(publicId: string, dispatcherId: number | null): Promise<OrderData> {
+    const response = await api.patch<Single<OrderData>>(`/orders/${publicId}/dispatcher`, {
+      dispatcherId,
+    });
+    return response.item;
+  },
+
+  /**
    * Manually outsource an order to external provider (admin only)
    */
   async outsource(publicId: string): Promise<OrderData> {

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -151,6 +151,7 @@ declare namespace App.Data.Business {
     typeName?: string;
     usersCanApproveOwnOrders?: boolean;
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
+    dispatcherId?: number | null;
     createdAt?: string;
     updatedAt?: string;
     deletedAt?: string | null;
@@ -170,6 +171,7 @@ declare namespace App.Data.Business {
     typeId?: number;
     usersCanApproveOwnOrders?: boolean;
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
+    dispatcherId?: number | null;
   };
 }
 declare namespace App.Data.Catalog {
@@ -486,6 +488,7 @@ declare namespace App.Data.Order {
     businessId?: number | null;
     driverId?: number | null;
     preferredDriverId?: number | null;
+    dispatcherId?: number | null;
     deliveryAddressId?: number | null;
     contactName?: string | null;
     contactPhone?: string | null;
@@ -619,6 +622,9 @@ declare namespace App.Data.Order {
     latitude: number;
     longitude: number;
     address: string;
+  };
+  export type UpdateOrderDispatcherData = {
+    dispatcherId: number | null;
   };
   export type UpdateOrderStopData = {
     addressId?: number | null;
@@ -1108,6 +1114,7 @@ declare namespace App.Data.User {
     langCode?: string;
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     preferredCurrency?: string | null;
+    dispatcherId?: number | null;
   };
   export type UserData = {
     id: number;
@@ -1121,6 +1128,7 @@ declare namespace App.Data.User {
     preferredCurrency?: string | null;
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     businessId?: number | null;
+    dispatcherId?: number | null;
     sexId?: number | null;
     isAdmin: boolean;
     isBusinessAccount: boolean;
@@ -1485,6 +1493,7 @@ declare namespace App.Enums {
     CLIENT = 'client',
     DRIVER = 'driver',
     ADMIN = 'admin',
+    DISPATCH = 'dispatch',
   }
   export enum RouteDateMode {
     TODAY = 'today',


### PR DESCRIPTION
Admin-panel companion for the dispatch role shipped in mandados-api #63/#65. Three slices merged via this buffer branch, each gated: #17 role gating (nav/route guards, read-only drivers, users restrictions), #18 dispatcher books UI (pickers, order reassignment, empty states), #19 orders dispatcher filter. Plus the generated type sync. Final gate on this tip: typecheck clean, lint clean (one pre-existing firebase-sw deprecation notice), vitest 154/154, next build green.