### PR TITLE
fix: exempt api-owned declaration files from prettier and eslint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,9 @@ coverage
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+# API-owned declaration files (byte-identical copies from api/resources/types —
+# never formatted or edited here; see CLAUDE.md cross-project sync)
+types/generated.d.ts
+types/response.d.ts
+types/notifications.d.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const eslintConfig = defineConfig([
     // Generated files (synced from API — never edit manually)
     'types/generated.d.ts',
     'types/response.d.ts',
+    'types/notifications.d.ts',
     'coverage/**',
   ]),
 ]);


### PR DESCRIPTION
## Summary

This repo holds verbatim copies of three declaration files the api owns: `types/generated.d.ts`, `types/response.d.ts`, `types/notifications.d.ts`. Per the workspace `CLAUDE.md` cross-project sync rule, no consumer repo may run its own formatter or linter over them — byte-identity with the api's copies is what makes `diff` a real drift detector. Two tools were violating that here.

- **Closes admin#34** — `format` / `format:check` are both `prettier .` repo-wide and `.prettierignore` had no entry for the three files. `format:check` is half of `npm run check` (the gate), so the gate was asserting prettier formatting over files this repo must not fix, across a prettier major-version boundary with the api (admin 3.7.4, api 3.8.1). They agree today; when they diverge the gate would red on a file nobody here is allowed to touch, and the obvious "fix" (reformatting) would destroy the byte-identity the contract depends on.
- **Closes admin#30** — `eslint.config.mjs`'s `globalIgnores` list covered `types/generated.d.ts` and `types/response.d.ts` but not `types/notifications.d.ts`, leaving eslint free to reach into it.

## Changes

- `.prettierignore`: added `types/generated.d.ts`, `types/response.d.ts`, `types/notifications.d.ts`.
- `eslint.config.mjs`: added `types/notifications.d.ts` to the existing `globalIgnores` list.

No other files touched. The three declaration files themselves are untouched and remain byte-identical to the api's copies (verified before and after — see gate comment).

## Test plan

- [x] `npm run check` (format:check + lint + typecheck) — green
- [x] `npm run test:run` — 13 files / 187 tests — green
- [x] Byte-identity diff of all three declaration files against `api/resources/types/*` — empty before and after
- [x] Named reversal (prettier): `npx prettier --file-info types/generated.d.ts` → `ignored: true` with the fix; `ignored: false` (and actually checked) with `.prettierignore` reverted
- [x] Named reversal (eslint): `npx eslint types/notifications.d.ts` → reports "File ignored because of a matching ignore pattern" with the fix; lints clean with 0 messages with the config reverted