### PR TITLE
feat(profile): add a self-service profile page for every panel role

### DIFF
--- a/app/[lang]/(dashboard)/profile/page.tsx
+++ b/app/[lang]/(dashboard)/profile/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { Mail, Phone, User } from 'lucide-react';
+
+import { useAuth } from '@/stores/useAuthStore';
+import { RoleBadge } from '@/components/users/RoleBadge';
+import { ChangePasswordCard } from '@/components/profile/ChangePasswordCard';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { validationAttribute } from '@/utils/lang';
+
+type Role = App.Enums.Role;
+
+function getInitials(name?: string): string {
+  if (!name) return '?';
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+/**
+ * Every authenticated panel role (admin, dispatch) lands here — unlike
+ * `/settings`, this page has no `RequireAdmin` gate, since it only ever
+ * shows and edits the caller's own account.
+ */
+export default function ProfilePage() {
+  const { t, ready } = useTranslation();
+  const { user, hydrated } = useAuth();
+
+  if (!ready || !hydrated) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">
+          {t('common:my_profile', { defaultValue: 'My profile' })}
+        </h1>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <User className="h-5 w-5" />
+              {t('users:detail.contact_info', { defaultValue: 'Contact Information' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-4">
+              <Avatar className="h-16 w-16">
+                <AvatarImage src={user.avatar} />
+                <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+              </Avatar>
+              <div className="space-y-1">
+                <p className="text-lg font-semibold">{user.name}</p>
+                <RoleBadge role={user.role as Role} />
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <Mail className="text-muted-foreground mt-0.5 h-4 w-4" />
+              <div>
+                <p className="font-medium">
+                  {user.email || t('users:detail.not_provided', { defaultValue: 'Not provided' })}
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  {validationAttribute('email', true)}
+                </p>
+              </div>
+            </div>
+
+            {user.phone && (
+              <div className="flex items-start gap-3">
+                <Phone className="text-muted-foreground mt-0.5 h-4 w-4" />
+                <div>
+                  <p className="font-medium">{user.phone}</p>
+                  <p className="text-muted-foreground text-sm">
+                    {validationAttribute('phone', true)}
+                  </p>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <ChangePasswordCard />
+      </div>
+    </div>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -17,14 +17,12 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { LogOut, Menu, User } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications';
 import { useSidebarStore } from '@/stores/useSidebarStore';
-import { useRole } from '@/hooks/auth';
 
 export function Header() {
   const { t } = useTranslation();
   const router = useLocalizedRouter();
   const { user } = useAuth();
   const { setOpen } = useSidebarStore();
-  const { isAdmin } = useRole();
 
   const handleLogout = async () => {
     await Auth.logout();
@@ -72,15 +70,11 @@ export function Header() {
                 </p>
               </div>
             </DropdownMenuLabel>
-            {isAdmin && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => router.push('/settings')}>
-                  <User className="mr-2 h-4 w-4" />
-                  {t('common:profile', { defaultValue: 'Profile' })}
-                </DropdownMenuItem>
-              </>
-            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => router.push('/profile')}>
+              <User className="mr-2 h-4 w-4" />
+              {t('common:profile', { defaultValue: 'Profile' })}
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>
               <LogOut className="mr-2 h-4 w-4" />

--- a/components/profile/ChangePasswordCard.tsx
+++ b/components/profile/ChangePasswordCard.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import { KeyRound } from 'lucide-react';
+
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { applyApiErrorsToForm } from '@/utils/form';
+import { validationMessage } from '@/utils/lang';
+import { useUpdatePasswordMutation } from '@/hooks/auth';
+
+const passwordSchema = z
+  .object({
+    currentPassword: z.string().min(1, validationMessage('required', 'currentPassword')),
+    password: z
+      .string()
+      .min(8, validationMessage('min.string', 'password', { min: 8 }))
+      .regex(/[a-zA-Z]/, validationMessage('password.letters', 'password'))
+      .regex(/(?=.*[a-z])(?=.*[A-Z])/, validationMessage('password.mixed', 'password'))
+      .regex(/\d/, validationMessage('password.numbers', 'password'))
+      .regex(/[^A-Za-z0-9]/, validationMessage('password.symbols', 'password')),
+    passwordConfirmation: z.string().min(1, validationMessage('required', 'passwordConfirmation')),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: validationMessage('confirmed', 'password'),
+    path: ['passwordConfirmation'],
+  });
+
+type FormValues = z.infer<typeof passwordSchema>;
+
+/**
+ * Self-service password change card for the profile page. Submits to the
+ * authenticated `PATCH /auth/password` endpoint, which enforces the current
+ * password check, confirmation match, and complexity rules server-side —
+ * the client schema mirrors those rules so most mistakes are caught before
+ * the request goes out, while server errors (e.g. wrong current password)
+ * still map back onto the matching field.
+ */
+export function ChangePasswordCard() {
+  const { t } = useTranslation();
+  const updatePassword = useUpdatePasswordMutation();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: {
+      currentPassword: '',
+      password: '',
+      passwordConfirmation: '',
+    },
+  });
+
+  const onSubmit = (values: FormValues) => {
+    updatePassword.mutate(values, {
+      onSuccess: () => {
+        toast.success(
+          t('auth:update_password.success', {
+            defaultValue: 'Your password has been updated.',
+          })
+        );
+        form.reset();
+      },
+      onError: (error) => {
+        applyApiErrorsToForm(error, form.setError);
+      },
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <KeyRound className="h-5 w-5" />
+          {t('auth:update_password.title', { defaultValue: 'Change Password' })}
+        </CardTitle>
+        <CardDescription>
+          {t('auth:update_password.subtitle', {
+            defaultValue: 'Enter your current password and choose a new one.',
+          })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="currentPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('auth:update_password.current_password', {
+                      defaultValue: 'Current password',
+                    })}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      autoComplete="current-password"
+                      disabled={updatePassword.isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('auth:update_password.new_password', { defaultValue: 'New password' })}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      autoComplete="new-password"
+                      disabled={updatePassword.isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="passwordConfirmation"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('auth:update_password.confirm_password', {
+                      defaultValue: 'Confirm new password',
+                    })}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      autoComplete="new-password"
+                      disabled={updatePassword.isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={updatePassword.isPending}>
+                {updatePassword.isPending
+                  ? t('common:loading', { defaultValue: 'Loading...' })
+                  : t('auth:update_password.button', { defaultValue: 'Update Password' })}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/auth/index.ts
+++ b/hooks/auth/index.ts
@@ -1,2 +1,3 @@
 export { useLoginMutation } from './useLoginMutation';
+export { useUpdatePasswordMutation } from './useUpdatePasswordMutation';
 export { useRole } from './useRole';

--- a/hooks/auth/useUpdatePasswordMutation.ts
+++ b/hooks/auth/useUpdatePasswordMutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { Auth } from '@/services/authService';
+
+type UpdatePasswordPayload = App.Data.User.UpdatePasswordData;
+
+export function useUpdatePasswordMutation() {
+  return useMutation({
+    mutationFn: (payload: UpdatePasswordPayload) => Auth.updatePassword(payload),
+  });
+}

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -5,6 +5,8 @@ import { useAuthStore } from '@/stores/useAuthStore';
 type UserData = App.Data.User.UserData;
 type LoginResponse = Api.Response.Login;
 type SingleUser = Api.Response.Single<UserData>;
+type UpdatePasswordPayload = App.Data.User.UpdatePasswordData;
+type SuccessBasic = Api.Response.SuccessBasic;
 
 interface LoginCredentials {
   email: string;
@@ -89,6 +91,13 @@ export const Auth = {
       document.cookie = 'auth-token=; path=/; max-age=0';
       return null;
     }
+  },
+
+  /**
+   * Update the authenticated user's password
+   */
+  async updatePassword(payload: UpdatePasswordPayload): Promise<SuccessBasic> {
+    return api.patch<SuccessBasic>('/auth/password', payload);
   },
 
   /**


### PR DESCRIPTION
## Summary
- Adds `app/[lang]/(dashboard)/profile/page.tsx` — a profile page for every authenticated panel role (admin, dispatch), no `RequireAdmin` gate. Shows name, email, phone (when present), and role via the existing `RoleBadge`.
- Adds a change-password card (`components/profile/ChangePasswordCard.tsx`) submitting to the authenticated `PATCH /auth/password` endpoint, via a new `Auth.updatePassword()` service method and `useUpdatePasswordMutation` hook.
- Updates `components/layout/Header.tsx` — the profile menu entry now points to `/profile` (was `/settings`) and renders for all roles (was admin-only).

## Gate mode
OVERRIDE — ran the full check sequence myself in the foreground (see comment below) rather than enqueuing.

## i18n
No new API lang keys needed — every string used already exists:
- `common:profile`, `common:my_profile`
- `users:detail.contact_info`, `users:detail.not_provided`
- `auth:update_password.{title,subtitle,current_password,new_password,confirm_password,button,success}`
- `validation:attributes.{email,phone}`, `validation:{required,confirmed,min.string,password.letters,password.mixed,password.numbers,password.symbols}`

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --run` — 154/154 (baseline)
- [x] `npm run build`
- [x] `/simplify` pass (4 parallel review agents: reuse, simplification, efficiency, altitude) — one fix applied (derive `FormValues` via `z.infer`), two findings judged not worth acting on (see PR comment)