### PR TITLE
fix(payments): gate refund/void actions behind admin

### DIFF
--- a/components/payments/PaymentSection.tsx
+++ b/components/payments/PaymentSection.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useOrderPayments } from '@/hooks/payments';
+import { useRole } from '@/hooks/auth';
 import { useOrderCurrencySymbol } from '@/hooks/currencies';
 import { RefundDialog } from './RefundDialog';
 import { RecordPaymentDialog } from './RecordPaymentDialog';
@@ -134,11 +135,16 @@ function RefundCard({ refund }: { refund: RefundData }) {
 
 function PaymentCard({ payment }: { payment: PaymentData }) {
   const { t } = useTranslation();
+  const { isAdmin } = useRole();
   const currencySymbol = useOrderCurrencySymbol(payment.currencyCode);
   const refundableAmount = (payment.amount || 0) - (payment.totalRefunded || 0);
-  const canRefund = payment.status === Enums.TransactionStatus.Succeeded && refundableAmount > 0;
+  // Refund issuance and voiding a recorded payment are admin-only at the API;
+  // recording (RecordPaymentDialog below) is staff, book-scoped for dispatch.
+  const canRefund =
+    isAdmin && payment.status === Enums.TransactionStatus.Succeeded && refundableAmount > 0;
   const isAuthorized = payment.status === Enums.TransactionStatus.Authorized;
   const canVoid =
+    isAdmin &&
     payment.provider === Enums.PaymentProvider.Manual &&
     payment.status === Enums.TransactionStatus.Succeeded;
 


### PR DESCRIPTION
Companion to mandados-api #68 (dispatch gets record, book-scoped). Refund and Void buttons were role-blind and would 403 for dispatch; now admin-only rendered. Gate: typecheck clean, lint clean (pre-existing firebase-sw notice), vitest 154/154, build green.