### PR TITLE
fix(refunds): on_account refund approval, and the class string a formatter ate

### DIFF
--- a/components/orders/ApproveRefundRequestDialog.tsx
+++ b/components/orders/ApproveRefundRequestDialog.tsx
@@ -25,11 +25,18 @@ import { Enums } from '@/data/app-enums';
 interface ApproveRefundRequestDialogProps {
   publicId: string;
   orderPublicId: string;
+  /**
+   * The order's payment status. `ON_ACCOUNT` is the one value that changes
+   * what this dialog may offer, because such an order has no payment row for
+   * the settlement lookup below to find.
+   */
+  paymentStatus?: string | null;
 }
 
 export function ApproveRefundRequestDialog({
   publicId,
   orderPublicId,
+  paymentStatus,
 }: ApproveRefundRequestDialogProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -47,9 +54,17 @@ export function ApproveRefundRequestDialog({
     .sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))[0];
   const isManual = settledPayment?.provider === Enums.PaymentProvider.Manual;
 
+  // A delivery billed to an account was never charged, so it has no payment
+  // row at all — the lookup above finds nothing and, left alone, reads that
+  // emptiness as a card payment and offers to reverse a charge that does not
+  // exist. The API branches on this same status and accepts nothing but
+  // credit, so the dialog has to know it before the admin picks.
+  const isOnAccount = paymentStatus === Enums.PaymentStatus.ON_ACCOUNT;
+  const balanceOnly = isOnAccount || isManual;
+
   // The method the admin hasn't explicitly overridden — recomputed from the
   // loaded payment each render rather than synced via an effect.
-  const defaultMethod = getDefaultRefundMethod(isManual);
+  const defaultMethod = getDefaultRefundMethod(balanceOnly);
 
   const [formData, setFormData] = useState({
     method: null as string | null,
@@ -101,7 +116,7 @@ export function ApproveRefundRequestDialog({
 
         <div className="grid gap-4 py-4">
           <RefundMethodFields
-            isManual={isManual}
+            balanceOnly={balanceOnly}
             method={method}
             onMethodChange={(value) => setFormData((prev) => ({ ...prev, method: value }))}
           />

--- a/components/orders/OrderActivityCard.tsx
+++ b/components/orders/OrderActivityCard.tsx
@@ -75,7 +75,15 @@ export function OrderActivityCard({ order }: OrderActivityCardProps) {
             <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
           </div>
         ) : timeline.length > 0 ? (
-          <div className={`space-y-1${hasSchedule ? 'border-t pt-3' : ''}`}>
+          // The space separating the two halves stays outside the ternary.
+          // prettier-plugin-tailwindcss sorts every class string it finds and
+          // trims its edges, so a leading space written inside the branch is
+          // deleted on the next format pass — which is how `space-y-1border-t`
+          // once shipped here, killing both classes.
+          <div
+            data-testid="activity-trail"
+            className={`space-y-1 ${hasSchedule ? 'border-t pt-3' : ''}`}
+          >
             {timeline.map((entry) => (
               <div key={entry.id} className="flex items-center justify-between text-sm">
                 <div className="flex items-center gap-2">

--- a/components/orders/RefundRequestCard.tsx
+++ b/components/orders/RefundRequestCard.tsx
@@ -103,6 +103,7 @@ export function RefundRequestCard({ refundRequest }: RefundRequestCardProps) {
           <ApproveRefundRequestDialog
             publicId={refundRequest.publicId as string}
             orderPublicId={orderPublicId}
+            paymentStatus={order?.paymentStatus}
           />
 
           <DenyRefundRequestDialog publicId={refundRequest.publicId as string} />

--- a/components/orders/__tests__/ApproveRefundRequestDialog.test.tsx
+++ b/components/orders/__tests__/ApproveRefundRequestDialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ApproveRefundRequestDialog } from '../ApproveRefundRequestDialog';
+import { Enums } from '@/data/app-enums';
+
+type PaymentData = App.Data.Payment.PaymentData;
+
+// Radix's Select opens by capturing the pointer on the trigger, which
+// happy-dom doesn't implement — without these the popover silently never
+// opens under test, though it works fine in a real browser.
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+const mutate = vi.fn();
+let payments: PaymentData[] = [];
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+}));
+
+vi.mock('@/hooks/refundRequests', () => ({
+  useApproveRefundRequest: () => ({ mutate, isPending: false }),
+}));
+
+vi.mock('@/hooks/payments', () => ({
+  useOrderPayments: () => ({ data: payments, isLoading: false }),
+}));
+
+const cardPayment = {
+  status: Enums.TransactionStatus.Succeeded,
+  provider: Enums.PaymentProvider.Tilopay,
+  createdAt: '2026-01-01T00:00:00Z',
+} as unknown as PaymentData;
+
+function open(paymentStatus?: string) {
+  return render(
+    <ApproveRefundRequestDialog
+      publicId="rr-1"
+      orderPublicId="ord-1"
+      paymentStatus={paymentStatus}
+    />
+  );
+}
+
+beforeEach(() => {
+  mutate.mockClear();
+  payments = [];
+});
+
+// An account-billed delivery has no payment row at all, so the settled-payment
+// lookup finds nothing. Read as a card payment, the dialog would default to a
+// gateway reversal — which the API answers with a 422 every single time.
+describe('ApproveRefundRequestDialog — an order billed to an account', () => {
+  it('locks the settlement to credit and explains why', async () => {
+    const user = userEvent.setup();
+    open(Enums.PaymentStatus.ON_ACCOUNT);
+
+    await user.click(screen.getByRole('button', { name: 'approve' }));
+
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveTextContent(`payments:refund_method.${Enums.RefundMethod.Balance}`);
+    expect(select).toBeDisabled();
+    expect(screen.getByText('payments:refund.balance_only_hint')).toBeInTheDocument();
+  });
+
+  it('submits the credit method the API accepts', async () => {
+    const user = userEvent.setup();
+    open(Enums.PaymentStatus.ON_ACCOUNT);
+
+    await user.click(screen.getByRole('button', { name: 'approve' }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'approve' }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { publicId: 'rr-1', data: { method: Enums.RefundMethod.Balance } },
+      expect.anything()
+    );
+  });
+});
+
+// The contrast case: a real card charge still defaults to reversing the card,
+// and the admin may still choose credit instead.
+describe('ApproveRefundRequestDialog — an order paid by card', () => {
+  it('defaults to a gateway reversal and leaves the choice open', async () => {
+    const user = userEvent.setup();
+    payments = [cardPayment];
+    open(Enums.PaymentStatus.PAID);
+
+    await user.click(screen.getByRole('button', { name: 'approve' }));
+
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveTextContent(`payments:refund_method.${Enums.RefundMethod.Gateway}`);
+    expect(select).not.toBeDisabled();
+    expect(screen.queryByText('payments:refund.balance_only_hint')).not.toBeInTheDocument();
+  });
+});

--- a/components/orders/__tests__/OrderActivityCard.test.tsx
+++ b/components/orders/__tests__/OrderActivityCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { OrderActivityCard } from '../OrderActivityCard';
+
+type OrderData = App.Data.Order.OrderData;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  statusLabel: (key: string) => key,
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDateTime: (value: string) => value,
+}));
+
+vi.mock('@/hooks/audit-logs', () => ({
+  useAuditLogList: () => ({
+    data: {
+      items: [
+        {
+          id: 1,
+          action: 'created',
+          userName: 'Jane Doe',
+          createdAt: '2026-01-01T00:00:00Z',
+          data: null,
+        },
+      ],
+    },
+    isLoading: false,
+  }),
+}));
+
+function orderWith(overrides: Partial<OrderData>): OrderData {
+  return { id: 1, ...overrides } as OrderData;
+}
+
+// prettier-plugin-tailwindcss rewrites class strings inside template literals,
+// and once ate the leading space of the conditional half — emitting
+// `space-y-1border-t pt-3`, which kills both `space-y-1` and `border-t`.
+// Asserting on the individual classes is what catches that: a fused
+// `space-y-1border-t` token matches neither.
+describe('OrderActivityCard — activity trail separator', () => {
+  it('keeps spacing and separator classes distinct when the order has a schedule', () => {
+    render(<OrderActivityCard order={orderWith({ desiredPickupAt: '2026-01-02T10:00:00Z' })} />);
+
+    const trail = screen.getByTestId('activity-trail');
+    expect(trail).toHaveClass('space-y-1');
+    expect(trail).toHaveClass('border-t');
+    expect(trail).toHaveClass('pt-3');
+  });
+
+  it('keeps the spacing class and drops the separator when there is no schedule', () => {
+    render(<OrderActivityCard order={orderWith({})} />);
+
+    const trail = screen.getByTestId('activity-trail');
+    expect(trail).toHaveClass('space-y-1');
+    expect(trail).not.toHaveClass('border-t');
+    expect(trail).not.toHaveClass('pt-3');
+  });
+});

--- a/components/payments/RefundDialog.tsx
+++ b/components/payments/RefundDialog.tsx
@@ -165,7 +165,7 @@ export function RefundDialog({ payment, onSuccess }: RefundDialogProps) {
 
           {/* How the refund is settled */}
           <RefundMethodFields
-            isManual={isManual}
+            balanceOnly={isManual}
             method={formData.method}
             onMethodChange={(value) => handleChange('method', value)}
           />

--- a/components/payments/RefundMethodFields.tsx
+++ b/components/payments/RefundMethodFields.tsx
@@ -19,19 +19,25 @@ export function getRefundMethodLabel(t: TFunction, method?: string | null): stri
 }
 
 /**
- * Default settlement for a payment.
+ * Default settlement for a refund.
  *
- * A manually-settled payment can only go to balance. A card payment defaults
- * to reversing the card — turning someone's card payment into account balance
- * is a deliberate choice, not a default.
+ * `balanceOnly` means there is no gateway charge behind this money, so there
+ * is nothing a provider could send back — the refund can only become credit.
+ * Anything else defaults to reversing the card: turning someone's card payment
+ * into account balance is a deliberate choice, not a default.
  */
-export function getDefaultRefundMethod(isManual: boolean): string {
-  return isManual ? Enums.RefundMethod.Balance : Enums.RefundMethod.Gateway;
+export function getDefaultRefundMethod(balanceOnly: boolean): string {
+  return balanceOnly ? Enums.RefundMethod.Balance : Enums.RefundMethod.Gateway;
 }
 
 interface RefundMethodFieldsProps {
-  /** Whether the underlying payment was settled manually (provider === Manual). */
-  isManual: boolean;
+  /**
+   * Whether credit is the only settlement the API will accept — no gateway
+   * charge stands behind the money. True for a manually-settled payment
+   * (provider === Manual) and for a delivery billed to an account, which has
+   * no payment row at all.
+   */
+  balanceOnly: boolean;
   method: string;
   onMethodChange: (method: string) => void;
 }
@@ -40,20 +46,24 @@ interface RefundMethodFieldsProps {
  * How a refund is settled.
  *
  * A card payment may be reversed to the card or kept on the customer's
- * balance — the admin picks, since they speak to the customer directly. A
- * manually-settled payment can only go to balance: there was no charge to
- * reverse, and money is never sent back out by hand, so the select locks.
+ * balance — the admin picks, since they speak to the customer directly. When
+ * no card was ever charged the select locks to balance: there is nothing to
+ * reverse, and money is never sent back out by hand.
  */
-export function RefundMethodFields({ isManual, method, onMethodChange }: RefundMethodFieldsProps) {
+export function RefundMethodFields({
+  balanceOnly,
+  method,
+  onMethodChange,
+}: RefundMethodFieldsProps) {
   const { t } = useTranslation();
-  const options = isManual
+  const options = balanceOnly
     ? [Enums.RefundMethod.Balance]
     : [Enums.RefundMethod.Gateway, Enums.RefundMethod.Balance];
 
   return (
     <div className="grid gap-2">
       <Label htmlFor="refund-method">{t('payments:refund.method_label')} *</Label>
-      <Select value={method} onValueChange={onMethodChange} disabled={isManual}>
+      <Select value={method} onValueChange={onMethodChange} disabled={balanceOnly}>
         <SelectTrigger id="refund-method" className="w-full">
           <SelectValue placeholder={t('payments:refund.method_placeholder')} />
         </SelectTrigger>
@@ -65,7 +75,7 @@ export function RefundMethodFields({ isManual, method, onMethodChange }: RefundM
           ))}
         </SelectContent>
       </Select>
-      {isManual && (
+      {balanceOnly && (
         <p className="text-muted-foreground text-xs">{t('payments:refund.balance_only_hint')}</p>
       )}
     </div>

--- a/hooks/refundRequests/__tests__/useApproveRefundRequest.test.tsx
+++ b/hooks/refundRequests/__tests__/useApproveRefundRequest.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { toast } from 'sonner';
+
+import { useApproveRefundRequest } from '../useApproveRefundRequest';
+import { RefundRequestService } from '@/services/refundRequestService';
+import { Enums } from '@/data/app-enums';
+import { ApiError } from '@/lib/api/error';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/services/refundRequestService', () => ({
+  RefundRequestService: { approve: vi.fn() },
+}));
+
+// The real helpers resolve translations from the API at runtime (see
+// config/i18next.ts), which this test suite has no server for.
+vi.mock('@/utils/lang', () => ({
+  crudSuccessMessage: (action: string, resource: string) => `${action}:${resource}`,
+  crudErrorMessage: (action: string, resource: string) => `${action}:${resource}`,
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function approve() {
+  const { result } = renderHook(() => useApproveRefundRequest(), { wrapper });
+  result.current.mutate({ publicId: 'rr-1', data: { method: Enums.RefundMethod.Gateway } });
+  return result;
+}
+
+beforeEach(() => {
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(RefundRequestService.approve).mockReset();
+});
+
+// Every refusal the API returns here is one the admin can act on — a gateway
+// refund on an account-billed delivery, a charge already given back — and each
+// arrives already translated. Replacing it with a generic "error approving"
+// throws away the only part that says what to do differently.
+describe('useApproveRefundRequest — refusal reporting', () => {
+  it("shows the API's own explanation when the approval is refused", async () => {
+    const refusal =
+      'A delivery billed to an account was never charged to a card, so there is nothing to reverse — it can only be refunded as credit.';
+    vi.mocked(RefundRequestService.approve).mockRejectedValue(new ApiError(refusal, 422));
+
+    approve();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith(refusal);
+  });
+
+  it('falls back to the generic message when the failure carries none', async () => {
+    vi.mocked(RefundRequestService.approve).mockRejectedValue(new Error('Network request failed'));
+
+    approve();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith('approving:refund_request');
+  });
+});

--- a/hooks/refundRequests/__tests__/useDenyRefundRequest.test.tsx
+++ b/hooks/refundRequests/__tests__/useDenyRefundRequest.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { toast } from 'sonner';
+
+import { useDenyRefundRequest } from '../useDenyRefundRequest';
+import { RefundRequestService } from '@/services/refundRequestService';
+import { ApiError } from '@/lib/api/error';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/services/refundRequestService', () => ({
+  RefundRequestService: { deny: vi.fn() },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function deny() {
+  const { result } = renderHook(() => useDenyRefundRequest(), { wrapper });
+  result.current.mutate({ publicId: 'rr-1', adminNotes: null });
+  return result;
+}
+
+beforeEach(() => {
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(RefundRequestService.deny).mockReset();
+});
+
+// The denial endpoint refuses for one reason the admin can act on — the
+// request was already resolved, usually by another admin — and it arrives
+// already translated. Reporting "failed to deny" in its place hides the fact
+// that the work is already done.
+describe('useDenyRefundRequest — refusal reporting', () => {
+  it("shows the API's own explanation when the denial is refused", async () => {
+    const refusal = 'This refund request has already been resolved.';
+    vi.mocked(RefundRequestService.deny).mockRejectedValue(new ApiError(refusal, 422));
+
+    deny();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith(refusal);
+  });
+
+  it('falls back to the generic message when the failure carries none', async () => {
+    vi.mocked(RefundRequestService.deny).mockRejectedValue(new Error('Network request failed'));
+
+    deny();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith('resource:error.updating');
+  });
+});

--- a/hooks/refundRequests/useApproveRefundRequest.ts
+++ b/hooks/refundRequests/useApproveRefundRequest.ts
@@ -4,6 +4,7 @@ import {
   type ApproveRefundRequestParams,
 } from '@/services/refundRequestService';
 import { toast } from 'sonner';
+import { isApiError } from '@/lib/api/error';
 import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
 
 interface ApproveRefundRequestArgs {
@@ -22,8 +23,16 @@ export function useApproveRefundRequest() {
       queryClient.invalidateQueries({ queryKey: ['orders'] });
       toast.success(crudSuccessMessage('approved', 'refund_request'));
     },
-    onError: () => {
-      toast.error(crudErrorMessage('approving', 'refund_request'));
+    // The API refuses an approval for reasons the admin can act on — a
+    // gateway refund on an account-billed delivery, a charge already given
+    // back — and each one arrives already translated. A generic "error
+    // approving" in its place tells them nothing about what to change.
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage('approving', 'refund_request'));
+      }
     },
   });
 }

--- a/hooks/refundRequests/useDenyRefundRequest.ts
+++ b/hooks/refundRequests/useDenyRefundRequest.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { RefundRequestService } from '@/services/refundRequestService';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
+import { isApiError } from '@/lib/api/error';
 
 export function useDenyRefundRequest() {
   const { t } = useTranslation();
@@ -15,7 +16,16 @@ export function useDenyRefundRequest() {
       queryClient.invalidateQueries({ queryKey: ['orders'] });
       toast.success(t('payments:refund_request.denied', { defaultValue: 'Refund request denied' }));
     },
-    onError: () => {
+    // A denial can be refused for reasons the admin can act on — a request
+    // another admin already resolved, most of all — and the message arrives
+    // already translated. The generic fallback stays for a transport failure,
+    // which carries nothing worth showing.
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+        return;
+      }
+
       toast.error(
         t('resource:error.updating', {
           count: 1,


### PR DESCRIPTION
Two admin defects off the deferred-billing contract review, plus one ledger item folded in at the coordinator's request.

Closes #36
Closes #37

## #36 — approving a refund on an `on_account` order

An `on_account` order has no `Payment` row: the api stamps `ON_ACCOUNT` at approval and `PaymentService::initiatePayment()` refuses before creating anything. `ApproveRefundRequestDialog` resolved its settlement from that empty payment list, read the emptiness as a card payment, and pre-selected `RefundMethod.Gateway` with both options unlocked and the credit-only hint suppressed. `RefundRequestController::approveOnAccount()` branches on the same `payment_status` and refuses anything but `Balance` with a 422 — so every admin who accepted the default got one.

**The lock, generalized rather than duplicated.** A manually-settled payment already gets exactly this treatment, driven by a single `isManual` boolean through `getDefaultRefundMethod()`, the `Select`'s `disabled`, and the `balance_only_hint`. That prop is now `balanceOnly` — one signal meaning *no gateway charge stands behind this money*, raised by either cause. `RefundDialog` (payment-scoped, where only manual settlement can raise it) passes `balanceOnly={isManual}`; the approve dialog passes `isOnAccount || isManual`, with `isOnAccount` compared against `Enums.PaymentStatus.ON_ACCOUNT` from the generated mirror. `RefundRequestCard` already had `order.paymentStatus` in hand for its badge and now hands it to the dialog.

**The reason reaching the screen.** `useApproveRefundRequest`'s `onError: () => toast.error(crudErrorMessage(...))` threw the api's message away, so the three translated `on_account_gateway_not_allowed` strings added this arc could never be read. It now follows the house pattern — `isApiError(error) ? error.message : crudErrorMessage(...)` — identical to `useProcessRefund`, `useVoidPayment`, `useRecordPayment` and ~20 other hooks.

## #37 — the prettier pass that ate a class

`prettier-plugin-tailwindcss` sorts every class string it finds, interpolated ternary branches included, and trims their edges. Commit `e43d51a` deleted the leading space in `${hasSchedule ? ' border-t pt-3' : ''}`, emitting `space-y-1border-t pt-3` — a fused token that kills both `space-y-1` and `border-t`, leaving only `pt-3`.

Restoring the space would be eaten again on the next format run. The separator now lives in the static half (`` `space-y-1 ${…}` ``), where the plugin does not reach — which is what every other conditional class string in the tree already does (`BalanceCard`, `NeedsAttentionCard`, `QuoteLineItemsEditor`, …). `cn()` is durable too but is confined to `components/ui/` primitives plus three files; the template literal is the house pattern for feature components.

Durability confirmed: `npx prettier --write components/orders/OrderActivityCard.tsx` reports `(unchanged)` and leaves the file byte-identical (sha `970a1b92…` before and after).

> **Note on `data-testid="activity-trail"`.** The `div` carries a new `data-testid`. It is a **test hook, not a styling or behavioural hook** — nothing in the app reads it, and it exists so the test can assert on the class list without selecting by the very classes under test. It matches the existing `data-testid="block-reason-badge"` in `BalanceCard`. Safe to keep; do not build styling on it.

## Folded in from the ledger — `useDenyRefundRequest`

Same defect as the approve half of #36, one file over: the error was discarded and a generic "failed to deny" shown. The denial endpoint refuses for exactly one reason and it is one the admin needs to read — `payments.refund_request.already_resolved`, the request having been resolved by another admin. Told only "failed", they retry work that is already done.

The fallback is **kept as-is** rather than moved to `crudErrorMessage`: this hook composes its own `resource:error.updating` message and there is no `resource:error.denying` key to move it to. Only the branch preferring the api's own message is new.

## Named reversals

Each applied, observed red, and reverted.

| # | Reversal applied | Observed failure |
|---|---|---|
| 1 | `const balanceOnly = isOnAccount \|\| isManual` → `= isManual` | 2 of 3 red. `toHaveTextContent`: expected `payments:refund_method.balance`, received `…gateway`; submitted `method: "gateway"` instead of `"balance"` |
| 2 | `useApproveRefundRequest.onError` back to the bare `crudErrorMessage('approving', 'refund_request')` | 1 of 2 red. `toast.error` called with `"approving:refund_request"` instead of the api's refusal text |
| 3 | `` `space-y-1 ${…}` `` → `` `space-y-1${…}` `` | 1 of 2 red. `toHaveClass('space-y-1')`: received `space-y-1border-t pt-3` |
| 4 | `useDenyRefundRequest.onError` back to the bare `t('resource:error.updating', …)` | 1 of 2 red. `toast.error` called with `"resource:error.updating"` instead of `"This refund request has already been resolved."` |

On 2 and 4 the *fallback* case stayed green under the reversal, which is what confirms the two branches are genuinely distinguished rather than the assertion tracking whatever the hook happens to emit. #37 additionally clears the formatter bar above.

## Gate

`npm run check` — format:check, lint, typecheck all clean, exit 0.
`npm run test:run` — **17 files, 196 tests, 0 failures**, exit 0 (187 before; 9 new: 3 dialog, 2 approve hook, 2 deny hook, 2 activity card).

No api-owned declaration file was touched (`types/generated.d.ts`, `types/response.d.ts`, `types/notifications.d.ts` untouched and still prettier-ignored). `Enums.PaymentStatus.ON_ACCOUNT` was already present in this branch's generated types — no type sync needed.

## Falsification ledger

### Investigated and closed — no admin-side fix exists

**`RefundRequestCard` shows no amount on a customer-raised refund for an account-billed order.** Investigated on the coordinator's steer; the conclusion is that the number is *not* in hand and this needs an api change.

- `refundRequest.amount` **is** on the payload (`RefundRequestData.amount`), and `RefundRequestCard` **already reaches for it** — `const owed = refundRequest.amount ?? null` renders whenever it is non-null. A **system-raised** request on an `on_account` order therefore displays its figure correctly today. No gap there.
- The gap is confined to a **customer-raised** request, where `amount` is null *by API design*. The DTO says so outright: `/** The specific sum owed; null on a customer request, meaning everything refundable. */`.
- In that branch the card falls back to `order.totalPaid`, and `Order::getTotalPaidAttribute()` sums `payments` with status `Succeeded`. An account-billed order has no payments, so `totalPaid` is `0` and the `totalPaid > 0` guard renders nothing.
- The figure the api would actually refund comes from `BalanceService::refundableDeferredCharge($order)`. It is on **no** payload admin holds — `OrderData` carries no deferred-charge or refundable field, and `getOrderDueAmount()` returns the quote total, which is not the same number once a partial refund exists.
- The client repo's `RefundStateCard` does the identical `refundRequest.amount ?? null` with **no fallback at all**, so it shows nothing in the same case. It does not demonstrate the number is available — it has the same gap.

Stopping here as instructed rather than inventing a fetch or substituting the quote total. **This needs `refundableAmount` (or equivalent) exposed on `RefundRequestData` or `OrderData` — an api change for a later wave.**

### Left alone by direction

- **`balance_only_hint` names cash/SINPE as the reason.** The api string reads *"Refunds on a cash or SINPE payment are always issued as credit."* An account-billed delivery was neither. The claim it makes (credit only) is true, but the reason is wrong for this case. Needs a new `payments.php` key in en/es/fr — an api-repo change, folded into an api wave by the coordinator.
- **`PaymentSection` renders "No payments recorded for this order"** for an account-billed order (`PaymentSection.tsx:271`). Literally true, but reads as *nothing was ever owed*. No false affordance results — the per-payment Refund button is scoped to a payment row and so correctly never appears. Stays a note.

Checked and clean: the api's 422 was the only *failing* path. Nothing else in the refund flow offers an action an `on_account` order cannot complete.
