### PR TITLE
feat(users): add role editor to user detail page

### DIFF
--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -8,7 +8,9 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { useUser, useDeleteUser, useUpdateUser } from '@/hooks/users';
 import { useRole } from '@/hooks/auth';
+import { useAuth } from '@/stores/useAuthStore';
 import { RoleBadge } from '@/components/users/RoleBadge';
+import { ASSIGNABLE_ROLES, ChangeRoleDialog } from '@/components/users/ChangeRoleDialog';
 import { DispatcherPicker } from '@/components/dispatch/DispatcherPicker';
 import { PaymentMethodsCard } from '@/components/payments/PaymentMethodsCard';
 import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
@@ -48,6 +50,7 @@ export default function UserDetailPage() {
   const { t, ready } = useTranslation();
   const router = useLocalizedRouter();
   const { isAdmin } = useRole();
+  const { user: currentUser } = useAuth();
   const userId = params.id as string;
 
   const { data: user, isLoading, error } = useUser(userId);
@@ -102,6 +105,12 @@ export default function UserDetailPage() {
     );
   }
 
+  // The API only allows role changes among client/dispatch/admin (driver and
+  // business.* users are a structural requirement), and never on the
+  // caller's own account — mirror both restrictions in what we render.
+  const canChangeRole =
+    isAdmin && ASSIGNABLE_ROLES.includes(user.role as Role) && currentUser?.id !== user.id;
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -118,6 +127,9 @@ export default function UserDetailPage() {
             <div className="flex items-center gap-3">
               <h1 className="text-3xl font-bold">{user.name}</h1>
               <RoleBadge role={user.role as Role} />
+              {canChangeRole && (
+                <ChangeRoleDialog userId={userId} currentRole={user.role as Role} />
+              )}
             </div>
             <p className="text-muted-foreground">
               {modelLabel('user')} {user.publicId}

--- a/components/users/ChangeRoleDialog.tsx
+++ b/components/users/ChangeRoleDialog.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { useUpdateUser } from '@/hooks/users';
+import { actionLabel, capitalize } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+import { UserCog } from 'lucide-react';
+
+type Role = App.Enums.Role;
+
+/**
+ * The only roles an admin may assign through the user-update endpoint.
+ * Driver and business.* roles are structural requirements the API rejects
+ * outright, so they're never offered here.
+ */
+export const ASSIGNABLE_ROLES: Role[] = [
+  Enums.Role.CLIENT,
+  Enums.Role.DISPATCH,
+  Enums.Role.ADMIN,
+] as Role[];
+
+interface ChangeRoleDialogProps {
+  userId: string;
+  currentRole: Role;
+}
+
+/**
+ * Admin-only dialog that promotes or demotes a user between the three
+ * assignable roles (client, dispatch, admin). This is how dispatch agents
+ * get created — by promoting an existing account. Mirrors the API's
+ * restrictions: driver/business.* users and the caller's own account are
+ * never editable here (callers gate rendering on that). Calls PATCH
+ * /users/{user} through the existing update mutation.
+ */
+export function ChangeRoleDialog({ userId, currentRole }: ChangeRoleDialogProps) {
+  const { t } = useTranslation('users');
+  const [open, setOpen] = useState(false);
+  const [selectedRole, setSelectedRole] = useState<Role>(currentRole);
+  const updateUser = useUpdateUser();
+
+  const handleOpenChange = (val: boolean) => {
+    if (val) {
+      setSelectedRole(currentRole);
+    }
+    setOpen(val);
+  };
+
+  const handleSubmit = () => {
+    updateUser.mutate(
+      { id: userId, data: { role: selectedRole } },
+      { onSuccess: () => handleOpenChange(false) }
+    );
+  };
+
+  const roleLabel = (role: Role) => t(`role.${role}`, { defaultValue: capitalize(role) });
+
+  const isDispatchDemotion =
+    currentRole === Enums.Role.DISPATCH && selectedRole !== Enums.Role.DISPATCH;
+  const isUnchanged = selectedRole === currentRole;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <UserCog className="mr-1 h-4 w-4" />
+          {t('role_change.button', { defaultValue: 'Change Role' })}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('role_change.title', { defaultValue: 'Change Role' })}</DialogTitle>
+          <DialogDescription>
+            {t('role_change.description', {
+              defaultValue: "Update this user's role. This takes effect immediately.",
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Select value={selectedRole} onValueChange={(next) => setSelectedRole(next as Role)}>
+          <SelectTrigger className="w-full">
+            <SelectValue
+              placeholder={t('role_change.placeholder', { defaultValue: 'Select role' })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {ASSIGNABLE_ROLES.map((role) => (
+              <SelectItem key={role} value={role}>
+                {roleLabel(role)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {isDispatchDemotion && (
+          <p className="text-muted-foreground text-sm">
+            {t('role_change.dispatch_demote_warning', {
+              defaultValue:
+                'Their assigned orders and customers remain in their book until an admin reassigns them.',
+            })}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button
+            type="button"
+            disabled={updateUser.isPending || isUnchanged}
+            onClick={handleSubmit}
+          >
+            {updateUser.isPending
+              ? t('common:loading', { defaultValue: 'Loading...' })
+              : actionLabel('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -1115,6 +1115,7 @@ declare namespace App.Data.User {
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     preferredCurrency?: string | null;
     dispatcherId?: number | null;
+    role?: string;
   };
   export type UserData = {
     id: number;


### PR DESCRIPTION
## Summary
- Admin-only role editor on the user detail page: lets an admin promote/demote a user among `client` / `dispatch` / `admin` — the only roles the API allows through the user-update endpoint.
- Rendered only when the viewer is an admin, the viewed user's current role is client/dispatch/admin (driver/business.* stay a plain `RoleBadge`, matching the API's rejection of those), and the viewed user isn't the viewer's own account (self role-change is rejected server-side, so it's never offered — the badge shows instead).
- A confirmation dialog (mirrors `ReassignDispatcherDialog`'s Dialog + Select + Save/Cancel pattern) wraps the change; demoting a `dispatch` user shows a warning that their assigned orders/customers stay in their book until reassigned.
- Wired through the existing `useUpdateUser` mutation — no new endpoint or service method.

## Suggested API lang keys
All three role labels (`users.role.client/dispatch/admin`) and the demote copy already reuse existing/spec'd translation keys except one new group, which should be added to `api/lang/{en,es,fr}/users.php`:
- `role_change.button` — "Change Role"
- `role_change.title` — "Change Role"
- `role_change.description` — "Update this user's role. This takes effect immediately."
- `role_change.placeholder` — "Select role"
- `role_change.dispatch_demote_warning` — "Their assigned orders and customers remain in their book until an admin reassigns them."

(`users.role.client`, `users.role.dispatch`, `users.role.admin` already exist in the API lang files, so the select's option labels resolve to real translations once locales load; only `role_change.*` is new.)

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --run` (154/154, matches baseline)
- [x] `npm run build`