### PR TITLE
fix(types): sync generated.d.ts and notifications.d.ts to api contract

### DIFF
--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -267,10 +267,9 @@ export const Enums = {
     RefundRequestDenied: 'refund_request_denied',
     BalanceCredited: 'balance_credited',
     RefundDue: 'refund_due',
-    RefundSettled: 'refund_settled',
-    SettlementCharged: 'settlement_charged',
-    SettlementFailed: 'settlement_failed',
-    SettlementBlockWarning: 'settlement_block_warning',
+    PeriodBillClosed: 'period_bill_closed',
+    PeriodBillDueSoon: 'period_bill_due_soon',
+    PeriodBillDeclarationResolved: 'period_bill_declaration_resolved',
   },
   NotificationStatus: {
     Unread: 'unread',

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -803,6 +803,38 @@ declare namespace App.Data.PaymentDestination {
     sortOrder?: number | null;
   };
 }
+declare namespace App.Data.PeriodBill {
+  export type PeriodBillData = {
+    id: number;
+    publicId: string;
+    cutoffAt: string;
+    dueAt: string | null;
+    baseAmount: number;
+    creditApplied: number;
+    netDue: number;
+    isOverdue: boolean;
+    currencyCode: string | null;
+    provider: App.Enums.PaymentProvider | null;
+    providerChargeId: string | null;
+    chargeUnresolvedAt: string | null;
+    status: App.Enums.PeriodBillStatus;
+    settlementMethod: App.Enums.SettlementMethod | null;
+    reference: string | null;
+    proofPath: string | null;
+    proofUrl: string | null;
+    notes?: string | null;
+    perCurrencyTotals?: Record<string, { amount: number; baseAmount: number }>;
+    lines?: Array<App.Data.PeriodBill.PeriodBillLineData>;
+  };
+  export type PeriodBillLineData = {
+    id: number;
+    orderPublicId: string;
+    amount: number;
+    currencyCode: string;
+    fxRate: number | null;
+    baseAmount: number;
+  };
+}
 declare namespace App.Data.Pricing {
   export type PricingRuleData = {
     id?: number;
@@ -1516,10 +1548,9 @@ declare namespace App.Enums {
     RefundRequestDenied = 'refund_request_denied',
     BalanceCredited = 'balance_credited',
     RefundDue = 'refund_due',
-    RefundSettled = 'refund_settled',
-    SettlementCharged = 'settlement_charged',
-    SettlementFailed = 'settlement_failed',
-    SettlementBlockWarning = 'settlement_block_warning',
+    PeriodBillClosed = 'period_bill_closed',
+    PeriodBillDueSoon = 'period_bill_due_soon',
+    PeriodBillDeclarationResolved = 'period_bill_declaration_resolved',
   }
   export enum NotificationStatus {
     Unread = 'unread',

--- a/types/notifications.d.ts
+++ b/types/notifications.d.ts
@@ -227,38 +227,37 @@ declare namespace Api.Broadcast {
     notes: string | null;
   }
 
-  /** settlement.charged */
-  export interface SettlementCharged extends Base {
-    settlementId: number;
-    settlementPublicId: string;
-    /** What the period's deliveries came to, gross, in base currency. */
-    amount: number;
-    /** How much of `amount` the account's own credit covered. */
+  /** period_bill.closed */
+  export interface PeriodBillClosed extends Base {
+    periodBillId: number;
+    periodBillPublicId: string;
+    /** The bill's total, in base currency. */
+    total: number;
+    /** How much of `total` the account's own credit covered. */
     creditApplied: number;
-    /** What actually left the card: `amount - creditApplied`. */
-    charged: number;
-    currency: string;
-    cutoffAt: string;
+    /** What is actually owed: `total - creditApplied`. */
+    amountDue: number;
+    /** Null only for a bill that somehow reaches the wire before `close()` stamps it. */
+    dueAt: string | null;
   }
 
-  /** settlement.failed */
-  export interface SettlementFailed extends Base {
-    settlementId: number;
-    settlementPublicId: string;
-    /** The figure the card was asked for, net of any credit applied. */
-    amount: number;
-    currency: string;
-    /** When the account stops being able to order if this is still unpaid. */
-    blockedFrom: string;
+  /** period_bill.due_soon */
+  export interface PeriodBillDueSoon extends Base {
+    periodBillId: number;
+    periodBillPublicId: string;
+    amountDue: number;
+    dueAt: string | null;
   }
 
-  /** settlement.block_warning */
-  export interface SettlementBlockWarning extends Base {
-    settlementId: number;
-    settlementPublicId: string;
-    amount: number;
-    currency: string;
-    blockedFrom: string;
+  /** period_bill.declaration_resolved */
+  export interface PeriodBillDeclarationResolved extends Base {
+    periodBillId: number;
+    periodBillPublicId: string;
+    /** Distinguishes the two outcomes — approved and rejected read identically otherwise. */
+    approved: boolean;
+    /** Set only on a rejection; a re-upload with no reason helps nobody. */
+    reason: string | null;
+    dueAt: string | null;
   }
 
   /** Union of all broadcast notification payloads. */
@@ -288,7 +287,7 @@ declare namespace Api.Broadcast {
     | RefundRequestResolved
     | BalanceCredited
     | RefundDue
-    | SettlementCharged
-    | SettlementFailed
-    | SettlementBlockWarning;
+    | PeriodBillClosed
+    | PeriodBillDueSoon
+    | PeriodBillDeclarationResolved;
 }


### PR DESCRIPTION
Refs #243

Two-file copy plus a regenerator run, in order:

1. Copied `types/generated.d.ts` and `types/notifications.d.ts` byte-for-byte from the api epic worktree's `resources/types/` at `e113a6c`. `types/response.d.ts` was already identical and is left untouched.
2. Ran `npm run gen:enums` against the freshly copied `generated.d.ts` to regenerate `data/app-enums.ts`.
3. Ran the gate (`npm run check && npm run test:run`) — green, 192 tests, unchanged from the fork-point baseline.

## What changed in the contract

- New `App.Data.PeriodBill` namespace (`PeriodBillData`, `PeriodBillLineData`).
- `NotificationAction` loses `SettlementCharged`, `SettlementFailed`, `SettlementBlockWarning`, `RefundSettled` and gains `PeriodBillClosed`, `PeriodBillDueSoon`, `PeriodBillDeclarationResolved`.
- `notifications.d.ts` swaps the three orphan `Settlement*` interfaces for three real `PeriodBill*` ones.

No hand-written code in this repo referenced any of the four retired cases (confirmed by a repo-wide grep), so this sync is inert by design — no UI, no test, no doc in this repo describes the retired or new notification cases.

## Verify

- `cmp` of all three declaration files against api's `resources/types/` at `e113a6c`: all three identical.
- `data/app-enums.ts` swept with `/usr/bin/grep`: the four retired cases are gone (0 hits each), the three `PeriodBill*` cases are present (1 hit each).
- Gate green, test count unchanged (192 → 192, re-measured at the fork point before any change).