### PR TITLE
fix(balance): sync generated types to the credit contract

### DIFF
--- a/app/[lang]/(dashboard)/businesses/[id]/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/__tests__/page.test.tsx
@@ -53,9 +53,8 @@ vi.mock('@/hooks/businesses', () => ({
       allowedPaymentMethods: [],
       balance: 0,
       dispatcherId: null,
-      balanceDebtCeiling: null,
+      balanceLimit: null,
       billingCycle: 'per_order',
-      gracePeriodDays: null,
       blockReason: null,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
@@ -71,21 +70,14 @@ vi.mock('@/components/TaxProfileCard', () => ({ TaxProfileCard: () => null }));
 vi.mock('@/components/payments/PaymentMethodsCard', () => ({ PaymentMethodsCard: () => null }));
 vi.mock('@/components/dispatch/DispatcherPicker', () => ({ DispatcherPicker: () => null }));
 
-// The billing-select/grace-input mechanics are BalanceCard's own — already
-// covered in components/balance/__tests__/BalanceCard.test.tsx. This page's
-// job is only to shape the payload it hands the update mutation, so the
-// stub exposes exactly the two callbacks that wiring depends on.
+// The billing-select mechanics are BalanceCard's own — already covered in
+// components/balance/__tests__/BalanceCard.test.tsx. This page's job is only
+// to shape the payload it hands the update mutation, so the stub exposes
+// exactly the callback that wiring depends on.
 vi.mock('@/components/balance/BalanceCard', () => ({
-  BalanceCard: ({
-    onBillingCycleChange,
-    onGracePeriodDaysChange,
-  }: {
-    onBillingCycleChange?: (value: string) => void;
-    onGracePeriodDaysChange?: (value: number | null) => void;
-  }) => (
+  BalanceCard: ({ onBillingCycleChange }: { onBillingCycleChange?: (value: string) => void }) => (
     <div>
       <button onClick={() => onBillingCycleChange?.('weekly')}>change-cycle</button>
-      <button onClick={() => onGracePeriodDaysChange?.(7)}>change-grace</button>
     </div>
   ),
 }));
@@ -102,14 +94,5 @@ describe('BusinessDetailPage — billing controls reach the update mutation', ()
     await user.click(screen.getByText('change-cycle'));
 
     expect(mutate).toHaveBeenCalledWith({ id: 'biz-1', data: { billingCycle: 'weekly' } });
-  });
-
-  it('sends gracePeriodDays under data, keyed by the business id', async () => {
-    const user = userEvent.setup();
-    render(<BusinessDetailPage />);
-
-    await user.click(screen.getByText('change-grace'));
-
-    expect(mutate).toHaveBeenCalledWith({ id: 'biz-1', data: { gracePeriodDays: 7 } });
   });
 });

--- a/app/[lang]/(dashboard)/businesses/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/businesses/[id]/page.tsx
@@ -43,10 +43,10 @@ export default function BusinessDetailPage() {
     });
   };
 
-  const handleChangeDebtCeiling = (next: number | null) => {
+  const handleChangeBalanceLimit = (next: number | null) => {
     updateBusiness.mutate({
       id: businessId,
-      data: { balanceDebtCeiling: next },
+      data: { balanceLimit: next },
     });
   };
 
@@ -54,13 +54,6 @@ export default function BusinessDetailPage() {
     updateBusiness.mutate({
       id: businessId,
       data: { billingCycle: next as App.Enums.BillingCycle },
-    });
-  };
-
-  const handleChangeGracePeriod = (next: number | null) => {
-    updateBusiness.mutate({
-      id: businessId,
-      data: { gracePeriodDays: next },
     });
   };
 
@@ -219,15 +212,12 @@ export default function BusinessDetailPage() {
         <BalanceCard
           ownerPublicId={business.publicId}
           canManage={isAdmin}
-          debtCeiling={business.balanceDebtCeiling}
-          onDebtCeilingChange={handleChangeDebtCeiling}
-          isSavingCeiling={updateBusiness.isPending}
+          balanceLimit={business.balanceLimit}
+          onBalanceLimitChange={handleChangeBalanceLimit}
+          isSavingLimit={updateBusiness.isPending}
           billingCycle={business.billingCycle}
           onBillingCycleChange={handleChangeBillingCycle}
           isSavingBillingCycle={updateBusiness.isPending}
-          gracePeriodDays={business.gracePeriodDays}
-          onGracePeriodDaysChange={handleChangeGracePeriod}
-          isSavingGracePeriod={updateBusiness.isPending}
           blockReason={business.blockReason}
         />
 

--- a/app/[lang]/(dashboard)/users/[id]/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/__tests__/page.test.tsx
@@ -52,9 +52,8 @@ vi.mock('@/hooks/users', () => ({
       allowedPaymentMethods: [],
       balance: 0,
       dispatcherId: null,
-      balanceDebtCeiling: null,
+      balanceLimit: null,
       billingCycle: 'per_order',
-      gracePeriodDays: null,
       blockReason: null,
       isAdmin: false,
       isBusinessAccount: false,
@@ -76,21 +75,14 @@ vi.mock('@/hooks/users', () => ({
 vi.mock('@/components/payments/PaymentMethodsCard', () => ({ PaymentMethodsCard: () => null }));
 vi.mock('@/components/dispatch/DispatcherPicker', () => ({ DispatcherPicker: () => null }));
 
-// The billing-select/grace-input mechanics are BalanceCard's own — already
-// covered in components/balance/__tests__/BalanceCard.test.tsx. This page's
-// job is only to shape the payload it hands the update mutation, so the
-// stub exposes exactly the two callbacks that wiring depends on.
+// The billing-select mechanics are BalanceCard's own — already covered in
+// components/balance/__tests__/BalanceCard.test.tsx. This page's job is only
+// to shape the payload it hands the update mutation, so the stub exposes
+// exactly the callback that wiring depends on.
 vi.mock('@/components/balance/BalanceCard', () => ({
-  BalanceCard: ({
-    onBillingCycleChange,
-    onGracePeriodDaysChange,
-  }: {
-    onBillingCycleChange?: (value: string) => void;
-    onGracePeriodDaysChange?: (value: number | null) => void;
-  }) => (
+  BalanceCard: ({ onBillingCycleChange }: { onBillingCycleChange?: (value: string) => void }) => (
     <div>
       <button onClick={() => onBillingCycleChange?.('monthly')}>change-cycle</button>
-      <button onClick={() => onGracePeriodDaysChange?.(14)}>change-grace</button>
     </div>
   ),
 }));
@@ -107,14 +99,5 @@ describe('UserDetailPage — billing controls reach the update mutation', () => 
     await user.click(screen.getByText('change-cycle'));
 
     expect(mutate).toHaveBeenCalledWith({ id: 'user-1', data: { billingCycle: 'monthly' } });
-  });
-
-  it('sends gracePeriodDays under data, keyed by the user id', async () => {
-    const user = userEvent.setup();
-    render(<UserDetailPage />);
-
-    await user.click(screen.getByText('change-grace'));
-
-    expect(mutate).toHaveBeenCalledWith({ id: 'user-1', data: { gracePeriodDays: 14 } });
   });
 });

--- a/app/[lang]/(dashboard)/users/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/users/[id]/page.tsx
@@ -69,10 +69,10 @@ export default function UserDetailPage() {
     });
   };
 
-  const handleChangeDebtCeiling = (next: number | null) => {
+  const handleChangeBalanceLimit = (next: number | null) => {
     updateUser.mutate({
       id: userId,
-      data: { balanceDebtCeiling: next },
+      data: { balanceLimit: next },
     });
   };
 
@@ -80,13 +80,6 @@ export default function UserDetailPage() {
     updateUser.mutate({
       id: userId,
       data: { billingCycle: next as App.Enums.BillingCycle },
-    });
-  };
-
-  const handleChangeGracePeriod = (next: number | null) => {
-    updateUser.mutate({
-      id: userId,
-      data: { gracePeriodDays: next },
     });
   };
 
@@ -335,15 +328,12 @@ export default function UserDetailPage() {
         <BalanceCard
           ownerPublicId={user.publicId}
           canManage={isAdmin}
-          debtCeiling={user.balanceDebtCeiling}
-          onDebtCeilingChange={handleChangeDebtCeiling}
-          isSavingCeiling={updateUser.isPending}
+          balanceLimit={user.balanceLimit}
+          onBalanceLimitChange={handleChangeBalanceLimit}
+          isSavingLimit={updateUser.isPending}
           billingCycle={user.billingCycle}
           onBillingCycleChange={handleChangeBillingCycle}
           isSavingBillingCycle={updateUser.isPending}
-          gracePeriodDays={user.gracePeriodDays}
-          onGracePeriodDaysChange={handleChangeGracePeriod}
-          isSavingGracePeriod={updateUser.isPending}
           blockReason={user.blockReason}
         />
 

--- a/components/balance/BalanceCard.tsx
+++ b/components/balance/BalanceCard.tsx
@@ -36,11 +36,11 @@ interface BalanceCardProps {
   ownerPublicId: string;
   /** Whether the viewer may move the balance. Grant/void is admin-only. */
   canManage?: boolean;
-  /** This account's own debt ceiling, or null when it follows the default. */
-  debtCeiling?: number | null;
-  /** Omit to hide the ceiling control entirely. */
-  onDebtCeilingChange?: (value: number | null) => void;
-  isSavingCeiling?: boolean;
+  /** This account's own balance limit, or null when it follows the default. */
+  balanceLimit?: number | null;
+  /** Omit to hide the limit control entirely. */
+  onBalanceLimitChange?: (value: number | null) => void;
+  isSavingLimit?: boolean;
   /**
    * This account's billing cycle (an `App.Enums.BillingCycle` value).
    * Undefined/null renders as `PerOrder`. Typed as `string`, not the
@@ -51,11 +51,6 @@ interface BalanceCardProps {
   /** Omit to hide the billing cycle control entirely. */
   onBillingCycleChange?: (value: string) => void;
   isSavingBillingCycle?: boolean;
-  /** Days of grace after a failed settlement before the account is blocked. */
-  gracePeriodDays?: number | null;
-  /** Omit to hide the grace period control entirely. */
-  onGracePeriodDaysChange?: (value: number | null) => void;
-  isSavingGracePeriod?: boolean;
   /**
    * Why THIS row is blocked from ordering, or null (an
    * `App.Enums.AccountBlockReason` value, typed as `string` for the same
@@ -75,15 +70,12 @@ interface BalanceCardProps {
 export function BalanceCard({
   ownerPublicId,
   canManage = false,
-  debtCeiling,
-  onDebtCeilingChange,
-  isSavingCeiling = false,
+  balanceLimit,
+  onBalanceLimitChange,
+  isSavingLimit = false,
   billingCycle,
   onBillingCycleChange,
   isSavingBillingCycle = false,
-  gracePeriodDays,
-  onGracePeriodDaysChange,
-  isSavingGracePeriod = false,
   blockReason,
 }: BalanceCardProps) {
   const { t } = useTranslation();
@@ -132,11 +124,11 @@ export function BalanceCard({
           </ul>
         )}
 
-        {canManage && onDebtCeilingChange && (
-          <DebtCeilingField
-            value={debtCeiling ?? null}
-            onChange={onDebtCeilingChange}
-            isPending={isSavingCeiling}
+        {canManage && onBalanceLimitChange && (
+          <BalanceLimitField
+            value={balanceLimit ?? null}
+            onChange={onBalanceLimitChange}
+            isPending={isSavingLimit}
           />
         )}
 
@@ -147,23 +139,15 @@ export function BalanceCard({
             isPending={isSavingBillingCycle}
           />
         )}
-
-        {canManage && onGracePeriodDaysChange && (
-          <GracePeriodField
-            value={gracePeriodDays ?? null}
-            onChange={onGracePeriodDaysChange}
-            isPending={isSavingGracePeriod}
-          />
-        )}
       </CardContent>
     </Card>
   );
 }
 
 /**
- * Why this account cannot order right now — over its debt ceiling, or a
- * settlement past its grace period. Renders nothing when the account isn't
- * blocked, since the absence of a reason is the common case.
+ * Why this account cannot order right now — over its balance limit, or a
+ * settlement past due. Renders nothing when the account isn't blocked, since
+ * the absence of a reason is the common case.
  */
 function BlockReasonBadge({ reason }: { reason?: string | null }) {
   if (!reason) return null;
@@ -211,53 +195,6 @@ function BillingCycleField({
 }
 
 /**
- * How many days a deferred account gets after a failed settlement before it
- * is blocked from ordering. Blank follows the configured default, same as
- * the debt ceiling above.
- */
-function GracePeriodField({
-  value,
-  onChange,
-  isPending,
-}: {
-  value: number | null;
-  onChange: (value: number | null) => void;
-  isPending: boolean;
-}) {
-  const [draft, setDraft] = useState(value === null ? '' : String(value));
-
-  const trimmed = draft.trim();
-  const parsed = trimmed === '' ? null : Number(trimmed);
-  const isValid = parsed === null || (Number.isInteger(parsed) && parsed >= 0);
-  const isDirty = (value === null ? '' : String(value)) !== trimmed;
-
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor="grace-period">{validationAttribute('gracePeriodDays', true)}</Label>
-      <div className="flex gap-2">
-        <Input
-          id="grace-period"
-          type="number"
-          step="1"
-          min="0"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-        />
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={!isValid || !isDirty || isPending}
-          onClick={() => onChange(parsed)}
-        >
-          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          {actionLabel('save')}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-/**
  * How far this account may go into debt before it is refused a new order.
  *
  * Blank means the account follows the configured default, which is what
@@ -265,7 +202,7 @@ function GracePeriodField({
  * curve: a long-standing business that has earned more rope, and someone who
  * has walked away from a debt once and has earned less.
  */
-function DebtCeilingField({
+function BalanceLimitField({
   value,
   onChange,
   isPending,
@@ -284,16 +221,16 @@ function DebtCeilingField({
 
   return (
     <div className="border-border grid gap-2 border-t pt-4">
-      <Label htmlFor="debt-ceiling">{validationAttribute('balanceDebtCeiling', true)}</Label>
+      <Label htmlFor="balance-limit">{validationAttribute('balanceLimit', true)}</Label>
       <div className="flex gap-2">
         <Input
-          id="debt-ceiling"
+          id="balance-limit"
           type="number"
           step="0.01"
           min="0"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          placeholder={t('payments:balance.ceiling_default')}
+          placeholder={t('payments:balance.limit_default')}
         />
         <Button
           size="sm"
@@ -305,18 +242,12 @@ function DebtCeilingField({
           {actionLabel('save')}
         </Button>
       </div>
-      <p className="text-muted-foreground text-xs">{t('payments:balance.ceiling_hint')}</p>
+      <p className="text-muted-foreground text-xs">{t('payments:balance.limit_hint')}</p>
     </div>
   );
 }
 
-function CreditEntryRow({
-  entry,
-  symbol,
-}: {
-  entry: App.Data.Balance.BalanceEntryData;
-  symbol: string;
-}) {
+function CreditEntryRow({ entry, symbol }: { entry: App.Data.Credit.CreditData; symbol: string }) {
   const { t } = useTranslation();
   const amount = entry.amount ?? 0;
   const isCredit = amount >= 0;
@@ -324,7 +255,7 @@ function CreditEntryRow({
   return (
     <li className="flex items-start justify-between gap-3 py-2">
       <div className="space-y-0.5">
-        <Badge variant="outline">{t(`payments:balance_entry_type.${entry.type}`)}</Badge>
+        <Badge variant="outline">{t(`payments:credit_type.${entry.type}`)}</Badge>
         {entry.notes && <p className="text-muted-foreground text-xs">{entry.notes}</p>}
         {entry.createdAt && (
           <p className="text-muted-foreground text-xs">{formatDate(entry.createdAt)}</p>
@@ -341,19 +272,19 @@ function CreditEntryRow({
 function GrantCreditDialog({ ownerPublicId, balance }: { ownerPublicId: string; balance: number }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [type, setType] = useState<string>(Enums.BalanceEntryType.AdminGrant);
+  const [type, setType] = useState<string>(Enums.CreditType.AdminGrant);
   const [amount, setAmount] = useState('');
   const [notes, setNotes] = useState('');
   const grant = useAdjustBalance();
 
   const parsed = parseFloat(amount);
-  const isVoid = type === Enums.BalanceEntryType.AdminVoid;
+  const isVoid = type === Enums.CreditType.AdminVoid;
   const isValid =
     !isNaN(parsed) && parsed > 0 && notes.trim().length >= 3 && (!isVoid || parsed <= balance);
 
   const handleOpenChange = (isOpen: boolean) => {
     if (isOpen) {
-      setType(Enums.BalanceEntryType.AdminGrant);
+      setType(Enums.CreditType.AdminGrant);
       setAmount('');
       setNotes('');
     }
@@ -388,19 +319,19 @@ function GrantCreditDialog({ ownerPublicId, balance }: { ownerPublicId: string; 
               type="button"
               variant={isVoid ? 'outline' : 'default'}
               size="sm"
-              onClick={() => setType(Enums.BalanceEntryType.AdminGrant)}
+              onClick={() => setType(Enums.CreditType.AdminGrant)}
             >
               <Plus className="mr-1 h-4 w-4" />
-              {t('payments:balance_entry_type.admin_grant')}
+              {t('payments:credit_type.admin_grant')}
             </Button>
             <Button
               type="button"
               variant={isVoid ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setType(Enums.BalanceEntryType.AdminVoid)}
+              onClick={() => setType(Enums.CreditType.AdminVoid)}
             >
               <Minus className="mr-1 h-4 w-4" />
-              {t('payments:balance_entry_type.admin_void')}
+              {t('payments:credit_type.admin_void')}
             </Button>
           </div>
 

--- a/components/balance/__tests__/BalanceCard.test.tsx
+++ b/components/balance/__tests__/BalanceCard.test.tsx
@@ -80,33 +80,6 @@ describe('BalanceCard — billing cycle select', () => {
   });
 });
 
-describe('BalanceCard — grace period field', () => {
-  it('saves a new grace period value', async () => {
-    const user = userEvent.setup();
-    const onGracePeriodDaysChange = vi.fn();
-    render(
-      <BalanceCard
-        ownerPublicId="pub-1"
-        canManage
-        gracePeriodDays={3}
-        onGracePeriodDaysChange={onGracePeriodDaysChange}
-      />
-    );
-
-    const input = screen.getByLabelText('gracePeriodDays');
-    await user.clear(input);
-    await user.type(input, '10');
-    await user.click(screen.getByRole('button', { name: 'save' }));
-
-    expect(onGracePeriodDaysChange).toHaveBeenCalledWith(10);
-  });
-
-  it('does not render the grace period control when onGracePeriodDaysChange is omitted', () => {
-    render(<BalanceCard ownerPublicId="pub-1" canManage />);
-    expect(screen.queryByLabelText('gracePeriodDays')).not.toBeInTheDocument();
-  });
-});
-
 describe('BalanceCard — block reason badge', () => {
   it.each(Object.values(Enums.AccountBlockReason))(
     'renders a badge for block reason "%s"',

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -2,7 +2,7 @@
 // Source: /types/generated.d.ts -> App.Enums
 export const Enums = {
   AccountBlockReason: {
-    DebtCeiling: 'debt_ceiling',
+    BalanceLimit: 'balance_limit',
     SettlementOverdue: 'settlement_overdue',
   },
   AddressType: {
@@ -91,19 +91,6 @@ export const Enums = {
     DELIVERY: 'delivery',
     INSTRUCTIONS: 'instructions',
   },
-  BalanceEntryType: {
-    RefundGrant: 'refund_grant',
-    AdminGrant: 'admin_grant',
-    OrderApplication: 'order_application',
-    ApplicationReversal: 'application_reversal',
-    AdminVoid: 'admin_void',
-    CancellationFee: 'cancellation_fee',
-    UnderCollection: 'under_collection',
-    DebtSettlement: 'debt_settlement',
-    DeferredCharge: 'deferred_charge',
-    SettlementApplication: 'settlement_application',
-    DeferredChargeReversal: 'deferred_charge_reversal',
-  },
   BillingCycle: {
     PerOrder: 'per_order',
     Weekly: 'weekly',
@@ -120,6 +107,14 @@ export const Enums = {
     TimeSensitiveViolation: 'time_sensitive_violation',
     OutsideOperatingHours: 'outside_operating_hours',
     OutsideDriverShift: 'outside_driver_shift',
+  },
+  CreditType: {
+    RefundGrant: 'refund_grant',
+    AdminGrant: 'admin_grant',
+    OrderApplication: 'order_application',
+    ApplicationReversal: 'application_reversal',
+    AdminVoid: 'admin_void',
+    PeriodBillApplication: 'period_bill_application',
   },
   CrudAction: {
     Retrieved: 'retrieved',
@@ -228,6 +223,7 @@ export const Enums = {
     Notification: 'notification',
     Payment: 'payment',
     PaymentMethod: 'payment_method',
+    PeriodBill: 'period_bill',
     Refund: 'refund',
     Route: 'route',
     RouteStop: 'route_stop',
@@ -242,8 +238,8 @@ export const Enums = {
     Invoice: 'invoice',
     InvoiceItem: 'invoice_item',
     RefundRequest: 'refund_request',
-    BalanceEntry: 'balance_entry',
-    Settlement: 'settlement',
+    Credit: 'credit',
+    PaymentDestination: 'payment_destination',
   },
   NotificationAction: {
     QuoteRequested: 'quote_requested',
@@ -336,6 +332,14 @@ export const Enums = {
     VOIDED: 'voided',
     CHARGEBACK: 'chargeback',
   },
+  PeriodBillStatus: {
+    Open: 'open',
+    Issued: 'issued',
+    AwaitingVerification: 'awaiting_verification',
+    Paid: 'paid',
+    Failed: 'failed',
+    Uncollectible: 'uncollectible',
+  },
   PricingCalculationMode: {
     CUMULATIVE: 'cumulative',
     DISCRETE: 'discrete',
@@ -415,11 +419,11 @@ export const Enums = {
     Reassigned: 'reassigned',
     Rescheduled: 'rescheduled',
   },
-  SettlementStatus: {
-    Pending: 'pending',
-    Paid: 'paid',
-    Failed: 'failed',
-    PartiallyPaid: 'partially_paid',
+  SettlementMethod: {
+    Card: 'card',
+    SinpeMobile: 'sinpe_mobile',
+    Transferencia: 'transferencia',
+    Cash: 'cash',
   },
   TipoIdentificacion: {
     Fisica: '01',

--- a/hooks/balance/useAdjustBalance.ts
+++ b/hooks/balance/useAdjustBalance.ts
@@ -15,13 +15,13 @@ export function useAdjustBalance() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['balance'] });
       queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast.success(crudSuccessMessage('created', 'balance_entry'));
+      toast.success(crudSuccessMessage('created', 'credit'));
     },
     onError: (error) => {
       if (isApiError(error)) {
         toast.error(error.message);
       } else {
-        toast.error(crudErrorMessage('creating', 'balance_entry'));
+        toast.error(crudErrorMessage('creating', 'credit'));
       }
     },
   });

--- a/services/balanceService.ts
+++ b/services/balanceService.ts
@@ -1,11 +1,11 @@
 import { api } from '@/lib/api/client';
 
-type BalanceEntryData = App.Data.Balance.BalanceEntryData;
+type CreditData = App.Data.Credit.CreditData;
 type Multiple<T> = Api.Response.Multiple<T>;
 type Single<T> = Api.Response.Single<T>;
 
 export interface BalanceLedger {
-  entries: BalanceEntryData[];
+  entries: CreditData[];
   /** Balance in base currency. */
   balance: number;
   baseCurrency: string | null;
@@ -27,7 +27,7 @@ export const BalanceService = {
    */
   async list(ownerPublicId?: string): Promise<BalanceLedger> {
     const query = ownerPublicId ? `?owner=${encodeURIComponent(ownerPublicId)}` : '';
-    const response = await api.get<Multiple<BalanceEntryData>>(`/balance${query}`);
+    const response = await api.get<Multiple<CreditData>>(`/balance${query}`);
 
     const extra = (response.extra ?? {}) as { balance?: number; baseCurrency?: string | null };
 
@@ -39,8 +39,8 @@ export const BalanceService = {
   },
 
   /** Add or remove balance by hand (admin only). */
-  async grant(data: AdjustBalanceParams): Promise<BalanceEntryData> {
-    const response = await api.post<Single<BalanceEntryData>>('/balance', {
+  async grant(data: AdjustBalanceParams): Promise<CreditData> {
+    const response = await api.post<Single<CreditData>>('/balance', {
       ownerPublicId: data.ownerPublicId,
       amount: data.amount,
       type: data.type,

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -142,27 +142,6 @@ declare namespace App.Data.Auth {
     password: string;
   };
 }
-declare namespace App.Data.Balance {
-  export type BalanceEntryData = {
-    id?: number;
-    publicId?: string;
-    type?: App.Enums.BalanceEntryType;
-    amount?: number;
-    originalAmount?: number | null;
-    originalCurrency?: string | null;
-    fxRate?: number | null;
-    sourceRefundId?: number | null;
-    appliedOrderId?: number | null;
-    notes?: string | null;
-    createdAt?: string;
-  };
-  export type StoreBalanceEntryData = {
-    ownerPublicId: string;
-    amount: number;
-    type: App.Enums.BalanceEntryType;
-    notes: string | null;
-  };
-}
 declare namespace App.Data.Business {
   export type BusinessData = {
     id: number;
@@ -174,9 +153,8 @@ declare namespace App.Data.Business {
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     balance?: number;
     dispatcherId?: number | null;
-    balanceDebtCeiling?: number | null;
+    balanceLimit?: number | null;
     billingCycle?: App.Enums.BillingCycle;
-    gracePeriodDays?: number | null;
     blockReason?: App.Enums.AccountBlockReason | null;
     createdAt?: string;
     updatedAt?: string;
@@ -198,9 +176,8 @@ declare namespace App.Data.Business {
     usersCanApproveOwnOrders?: boolean;
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     dispatcherId?: number | null;
-    balanceDebtCeiling?: number | null;
+    balanceLimit?: number | null;
     billingCycle?: App.Enums.BillingCycle;
-    gracePeriodDays?: number | null;
   };
 }
 declare namespace App.Data.Catalog {
@@ -273,6 +250,27 @@ declare namespace App.Data.Chat {
     imageUrl: string | null;
     createdAt: string;
     user?: App.Data.User.UserData;
+  };
+}
+declare namespace App.Data.Credit {
+  export type CreditData = {
+    id?: number;
+    publicId?: string;
+    type?: App.Enums.CreditType;
+    amount?: number;
+    originalAmount?: number | null;
+    originalCurrency?: string | null;
+    fxRate?: number | null;
+    sourceRefundId?: number | null;
+    appliedOrderId?: number | null;
+    notes?: string | null;
+    createdAt?: string;
+  };
+  export type StoreCreditData = {
+    ownerPublicId: string;
+    amount: number;
+    type: App.Enums.CreditType;
+    notes: string | null;
   };
 }
 declare namespace App.Data.Currency {
@@ -639,7 +637,7 @@ declare namespace App.Data.Order {
   };
   export type StoreOrderData = {
     deliveryAddress: App.Data.Address.StoreSnapshotAddressData;
-    currencyCode: string;
+    currencyCode?: string;
     contactName?: string;
     contactPhone?: string;
     desiredDeliveryAt: string | null;
@@ -759,6 +757,50 @@ declare namespace App.Data.Payment {
     amount: number;
     method: App.Enums.RefundMethod;
     reason: string | null;
+  };
+}
+declare namespace App.Data.PaymentDestination {
+  export type PaymentDestinationData = {
+    id?: number;
+    method?: App.Enums.SettlementMethod;
+    currencyCode?: string | null;
+    phoneNumber?: string | null;
+    bankName?: string | null;
+    accountNumber?: string | null;
+    iban?: string | null;
+    holderName?: string;
+    legalId?: string;
+    maxAmount?: number | null;
+    active?: boolean;
+    sortOrder?: number;
+    createdAt?: string;
+    updatedAt?: string;
+    deletedAt?: string | null;
+  };
+  export type StorePaymentDestinationData = {
+    method: App.Enums.SettlementMethod;
+    currencyCode?: string | null;
+    phoneNumber?: string | null;
+    bankName?: string | null;
+    accountNumber?: string | null;
+    iban?: string | null;
+    holderName: string;
+    legalId: string;
+    maxAmount?: number | null;
+    active?: boolean;
+    sortOrder?: number | null;
+  };
+  export type UpdatePaymentDestinationData = {
+    currencyCode?: string | null;
+    phoneNumber?: string | null;
+    bankName?: string | null;
+    accountNumber?: string | null;
+    iban?: string | null;
+    holderName?: string;
+    legalId?: string;
+    maxAmount?: number | null;
+    active?: boolean;
+    sortOrder?: number | null;
   };
 }
 declare namespace App.Data.Pricing {
@@ -1056,20 +1098,6 @@ declare namespace App.Data.Setting {
     idleGraceMinutes?: number;
   };
 }
-declare namespace App.Data.Settlement {
-  export type SettlementData = {
-    id: number;
-    publicId: string;
-    cutoffAt: string;
-    amount: number;
-    creditApplied: number;
-    netDue: number;
-    currencyCode: string;
-    status: App.Enums.SettlementStatus;
-    failedAt: string | null;
-    createdAt: string;
-  };
-}
 declare namespace App.Data.Shared {
   export type FullLangData = {
     en: string;
@@ -1181,9 +1209,8 @@ declare namespace App.Data.User {
     allowedPaymentMethods?: Array<App.Enums.PaymentMethodType>;
     preferredCurrency?: string | null;
     dispatcherId?: number | null;
-    balanceDebtCeiling?: number | null;
+    balanceLimit?: number | null;
     billingCycle?: App.Enums.BillingCycle;
-    gracePeriodDays?: number | null;
     role?: string;
   };
   export type UserData = {
@@ -1200,9 +1227,8 @@ declare namespace App.Data.User {
     balance?: number;
     businessId?: number | null;
     dispatcherId?: number | null;
-    balanceDebtCeiling?: number | null;
+    balanceLimit?: number | null;
     billingCycle?: App.Enums.BillingCycle;
-    gracePeriodDays?: number | null;
     blockReason?: App.Enums.AccountBlockReason | null;
     sexId?: number | null;
     isAdmin: boolean;
@@ -1225,7 +1251,7 @@ declare namespace App.Data.User {
 }
 declare namespace App.Enums {
   export enum AccountBlockReason {
-    DebtCeiling = 'debt_ceiling',
+    BalanceLimit = 'balance_limit',
     SettlementOverdue = 'settlement_overdue',
   }
   export enum AddressType {
@@ -1314,19 +1340,6 @@ declare namespace App.Enums {
     DELIVERY = 'delivery',
     INSTRUCTIONS = 'instructions',
   }
-  export enum BalanceEntryType {
-    RefundGrant = 'refund_grant',
-    AdminGrant = 'admin_grant',
-    OrderApplication = 'order_application',
-    ApplicationReversal = 'application_reversal',
-    AdminVoid = 'admin_void',
-    CancellationFee = 'cancellation_fee',
-    UnderCollection = 'under_collection',
-    DebtSettlement = 'debt_settlement',
-    DeferredCharge = 'deferred_charge',
-    SettlementApplication = 'settlement_application',
-    DeferredChargeReversal = 'deferred_charge_reversal',
-  }
   export enum BillingCycle {
     PerOrder = 'per_order',
     Weekly = 'weekly',
@@ -1343,6 +1356,14 @@ declare namespace App.Enums {
     TimeSensitiveViolation = 'time_sensitive_violation',
     OutsideOperatingHours = 'outside_operating_hours',
     OutsideDriverShift = 'outside_driver_shift',
+  }
+  export enum CreditType {
+    RefundGrant = 'refund_grant',
+    AdminGrant = 'admin_grant',
+    OrderApplication = 'order_application',
+    ApplicationReversal = 'application_reversal',
+    AdminVoid = 'admin_void',
+    PeriodBillApplication = 'period_bill_application',
   }
   export enum CrudAction {
     Retrieved = 'retrieved',
@@ -1451,6 +1472,7 @@ declare namespace App.Enums {
     Notification = 'notification',
     Payment = 'payment',
     PaymentMethod = 'payment_method',
+    PeriodBill = 'period_bill',
     Refund = 'refund',
     Route = 'route',
     RouteStop = 'route_stop',
@@ -1465,8 +1487,8 @@ declare namespace App.Enums {
     Invoice = 'invoice',
     InvoiceItem = 'invoice_item',
     RefundRequest = 'refund_request',
-    BalanceEntry = 'balance_entry',
-    Settlement = 'settlement',
+    Credit = 'credit',
+    PaymentDestination = 'payment_destination',
   }
   export enum NotificationAction {
     QuoteRequested = 'quote_requested',
@@ -1559,6 +1581,14 @@ declare namespace App.Enums {
     VOIDED = 'voided',
     CHARGEBACK = 'chargeback',
   }
+  export enum PeriodBillStatus {
+    Open = 'open',
+    Issued = 'issued',
+    AwaitingVerification = 'awaiting_verification',
+    Paid = 'paid',
+    Failed = 'failed',
+    Uncollectible = 'uncollectible',
+  }
   export enum PricingCalculationMode {
     CUMULATIVE = 'cumulative',
     DISCRETE = 'discrete',
@@ -1638,11 +1668,11 @@ declare namespace App.Enums {
     Reassigned = 'reassigned',
     Rescheduled = 'rescheduled',
   }
-  export enum SettlementStatus {
-    Pending = 'pending',
-    Paid = 'paid',
-    Failed = 'failed',
-    PartiallyPaid = 'partially_paid',
+  export enum SettlementMethod {
+    Card = 'card',
+    SinpeMobile = 'sinpe_mobile',
+    Transferencia = 'transferencia',
+    Cash = 'cash',
   }
   export enum TipoIdentificacion {
     Fisica = '01',


### PR DESCRIPTION
## Summary

Syncs admin's three generated type files to api `epic/deferred-billing@684eb58` (BalanceEntry -> Credit, balanceDebtCeiling -> balanceLimit, gracePeriodDays and the settlement model removed) and repairs everything the sync breaks, including the gracePeriodDays control which was already writing to a field the API doesn't have on any account DTO.

- `types/{generated,response,notifications}.d.ts` copied byte-identical from api, `npm run gen:enums` run against the fresh `generated.d.ts`
- `App.Data.Balance.BalanceEntryData` -> `App.Data.Credit.CreditData`, `Enums.BalanceEntryType` -> `Enums.CreditType` (values unchanged) in `BalanceCard` and `balanceService`
- `balanceDebtCeiling` -> `balanceLimit` on both detail pages and `BalanceCard`; `DebtCeilingField` renamed `BalanceLimitField` to match what it edits
- Locale keys: `payments:balance_entry_type.*` -> `payments:credit_type.*`, `payments:balance.ceiling_default/hint` -> `limit_default/hint`, `crudSuccessMessage`/`crudErrorMessage` model key `balance_entry` -> `credit`
- Removed the `gracePeriodDays` control entirely (props, field component, page handlers, tests) — see "UI removed" below

## UI removed (judgement call — please review)

`GracePeriodField` in `BalanceCard.tsx`, plus its props (`gracePeriodDays`, `onGracePeriodDaysChange`, `isSavingGracePeriod`) and the `handleChangeGracePeriod` handlers on both the business and user detail pages. None of the four account DTOs (`BusinessData`, `UpdateBusinessData`, `UserData`, `UpdateUserData`) carry this field any more — it was removed outright in api, not renamed — so the control was PATCHing a field that no longer exists. Deleted rather than left dangling.

## Verify

- Gate (`npm run check && npm run test:run`): green, run in the foreground
- All three generated files `diff` byte-identical against api's at `684eb58`
- Sweeps (`/usr/bin/grep`), all zero in live code: `balanceDebtCeiling`, `gracePeriodDays`, `BalanceEntryData`, `BalanceEntryType`, `App.Data.Balance`, `debt_ceiling`, `balance_entry_type`, `balance_entry`, `ceiling_default`, `ceiling_hint`, `SettlementStatus`, `App.Data.Settlement`
- Every changed locale key confirmed present in api's `lang/{en,es,fr}/payments.php` and `validation.php`
- Test count: 196 before -> 192 after (4 tests removed, all for the deleted gracePeriodDays control — no other test touched or weakened)