### PR TITLE
feat(admin): billing cycle, grace period, and block-reason controls

### DIFF
--- a/app/[lang]/(dashboard)/businesses/[id]/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/__tests__/page.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BusinessDetailPage from '../page';
+
+const mutate = vi.fn();
+
+// This page's own params/router come through next/navigation — override the
+// blanket vitest.setup.ts stub so `params.id` resolves to a real business id.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useParams: () => ({ id: 'biz-1', lang: 'en' }),
+  usePathname: () => '',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, ready: true }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  modelLabel: (key: string) => key,
+  resourceMessage: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+vi.mock('@/hooks/auth', () => ({
+  useRole: () => ({ isAdmin: true }),
+}));
+
+vi.mock('@/hooks/tax-profiles', () => ({
+  useBusinessTaxProfile: () => ({ data: undefined }),
+}));
+
+vi.mock('@/hooks/businesses', () => ({
+  useBusiness: () => ({
+    data: {
+      id: 1,
+      publicId: 'biz-1',
+      name: 'Acme',
+      typeId: 1,
+      typeName: 'Retail',
+      usersCanApproveOwnOrders: false,
+      allowedPaymentMethods: [],
+      balance: 0,
+      dispatcherId: null,
+      balanceDebtCeiling: null,
+      billingCycle: 'per_order',
+      gracePeriodDays: null,
+      blockReason: null,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteBusiness: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateBusiness: () => ({ mutate, isPending: false }),
+}));
+
+vi.mock('@/components/TaxProfileCard', () => ({ TaxProfileCard: () => null }));
+vi.mock('@/components/payments/PaymentMethodsCard', () => ({ PaymentMethodsCard: () => null }));
+vi.mock('@/components/dispatch/DispatcherPicker', () => ({ DispatcherPicker: () => null }));
+
+// The billing-select/grace-input mechanics are BalanceCard's own — already
+// covered in components/balance/__tests__/BalanceCard.test.tsx. This page's
+// job is only to shape the payload it hands the update mutation, so the
+// stub exposes exactly the two callbacks that wiring depends on.
+vi.mock('@/components/balance/BalanceCard', () => ({
+  BalanceCard: ({
+    onBillingCycleChange,
+    onGracePeriodDaysChange,
+  }: {
+    onBillingCycleChange?: (value: string) => void;
+    onGracePeriodDaysChange?: (value: number | null) => void;
+  }) => (
+    <div>
+      <button onClick={() => onBillingCycleChange?.('weekly')}>change-cycle</button>
+      <button onClick={() => onGracePeriodDaysChange?.(7)}>change-grace</button>
+    </div>
+  ),
+}));
+
+describe('BusinessDetailPage — billing controls reach the update mutation', () => {
+  beforeEach(() => {
+    mutate.mockClear();
+  });
+
+  it('sends billingCycle under data, keyed by the business id', async () => {
+    const user = userEvent.setup();
+    render(<BusinessDetailPage />);
+
+    await user.click(screen.getByText('change-cycle'));
+
+    expect(mutate).toHaveBeenCalledWith({ id: 'biz-1', data: { billingCycle: 'weekly' } });
+  });
+
+  it('sends gracePeriodDays under data, keyed by the business id', async () => {
+    const user = userEvent.setup();
+    render(<BusinessDetailPage />);
+
+    await user.click(screen.getByText('change-grace'));
+
+    expect(mutate).toHaveBeenCalledWith({ id: 'biz-1', data: { gracePeriodDays: 7 } });
+  });
+});

--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -50,6 +50,20 @@ export default function BusinessDetailPage() {
     });
   };
 
+  const handleChangeBillingCycle = (next: string) => {
+    updateBusiness.mutate({
+      id: businessId,
+      data: { billingCycle: next as App.Enums.BillingCycle },
+    });
+  };
+
+  const handleChangeGracePeriod = (next: number | null) => {
+    updateBusiness.mutate({
+      id: businessId,
+      data: { gracePeriodDays: next },
+    });
+  };
+
   const formatAddress = (address?: App.Data.Address.AddressData | null): string => {
     const notSpecified = t('businesses:detail.not_specified', { defaultValue: 'Not specified' });
     if (!address) return notSpecified;
@@ -208,6 +222,13 @@ export default function BusinessDetailPage() {
           debtCeiling={business.balanceDebtCeiling}
           onDebtCeilingChange={handleChangeDebtCeiling}
           isSavingCeiling={updateBusiness.isPending}
+          billingCycle={business.billingCycle}
+          onBillingCycleChange={handleChangeBillingCycle}
+          isSavingBillingCycle={updateBusiness.isPending}
+          gracePeriodDays={business.gracePeriodDays}
+          onGracePeriodDaysChange={handleChangeGracePeriod}
+          isSavingGracePeriod={updateBusiness.isPending}
+          blockReason={business.blockReason}
         />
 
         {/* Dispatcher */}

--- a/app/[lang]/(dashboard)/users/[id]/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/__tests__/page.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import UserDetailPage from '../page';
+
+const mutate = vi.fn();
+
+// This page's own params/router come through next/navigation — override the
+// blanket vitest.setup.ts stub so `params.id` resolves to a real user id.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useParams: () => ({ id: 'user-1', lang: 'en' }),
+  usePathname: () => '',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, ready: true }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  getInitials: (name?: string) => (name ? name[0] : '?'),
+  modelLabel: (key: string) => key,
+  resourceMessage: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+// isAdmin: false keeps ChangeRoleDialog and the delete button off the tree —
+// neither is relevant here, and BalanceCard (stubbed below) renders
+// unconditionally on this page regardless of role.
+vi.mock('@/hooks/auth', () => ({
+  useRole: () => ({ isAdmin: false }),
+}));
+
+vi.mock('@/hooks/users', () => ({
+  useUser: () => ({
+    data: {
+      id: 1,
+      publicId: 'user-1',
+      role: 'client',
+      name: 'Jane Doe',
+      langCode: 'en',
+      allowedPaymentMethods: [],
+      balance: 0,
+      dispatcherId: null,
+      balanceDebtCeiling: null,
+      billingCycle: 'per_order',
+      gracePeriodDays: null,
+      blockReason: null,
+      isAdmin: false,
+      isBusinessAccount: false,
+      isBusinessOwner: false,
+      isBusinessUser: false,
+      isDriver: false,
+      isClient: true,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteUser: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateUser: () => ({ mutate, isPending: false }),
+  useDispatchUsers: () => ({ data: { items: [] }, isLoading: false }),
+}));
+
+vi.mock('@/components/payments/PaymentMethodsCard', () => ({ PaymentMethodsCard: () => null }));
+vi.mock('@/components/dispatch/DispatcherPicker', () => ({ DispatcherPicker: () => null }));
+
+// The billing-select/grace-input mechanics are BalanceCard's own — already
+// covered in components/balance/__tests__/BalanceCard.test.tsx. This page's
+// job is only to shape the payload it hands the update mutation, so the
+// stub exposes exactly the two callbacks that wiring depends on.
+vi.mock('@/components/balance/BalanceCard', () => ({
+  BalanceCard: ({
+    onBillingCycleChange,
+    onGracePeriodDaysChange,
+  }: {
+    onBillingCycleChange?: (value: string) => void;
+    onGracePeriodDaysChange?: (value: number | null) => void;
+  }) => (
+    <div>
+      <button onClick={() => onBillingCycleChange?.('monthly')}>change-cycle</button>
+      <button onClick={() => onGracePeriodDaysChange?.(14)}>change-grace</button>
+    </div>
+  ),
+}));
+
+describe('UserDetailPage — billing controls reach the update mutation', () => {
+  beforeEach(() => {
+    mutate.mockClear();
+  });
+
+  it('sends billingCycle under data, keyed by the user id', async () => {
+    const user = userEvent.setup();
+    render(<UserDetailPage />);
+
+    await user.click(screen.getByText('change-cycle'));
+
+    expect(mutate).toHaveBeenCalledWith({ id: 'user-1', data: { billingCycle: 'monthly' } });
+  });
+
+  it('sends gracePeriodDays under data, keyed by the user id', async () => {
+    const user = userEvent.setup();
+    render(<UserDetailPage />);
+
+    await user.click(screen.getByText('change-grace'));
+
+    expect(mutate).toHaveBeenCalledWith({ id: 'user-1', data: { gracePeriodDays: 14 } });
+  });
+});

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -76,6 +76,20 @@ export default function UserDetailPage() {
     });
   };
 
+  const handleChangeBillingCycle = (next: string) => {
+    updateUser.mutate({
+      id: userId,
+      data: { billingCycle: next as App.Enums.BillingCycle },
+    });
+  };
+
+  const handleChangeGracePeriod = (next: number | null) => {
+    updateUser.mutate({
+      id: userId,
+      data: { gracePeriodDays: next },
+    });
+  };
+
   const handleDelete = () => {
     if (
       confirm(
@@ -324,6 +338,13 @@ export default function UserDetailPage() {
           debtCeiling={user.balanceDebtCeiling}
           onDebtCeilingChange={handleChangeDebtCeiling}
           isSavingCeiling={updateUser.isPending}
+          billingCycle={user.billingCycle}
+          onBillingCycleChange={handleChangeBillingCycle}
+          isSavingBillingCycle={updateUser.isPending}
+          gracePeriodDays={user.gracePeriodDays}
+          onGracePeriodDaysChange={handleChangeGracePeriod}
+          isSavingGracePeriod={updateUser.isPending}
+          blockReason={user.blockReason}
         />
 
         {/* Timestamps */}

--- a/components/balance/BalanceCard.tsx
+++ b/components/balance/BalanceCard.tsx
@@ -13,9 +13,16 @@ import {
   DialogTitle,
   Dialog,
 } from '@/components/ui/dialog';
+import {
+  SelectContent,
+  SelectTrigger,
+  SelectValue,
+  SelectItem,
+  Select,
+} from '@/components/ui/select';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useBalance, useAdjustBalance } from '@/hooks/balance';
-import { actionLabel, validationAttribute } from '@/utils/lang';
+import { actionLabel, statusLabel, validationAttribute } from '@/utils/lang';
 import { formatCurrency, formatDate } from '@/utils/format';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
@@ -34,6 +41,29 @@ interface BalanceCardProps {
   /** Omit to hide the ceiling control entirely. */
   onDebtCeilingChange?: (value: number | null) => void;
   isSavingCeiling?: boolean;
+  /**
+   * This account's billing cycle (an `App.Enums.BillingCycle` value).
+   * Undefined/null renders as `PerOrder`. Typed as `string`, not the
+   * nominal TS enum — DTO fields pass their raw string value here, which a
+   * nominal enum type would reject at the call site.
+   */
+  billingCycle?: string | null;
+  /** Omit to hide the billing cycle control entirely. */
+  onBillingCycleChange?: (value: string) => void;
+  isSavingBillingCycle?: boolean;
+  /** Days of grace after a failed settlement before the account is blocked. */
+  gracePeriodDays?: number | null;
+  /** Omit to hide the grace period control entirely. */
+  onGracePeriodDaysChange?: (value: number | null) => void;
+  isSavingGracePeriod?: boolean;
+  /**
+   * Why THIS row is blocked from ordering, or null (an
+   * `App.Enums.AccountBlockReason` value, typed as `string` for the same
+   * reason as `billingCycle` above). On a business member this describes
+   * their own account, never the company's — the company's reason lives on
+   * `BusinessData` and is rendered on the business's own card.
+   */
+  blockReason?: string | null;
 }
 
 /**
@@ -48,6 +78,13 @@ export function BalanceCard({
   debtCeiling,
   onDebtCeilingChange,
   isSavingCeiling = false,
+  billingCycle,
+  onBillingCycleChange,
+  isSavingBillingCycle = false,
+  gracePeriodDays,
+  onGracePeriodDaysChange,
+  isSavingGracePeriod = false,
+  blockReason,
 }: BalanceCardProps) {
   const { t } = useTranslation();
   const { data, isLoading } = useBalance(ownerPublicId);
@@ -67,6 +104,7 @@ export function BalanceCard({
         <CardTitle className="flex items-center gap-2 text-base">
           <Wallet className="h-4 w-4" />
           {isDebt ? t('payments:balance.debt_title') : t('payments:balance.title')}
+          <BlockReasonBadge reason={blockReason} />
         </CardTitle>
         {canManage && <GrantCreditDialog ownerPublicId={ownerPublicId} balance={balance} />}
       </CardHeader>
@@ -101,8 +139,121 @@ export function BalanceCard({
             isPending={isSavingCeiling}
           />
         )}
+
+        {canManage && onBillingCycleChange && (
+          <BillingCycleField
+            value={billingCycle}
+            onChange={onBillingCycleChange}
+            isPending={isSavingBillingCycle}
+          />
+        )}
+
+        {canManage && onGracePeriodDaysChange && (
+          <GracePeriodField
+            value={gracePeriodDays ?? null}
+            onChange={onGracePeriodDaysChange}
+            isPending={isSavingGracePeriod}
+          />
+        )}
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Why this account cannot order right now — over its debt ceiling, or a
+ * settlement past its grace period. Renders nothing when the account isn't
+ * blocked, since the absence of a reason is the common case.
+ */
+function BlockReasonBadge({ reason }: { reason?: string | null }) {
+  if (!reason) return null;
+
+  return (
+    <Badge data-testid="block-reason-badge" variant="destructive">
+      {statusLabel(reason)}
+    </Badge>
+  );
+}
+
+/**
+ * How often this account is charged: per order, or on a deferred cycle that
+ * accrues deliveries and settles them together. Options are derived from the
+ * enum itself so a new cycle case can't silently go missing from the list.
+ */
+function BillingCycleField({
+  value,
+  onChange,
+  isPending,
+}: {
+  value?: string | null;
+  onChange: (value: string) => void;
+  isPending: boolean;
+}) {
+  const current = value ?? Enums.BillingCycle.PerOrder;
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="billing-cycle">{validationAttribute('billingCycle', true)}</Label>
+      <Select value={current} onValueChange={onChange} disabled={isPending}>
+        <SelectTrigger id="billing-cycle" className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {Object.values(Enums.BillingCycle).map((cycle) => (
+            <SelectItem key={cycle} value={cycle}>
+              {statusLabel(cycle)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+/**
+ * How many days a deferred account gets after a failed settlement before it
+ * is blocked from ordering. Blank follows the configured default, same as
+ * the debt ceiling above.
+ */
+function GracePeriodField({
+  value,
+  onChange,
+  isPending,
+}: {
+  value: number | null;
+  onChange: (value: number | null) => void;
+  isPending: boolean;
+}) {
+  const [draft, setDraft] = useState(value === null ? '' : String(value));
+
+  const trimmed = draft.trim();
+  const parsed = trimmed === '' ? null : Number(trimmed);
+  const isValid = parsed === null || (Number.isInteger(parsed) && parsed >= 0);
+  const isDirty = (value === null ? '' : String(value)) !== trimmed;
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="grace-period">{validationAttribute('gracePeriodDays', true)}</Label>
+      <div className="flex gap-2">
+        <Input
+          id="grace-period"
+          type="number"
+          step="1"
+          min="0"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={!isValid || !isDirty || isPending}
+          onClick={() => onChange(parsed)}
+        >
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {actionLabel('save')}
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/components/balance/__tests__/BalanceCard.test.tsx
+++ b/components/balance/__tests__/BalanceCard.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BalanceCard } from '../BalanceCard';
+import { Enums } from '@/data/app-enums';
+
+// Radix's Select opens by capturing the pointer on the trigger, which
+// happy-dom doesn't implement — without these the popover silently never
+// opens under test, though it works fine in a real browser.
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// The real helpers resolve translations from the API at runtime (see
+// config/i18next.ts), which this test suite has no server for. Stub them to
+// identity so assertions can target the enum values they were given.
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  statusLabel: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+vi.mock('@/hooks/balance', () => ({
+  useBalance: () => ({
+    data: { balance: 0, entries: [], baseCurrency: 'CRC' },
+    isLoading: false,
+  }),
+  useAdjustBalance: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+describe('BalanceCard — billing cycle select', () => {
+  it('renders an option for every member of Enums.BillingCycle', async () => {
+    const user = userEvent.setup();
+    render(
+      <BalanceCard
+        ownerPublicId="pub-1"
+        canManage
+        billingCycle={Enums.BillingCycle.Weekly}
+        onBillingCycleChange={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'billingCycle' }));
+    const listbox = await screen.findByRole('listbox');
+
+    for (const cycle of Object.values(Enums.BillingCycle)) {
+      expect(within(listbox).getByRole('option', { name: cycle })).toBeInTheDocument();
+    }
+  });
+
+  it('commits the selected cycle through onBillingCycleChange', async () => {
+    const user = userEvent.setup();
+    const onBillingCycleChange = vi.fn();
+    render(
+      <BalanceCard
+        ownerPublicId="pub-1"
+        canManage
+        billingCycle={Enums.BillingCycle.PerOrder}
+        onBillingCycleChange={onBillingCycleChange}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'billingCycle' }));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByRole('option', { name: Enums.BillingCycle.Monthly }));
+
+    expect(onBillingCycleChange).toHaveBeenCalledWith(Enums.BillingCycle.Monthly);
+  });
+
+  it('does not render the billing cycle control when onBillingCycleChange is omitted', () => {
+    render(<BalanceCard ownerPublicId="pub-1" canManage />);
+    expect(screen.queryByRole('combobox', { name: 'billingCycle' })).not.toBeInTheDocument();
+  });
+});
+
+describe('BalanceCard — grace period field', () => {
+  it('saves a new grace period value', async () => {
+    const user = userEvent.setup();
+    const onGracePeriodDaysChange = vi.fn();
+    render(
+      <BalanceCard
+        ownerPublicId="pub-1"
+        canManage
+        gracePeriodDays={3}
+        onGracePeriodDaysChange={onGracePeriodDaysChange}
+      />
+    );
+
+    const input = screen.getByLabelText('gracePeriodDays');
+    await user.clear(input);
+    await user.type(input, '10');
+    await user.click(screen.getByRole('button', { name: 'save' }));
+
+    expect(onGracePeriodDaysChange).toHaveBeenCalledWith(10);
+  });
+
+  it('does not render the grace period control when onGracePeriodDaysChange is omitted', () => {
+    render(<BalanceCard ownerPublicId="pub-1" canManage />);
+    expect(screen.queryByLabelText('gracePeriodDays')).not.toBeInTheDocument();
+  });
+});
+
+describe('BalanceCard — block reason badge', () => {
+  it.each(Object.values(Enums.AccountBlockReason))(
+    'renders a badge for block reason "%s"',
+    (reason) => {
+      render(<BalanceCard ownerPublicId="pub-1" blockReason={reason} />);
+      const badge = screen.getByTestId('block-reason-badge');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(reason);
+    }
+  );
+
+  it('renders nothing when blockReason is null', () => {
+    render(<BalanceCard ownerPublicId="pub-1" blockReason={null} />);
+    expect(screen.queryByTestId('block-reason-badge')).not.toBeInTheDocument();
+  });
+});

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -175,6 +175,9 @@ declare namespace App.Data.Business {
     balance?: number;
     dispatcherId?: number | null;
     balanceDebtCeiling?: number | null;
+    billingCycle?: App.Enums.BillingCycle;
+    gracePeriodDays?: number | null;
+    blockReason?: App.Enums.AccountBlockReason | null;
     createdAt?: string;
     updatedAt?: string;
     deletedAt?: string | null;
@@ -196,6 +199,8 @@ declare namespace App.Data.Business {
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     dispatcherId?: number | null;
     balanceDebtCeiling?: number | null;
+    billingCycle?: App.Enums.BillingCycle;
+    gracePeriodDays?: number | null;
   };
 }
 declare namespace App.Data.Catalog {
@@ -1051,6 +1056,20 @@ declare namespace App.Data.Setting {
     idleGraceMinutes?: number;
   };
 }
+declare namespace App.Data.Settlement {
+  export type SettlementData = {
+    id: number;
+    publicId: string;
+    cutoffAt: string;
+    amount: number;
+    creditApplied: number;
+    netDue: number;
+    currencyCode: string;
+    status: App.Enums.SettlementStatus;
+    failedAt: string | null;
+    createdAt: string;
+  };
+}
 declare namespace App.Data.Shared {
   export type FullLangData = {
     en: string;
@@ -1163,6 +1182,8 @@ declare namespace App.Data.User {
     preferredCurrency?: string | null;
     dispatcherId?: number | null;
     balanceDebtCeiling?: number | null;
+    billingCycle?: App.Enums.BillingCycle;
+    gracePeriodDays?: number | null;
     role?: string;
   };
   export type UserData = {
@@ -1180,6 +1201,9 @@ declare namespace App.Data.User {
     businessId?: number | null;
     dispatcherId?: number | null;
     balanceDebtCeiling?: number | null;
+    billingCycle?: App.Enums.BillingCycle;
+    gracePeriodDays?: number | null;
+    blockReason?: App.Enums.AccountBlockReason | null;
     sexId?: number | null;
     isAdmin: boolean;
     isBusinessAccount: boolean;


### PR DESCRIPTION
## Summary

Slice 5c of the deferred-billing epic (Wave 5.2) — admin billing controls.

- Synced `types/generated.d.ts` byte-for-byte from the api's `epic/deferred-billing` (`cdec534`): `billingCycle`, `gracePeriodDays`, `blockReason` on `BusinessData`/`UserData`; `billingCycle`/`gracePeriodDays` on the update DTOs; the new `App.Data.Settlement.SettlementData` (unused here — that's client's, admin's settlements list is admin#31).
- `BalanceCard`: added a billing-cycle select (options built from `Enums.BillingCycle`, not hand-listed) and a grace-period input (nullable numeric, draft state, explicit save — mirrors `DebtCeilingField`), plus a block-reason badge (renders nothing when `blockReason` is null).
- Wired both detail pages (`businesses/[id]`, `users/[id]`) to pass `value`/`onChange`/`isPending` down, the same way the debt ceiling already does, each shaping its own single-field PATCH payload.
- `blockReason` is rendered exactly as each DTO reports it — no derivation, no second fetch. On a business member this is `null` even when the company is blocked; the company's own reason is not reachable from the user-detail response (verified: `UserController::show()` doesn't include the business relation, and nothing in the api uses Spatie's include mechanism). Filed as admin#32, not worked around here.

## Falsification ledger

None. `docs/architecture.md` was checked against this slice's actual surface (`BusinessData`/`UserData` field shape, `BalanceCard`'s behavior, the enum-select pattern) and contains no passage describing any of it — its "Generated Types" section lists a handful of DTOs/enums as illustrative examples only (`App.Enums.OrderStatus`, `App.Enums.PaymentStatus`, etc.), not an exhaustive field inventory, and nowhere does it describe business/user detail-page contents or the balance card. The decomposition's slice-5c line said this slice "Falsifies `docs/architecture.md` (admin's own)" — grounding against the actual file found no such passage. Reporting this as a contradiction with the brief rather than inventing an edit to justify it.

## Contradicts the brief

- The claim that this slice falsifies `docs/architecture.md` doesn't hold up — see Falsification ledger above. No admin doc needed a ledger entry for this change.

## Named reversals (real output)

**Reversal 1 — billing cycle select, remove a member:** filtered `Enums.BillingCycle.Monthly` out of the options `BillingCycleField` builds. Result:
```
FAIL components/balance/__tests__/BalanceCard.test.tsx > BalanceCard — billing cycle select > renders an option for every member of Enums.BillingCycle
TestingLibraryElementError: Unable to find an accessible element with the role "option" and name "monthly"
```
Restored → 8/8 green.

**Reversal 2 — block badge, null case:** made `BlockReasonBadge` render a badge (text `'none'`) when `reason` is null instead of returning `null`. Result:
```
FAIL components/balance/__tests__/BalanceCard.test.tsx > BalanceCard — block reason badge > renders nothing when blockReason is null
Error: expect(element).not.toBeInTheDocument()
expected document not to contain element, found <span ... data-testid="block-reason-badge">none</span> instead
```
Restored → 8/8 green.

## `diff` against the api's copies (byte-identity)

```
$ diff .../api/resources/types/generated.d.ts types/generated.d.ts   → empty
$ diff .../api/resources/types/response.d.ts types/response.d.ts     → empty
$ diff .../api/resources/types/notifications.d.ts types/notifications.d.ts → empty
```
`response.d.ts` and `notifications.d.ts` needed no copy — already identical, as expected (unchanged by Wave 5).

`npm run gen:enums` confirmed a no-op: `data/app-enums.ts` hash unchanged before/after, `git diff --stat` empty.

## Gate

`npm run check && npm run test:run` — full output posted as a comment on this PR.
