### PR TITLE
chore(agents): onboard to the current worktree.json contract

### DIFF
--- a/.agents/worktree.json
+++ b/.agents/worktree.json
@@ -1,6 +1,23 @@
 {
+  "envFiles": [".env.local"],
   "install": "npm ci",
   "gate": "npm run check && npm run test:run",
   "scopedCheck": "npm run check",
-  "envFiles": []
+  "format": "npm run format",
+  "sharedResources": [],
+  "frameworkSkills": [
+    {
+      "skill": "vercel:nextjs",
+      "when": "Next.js 16 App Router work — routing, layouts, Server Components, middleware, data fetching, rendering strategy"
+    },
+    {
+      "skill": "vercel:shadcn",
+      "when": "components/ui/* — the shadcn/ui + Radix primitives this repo vendors (components.json is present)"
+    },
+    {
+      "skill": "vercel:react-best-practices",
+      "when": "React component/hook work outside components/ui — re-render cost, bundle size, effect and state patterns"
+    }
+  ],
+  "briefConventions": "docs/strict-rules.md and CLAUDE.md are in this repo — read both. types/generated.d.ts, types/response.d.ts and types/notifications.d.ts are generated in the api repo and copied here byte-identical: never hand-edit them and never run a formatter over them (.prettierignore enforces this). Layering is api (lib/api/) -> services/ -> hooks/. Wait for a store's `hydrated: true` before rendering. Use applyApiErrorsToForm() to bridge API errors into react-hook-form. Use the i18n helpers (actionLabel, modelLabel, crudSuccessMessage), never a raw t() for those, and register any new namespace in config/i18next.ts. Use Enums.EnumName.Value from @/data/app-enums for runtime comparisons, never a magic string."
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,10 @@ coverage
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+# Generated in the api repo (`php artisan typescript:transform`) and copied here
+# byte-identical. Formatting them here rewrites the copy and destroys the `diff`
+# that detects real drift against the api source. See the workspace CLAUDE.md.
+types/generated.d.ts
+types/response.d.ts
+types/notifications.d.ts


### PR DESCRIPTION
Brings `.agents/worktree.json` up to the current contract. It was written to the older minimal shape (`install`, `gate`, `scopedCheck`, `envFiles`) and is missing everything the contract has grown since.

## `sharedResources: []` — the one value that cannot be read off a lockfile

`[]` is not the same as omitting the key. Omitting it says nobody asked; `[]` says somebody asked and the checks touch nothing outside their own tree. A dispatcher reads the second as licence to fan out, so it is stated deliberately. Grounded on:

- `vitest.config.ts` — `environment: 'happy-dom'`, everything in-process. No `globalSetup`, no server, no fixtures on disk.
- `vitest.setup.ts` — `next/navigation` and `localStorage` are mocked.
- All 10 test files are pure unit tests under `utils/`, `services/` and `lib/api/`. Nothing binds a port, opens a socket, reaches a database, a queue or a bucket.
- Vitest's cache resolves to `node_modules/.vite` — **inside** the worktree, confirmed by inspection after a run.
- **Empirically:** a second worktree was cut off the same base and the gate run in both with a fully overlapping window (both started within 0.2s of each other, both ran ~26s). Both green, no infrastructure-shaped failure.

`reclaim` is therefore omitted, which is *derived* from `sharedResources` being `[]` rather than a question nobody asked: nothing durable is created outside a worktree, so there is nothing to sweep.

## `epicMerge` — omitted, and the reason is structural

`release/0.1.0` **is this repository's default branch on GitHub**. `epicMerge` governs exactly one merge — an epic branch collapsing back into the integration branch — and only when that integration branch is not the default branch. Here they are the same branch, so the key is inert whatever it says. Omitting it is a fact about the repo, not a preference.

## `env` — omitted

No Turborepo, no Nx, no `turbo.json`. Next.js keeps its build cache in `.next/cache`, inside the worktree, with no environment variable to relocate it to a shared directory. There is no build cache worth sharing across worktrees, so the example's `TURBO_CACHE_DIR` entry was not copied.

## The `.prettierignore` change is load-bearing, not tidying

`format` is run in *write* mode right before every commit. `npm run format` here is `prettier --write .`, and `.prettierignore` did not exclude the three api-owned type files — so declaring `format` without this guard would have made "reformat the api's generated types" a step in every single commit.

Measured before the guard: `prettier --check types/*.d.ts` flagged `response.d.ts` and `notifications.d.ts`. Those two are **byte-identical to `api/resources/types/`** today, and rewriting them here destroys the `diff` that detects real drift against the api source — the exact thing the workspace `CLAUDE.md` forbids. With the guard, `npm run format` leaves them untouched (verified with `cmp`).

## ⚠️ Pre-existing red baseline — not fixed here

`npm run check` (the declared `scopedCheck`, and the first half of the declared `gate`) **exits 1 on an untouched `release/0.1.0`**. `prettier --check .` flags **17 source files** that do not match this repo's own `.prettierrc`, and `check` short-circuits there — so `lint` and `typecheck` never run.

This guard removes 2 of the original 19 (the api-owned types). The other 17 are genuine formatting drift in `app/`, `components/`, `config/`, `content/guide/*.md`, `public/sw.js` and `public/offline.html`, and they are left alone on purpose: `prettier --write .` would rewrite markdown content and a service worker, which deserves its own reviewed commit rather than a rider on a config PR.

**Until it is fixed, every implementer dispatched into an admin worktree fails its scoped check on code it never touched.** The fix is one command on a branch of its own:

```
npm run format
```

For the record, everything past the format step is green: `lint`, `typecheck` and `test:run` (10 files, 175 tests) all pass.

## What was verified, and what was not

Verified empirically in a fresh worktree cut with `setup-worktree.sh feature/agents-config release/0.1.0`:

- the worktree's HEAD equals the `release/0.1.0` tip
- `npm ci` completes and `node_modules` is populated
- every declared command resolves and runs
- each declared `envFiles` path exists in the main checkout, is gitignored, and the checks behave identically with it symlinked in

**Not verified: the config path itself.** `setup-worktree.sh` reads `.agents/worktree.json` from the **main checkout's working tree**, not from the branch under review — so this change cannot be exercised through the helper until it merges. That is a documented property of the helper, not a bug, and reaching into the main checkout to make it see the change early is forbidden shared mutable state. The effect of every new key was therefore applied by hand in the worktree and checked that way. `envFiles` in particular was proven by creating the symlinks manually, not by the helper creating them.

## Not applicable here

`enqueue` / `drain` are absent because this repo has no gate queue, and none was invented for it. A dispatcher reads that absence as **in-line gating**: the implementer runs `gate` itself in the foreground and posts the result as a comment on its own draft PR. The PR is still a draft at hand-back; only who runs the gate changes.
