### PR TITLE
refactor: extract shared getInitials helper

### DIFF
--- a/app/[lang]/(dashboard)/drivers/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/[id]/page.tsx
@@ -3,6 +3,7 @@
 import {
   actionLabel,
   capitalize,
+  getInitials,
   modelLabel,
   resourceMessage,
   statusLabel,
@@ -43,16 +44,6 @@ import { DriverScheduleTab } from '@/components/drivers/DriverScheduleTab';
 import { ArrowLeft, User, CreditCard, Car, Calendar, Trash2, MapPin, Pencil } from 'lucide-react';
 import { GeoService } from '@/services/geoService';
 import { formatDate } from '@/utils/format';
-
-function getInitials(name?: string): string {
-  if (!name) return '?';
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 function isLicenseExpired(date?: string): boolean {
   if (!date) return false;

--- a/app/[lang]/(dashboard)/drivers/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/page.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 import {
   actionLabel,
   capitalize,
+  getInitials,
   modelLabel,
   resourceMessage,
   statusLabel,
@@ -31,16 +32,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ChevronLeft, ChevronRight, Plus, Search, Truck } from 'lucide-react';
 import { formatDate } from '@/utils/format';
-
-function getInitials(name?: string): string {
-  if (!name) return '?';
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 export default function DriversPage() {
   const { t, ready } = useTranslation();

--- a/app/[lang]/(dashboard)/profile/page.tsx
+++ b/app/[lang]/(dashboard)/profile/page.tsx
@@ -8,19 +8,9 @@ import { RoleBadge } from '@/components/users/RoleBadge';
 import { ChangePasswordCard } from '@/components/profile/ChangePasswordCard';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { validationAttribute } from '@/utils/lang';
+import { getInitials, validationAttribute } from '@/utils/lang';
 
 type Role = App.Enums.Role;
-
-function getInitials(name?: string): string {
-  if (!name) return '?';
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 /**
  * Every authenticated panel role (admin, dispatch) lands here — unlike

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  getInitials,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { formatDate } from '@/utils/format';
 import { Badge } from '@/components/ui/badge';
 import { useParams } from 'next/navigation';
@@ -34,16 +40,6 @@ import {
 } from 'lucide-react';
 
 type Role = App.Enums.Role;
-
-function getInitials(name?: string): string {
-  if (!name) return '?';
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 export default function UserDetailPage() {
   const params = useParams();

--- a/app/[lang]/(dashboard)/users/page.tsx
+++ b/app/[lang]/(dashboard)/users/page.tsx
@@ -17,7 +17,13 @@ import {
 } from '@/components/ui/select';
 
 import { useState } from 'react';
-import { actionLabel, modelLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  getInitials,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
 import { formatDate } from '@/utils/format';
 import { useUserList } from '@/hooks/users';
 import { Input } from '@/components/ui/input';
@@ -31,16 +37,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChevronLeft, ChevronRight, Search, Users } from 'lucide-react';
 
 type Role = App.Enums.Role;
-
-function getInitials(name?: string): string {
-  if (!name) return '?';
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 export default function UsersPage() {
   const { t, ready } = useTranslation();

--- a/utils/__tests__/lang.test.ts
+++ b/utils/__tests__/lang.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import {
   capitalize,
+  getInitials,
   getModelGender,
   validationAttribute,
   validationMessage,
@@ -50,6 +51,40 @@ describe('capitalize', () => {
   it('handles strings starting with special characters', () => {
     expect(capitalize('_test')).toBe('_test');
     expect(capitalize('!hello')).toBe('!hello');
+  });
+});
+
+describe('getInitials', () => {
+  it('returns initials for a two-word name', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+  });
+
+  it('returns a single initial for a single-word name', () => {
+    expect(getInitials('John')).toBe('J');
+  });
+
+  it('returns only the first two initials for a multi-word name', () => {
+    expect(getInitials('John Jacob Doe')).toBe('JJ');
+  });
+
+  it('uppercases lowercase names', () => {
+    expect(getInitials('john doe')).toBe('JD');
+  });
+
+  it('returns ? for undefined', () => {
+    expect(getInitials(undefined)).toBe('?');
+  });
+
+  it('returns ? for an empty string', () => {
+    expect(getInitials('')).toBe('?');
+  });
+
+  it('handles extra whitespace between words', () => {
+    expect(getInitials('John  Doe')).toBe('JD');
+  });
+
+  it('handles leading and trailing whitespace', () => {
+    expect(getInitials('  John Doe  ')).toBe('JD');
   });
 });
 

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -14,6 +14,21 @@ export const capitalize = (str: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
+/**
+ * Get up to two uppercase initials from a name, for use in avatar fallbacks.
+ * @param name - The full name (e.g. 'John Doe')
+ * @returns Up to two uppercase initials (e.g. 'JD'), or '?' when no name is given
+ */
+export const getInitials = (name?: string): string => {
+  if (!name) return '?';
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+};
+
 export const validationAttribute = (key: string, toUpper = true) => {
   const translation = i18next.t(`validation:attributes.${key}`);
   return toUpper ? capitalize(translation) : translation;


### PR DESCRIPTION
## Summary
- Adds a single `getInitials` implementation to `utils/lang.ts` (alongside `capitalize` and the other lang string helpers), with JSDoc matching the file's existing style.
- Removes the five identical private `getInitials` copies from `drivers/page.tsx`, `drivers/[id]/page.tsx`, `users/page.tsx`, `users/[id]/page.tsx`, and `profile/page.tsx`, importing the shared helper from `@/utils/lang` instead.
- Adds unit tests for `getInitials` in `utils/__tests__/lang.test.ts` (two-word name, single-word name, 3+ words, lowercase input, undefined/empty string, extra/leading/trailing whitespace).

The five original copies were byte-for-byte identical, so no behavioral differences needed reconciling — extraction is a pure dedupe with no behavior change.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing unrelated warning in `public/firebase-messaging-sw.js` only)
- [x] `npm run test -- --run` — reported below
- [x] `npm run build` — reported below