### PR TITLE
[P2-B] admin: the operator can see and act on bills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,19 @@ npm run check      # Run format:check + lint + typecheck
 ## Testing
 
 ```bash
-npm test              # Run tests
-npm test -- --coverage  # Run tests with coverage report
+npm run test:run        # Run tests once and exit — use this in any gate or script
+npm test                # WATCH MODE — never exits; interactive use only
+npm run test:coverage   # Run once with a coverage report
 ```
 
 Tests use Vitest. Test files are in `__tests__/` folders next to source files:
 
 - `lib/api/__tests__/` - API error handling
 - `utils/__tests__/` - Utility functions (form, format, http, lang)
+- `services/__tests__/` - Service-layer request shaping
+- `hooks/*/__tests__/` - React Query hooks
+- `components/*/__tests__/` - Component behavior
+- `app/**/__tests__/` - Page-level behavior
 
 Coverage target: 100% on all tested utility files.
 
@@ -63,7 +68,7 @@ Coverage target: 100% on all tested utility files.
 1. **Three layers**: API (`lib/api/`) → Services (`services/`) → Hooks (`hooks/`)
 2. **Hydration**: Wait for `hydrated: true` from stores before rendering
 3. **API errors**: Use `applyApiErrorsToForm()` to bridge API → form errors
-4. **i18n**: Always use namespaces, provide `defaultValue` for safety
+4. **i18n**: Always use namespaces. **Do not add `defaultValue` to a key that exists** — see below
 5. **Queries**: Invalidate queries after mutations for fresh data
 
 ---
@@ -71,6 +76,24 @@ Coverage target: 100% on all tested utility files.
 ## i18n (Translations)
 
 Translations come from the API via [laravel-to-i18next](https://github.com/LorenzoWynberg/laravel-to-i18next).
+
+### `defaultValue` is a marker, not a safety net
+
+The locale JSON lives in the **api** repo (`lang/{en,es,fr}/`) and is served over
+HTTP — **no consumer repo can add a key.** That is what makes `defaultValue`
+dangerous rather than merely redundant:
+
+- **On a key that exists, never use it.** It silently masks a broken namespace
+  registration or a typo'd key — the string renders, the wiring stays wrong, and
+  nobody finds out. This is the failure this repo has actually hit.
+- **On a key that genuinely does not exist yet**, it is defensible only as a
+  temporary marker that a cross-repo change is half-landed, and it is a debt to
+  clear, not a fallback to leave behind. The right move is to add the key in api
+  first.
+
+If a key you need is missing from api's `lang/`, ask for it there — do not invent
+a fallback here. Existing call sites that still pass `defaultValue` predate this
+rule and are not worth churning on their own.
 
 ### Placeholder Capitalization
 

--- a/app/[lang]/(dashboard)/needs-attention/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/needs-attention/__tests__/page.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import NeedsAttentionPage from '../page';
+import { Enums } from '@/data/app-enums';
+
+type BillNeedsAttentionData = App.Data.PeriodBill.BillNeedsAttentionData;
+
+let bills: BillNeedsAttentionData[] = [];
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, ready: true }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  capitalize: (value: string) => value,
+  modelLabel: (key: string) => key,
+}));
+
+const emptyList = { data: undefined, isLoading: false, refetch: vi.fn(), isRefetching: false };
+
+vi.mock('@/hooks/orders', () => ({
+  useOrderList: () => ({ ...emptyList, data: { items: [], meta: { total: 0 } } }),
+}));
+vi.mock('@/hooks/orders/useNeedsAttention', () => ({
+  useNeedsAttention: () => ({ ...emptyList, data: { data: [], summary: {} } }),
+}));
+vi.mock('@/hooks/orders/usePendingReconciliation', () => ({
+  usePendingReconciliation: () => ({ ...emptyList, data: { data: [], summary: { count: 0 } } }),
+}));
+vi.mock('@/hooks/refundRequests', () => ({
+  usePendingRefundRequests: () => ({ ...emptyList, data: { items: [] } }),
+}));
+vi.mock('@/hooks/currencies', () => ({
+  useCurrencyList: () => ({ data: { items: [] } }),
+}));
+vi.mock('@/hooks/useLocalizedRouter', () => ({
+  useLocalizedRouter: () => ({ push: vi.fn(), replace: vi.fn(), lang: 'en' }),
+}));
+
+vi.mock('@/hooks/periodBills', () => ({
+  useBillsNeedingAttention: () => ({
+    data: { items: bills, summary: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+    isRefetching: false,
+  }),
+}));
+
+// The other five tabs' cards are not this test's subject, and each already has
+// its own coverage.
+vi.mock('@/components/orders/NeedsAttentionCard', () => ({ NeedsAttentionCard: () => null }));
+vi.mock('@/components/orders/PendingReconciliationCard', () => ({
+  PendingReconciliationCard: () => null,
+}));
+vi.mock('@/components/orders/RefundRequestCard', () => ({ RefundRequestCard: () => null }));
+vi.mock('@/components/orders/OrderStatusBadge', () => ({ OrderStatusBadge: () => null }));
+vi.mock('@/components/orders/PaymentStatusBadge', () => ({ PaymentStatusBadge: () => null }));
+vi.mock('@/components/payments/RecordPaymentDialog', () => ({ RecordPaymentDialog: () => null }));
+vi.mock('@/components/payments/PaymentSection', () => ({
+  getPaymentMethodLabel: () => '',
+  getOrderDueAmount: () => 0,
+}));
+
+// Stubbed down to the three fields this test is about, so the assertion reads
+// the page's own output rather than the card's rendering. The card's own test
+// covers what it draws.
+vi.mock('@/components/periodBills/BillAttentionCard', () => ({
+  BillAttentionCard: ({ item }: { item: BillNeedsAttentionData }) => (
+    <li data-testid="bill-row" data-reason={item.reason} data-urgency={item.urgency}>
+      {item.bill.publicId}
+    </li>
+  ),
+}));
+
+// `data/app-enums.ts` holds plain string constants; `generated.d.ts` declares
+// nominal TS enums over the same values, and the two are deliberately not
+// assignable to each other. Production code never needs the bridge — it reads
+// these values off DTOs, where they already carry the nominal type — so
+// fixtures cross that boundary once, here.
+function billRow(
+  publicId: string,
+  reason: string,
+  urgency: string,
+  dueAt: string
+): BillNeedsAttentionData {
+  return {
+    bill: { publicId, dueAt },
+    urgency,
+    reason,
+    ownerType: 'business',
+    ownerPublicId: `owner-${publicId}`,
+    ownerName: `Owner ${publicId}`,
+  } as BillNeedsAttentionData;
+}
+
+async function openBillsTab() {
+  const user = userEvent.setup();
+  render(<NeedsAttentionPage />);
+  await user.click(screen.getByRole('tab', { name: /period_bill/ }));
+}
+
+beforeEach(() => {
+  bills = [];
+});
+
+describe('Needs Attention — the period-bill tab', () => {
+  it('renders every BillAttentionReason the api can send, with its urgency', async () => {
+    bills = [
+      billRow(
+        'pb-1',
+        Enums.BillAttentionReason.UnresolvedCharge,
+        Enums.AttentionUrgency.Critical,
+        '2026-03-01T00:00:00Z'
+      ),
+      billRow(
+        'pb-2',
+        Enums.BillAttentionReason.Overdue,
+        Enums.AttentionUrgency.High,
+        '2026-03-02T00:00:00Z'
+      ),
+      billRow(
+        'pb-3',
+        Enums.BillAttentionReason.DeclarationToVerify,
+        Enums.AttentionUrgency.Medium,
+        '2026-03-03T00:00:00Z'
+      ),
+      billRow(
+        'pb-4',
+        Enums.BillAttentionReason.Quiet,
+        Enums.AttentionUrgency.Low,
+        '2026-03-04T00:00:00Z'
+      ),
+    ];
+
+    await openBillsTab();
+
+    const rendered = screen.getAllByTestId('bill-row');
+    expect(rendered).toHaveLength(Object.values(Enums.BillAttentionReason).length);
+    expect(rendered.map((row) => row.dataset.reason)).toEqual(
+      Object.values(Enums.BillAttentionReason)
+    );
+    expect(rendered.map((row) => row.dataset.urgency)).toEqual([
+      Enums.AttentionUrgency.Critical,
+      Enums.AttentionUrgency.High,
+      Enums.AttentionUrgency.Medium,
+      Enums.AttentionUrgency.Low,
+    ]);
+  });
+
+  // The precedence is the api's: an unresolved charge outranks an overdue bill
+  // because the customer's money may already be gone while the bill still reads
+  // unpaid. The fixture is built so that ANY client-side re-sort flips it — the
+  // unresolved row has the LATER due date and the LATER-sorting public id, so
+  // sorting by either would put the overdue bill first.
+  it('keeps an unresolved charge above an overdue bill, in the api order', async () => {
+    bills = [
+      billRow(
+        'pb-zz',
+        Enums.BillAttentionReason.UnresolvedCharge,
+        Enums.AttentionUrgency.Critical,
+        '2030-01-01T00:00:00Z'
+      ),
+      billRow(
+        'pb-aa',
+        Enums.BillAttentionReason.Overdue,
+        Enums.AttentionUrgency.High,
+        '2020-01-01T00:00:00Z'
+      ),
+    ];
+
+    await openBillsTab();
+
+    expect(screen.getAllByTestId('bill-row').map((row) => row.textContent)).toEqual([
+      'pb-zz',
+      'pb-aa',
+    ]);
+  });
+
+  it('says nothing needs chasing when the queue is empty', async () => {
+    await openBillsTab();
+
+    expect(screen.queryAllByTestId('bill-row')).toHaveLength(0);
+    expect(screen.getByText('payments:period_bill.attention_empty')).toBeInTheDocument();
+  });
+
+  it('counts the queue on the tab', async () => {
+    bills = [
+      billRow(
+        'pb-1',
+        Enums.BillAttentionReason.Quiet,
+        Enums.AttentionUrgency.Low,
+        '2026-03-01T00:00:00Z'
+      ),
+    ];
+
+    render(<NeedsAttentionPage />);
+
+    expect(screen.getByRole('tab', { name: /period_bill/ })).toHaveTextContent('1');
+  });
+});

--- a/app/[lang]/(dashboard)/needs-attention/page.tsx
+++ b/app/[lang]/(dashboard)/needs-attention/page.tsx
@@ -6,8 +6,10 @@ import { useOrderList } from '@/hooks/orders';
 import { useNeedsAttention } from '@/hooks/orders/useNeedsAttention';
 import { usePendingReconciliation } from '@/hooks/orders/usePendingReconciliation';
 import { usePendingRefundRequests } from '@/hooks/refundRequests';
+import { useBillsNeedingAttention } from '@/hooks/periodBills';
 import { useCurrencyList } from '@/hooks/currencies';
 import { NeedsAttentionCard } from '@/components/orders/NeedsAttentionCard';
+import { BillAttentionCard } from '@/components/periodBills/BillAttentionCard';
 import { PendingReconciliationCard } from '@/components/orders/PendingReconciliationCard';
 import { RefundRequestCard } from '@/components/orders/RefundRequestCard';
 import { OrderStatusBadge } from '@/components/orders/OrderStatusBadge';
@@ -22,7 +24,7 @@ import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
 import { RefreshCw, AlertTriangle, Eye, Clock, User, Building2 } from 'lucide-react';
 import { formatDateTime } from '@/utils/format';
 import { Enums } from '@/data/app-enums';
-import { actionLabel } from '@/utils/lang';
+import { actionLabel, capitalize, modelLabel } from '@/utils/lang';
 
 type OrderData = App.Data.Order.OrderData;
 
@@ -123,6 +125,12 @@ export default function NeedsAttentionPage() {
     refetch: refetchRefundRequests,
     isRefetching: isRefetchingRefundRequests,
   } = usePendingRefundRequests();
+  const {
+    data: billsData,
+    isLoading: billsLoading,
+    refetch: refetchBills,
+    isRefetching: isRefetchingBills,
+  } = useBillsNeedingAttention();
   const [filter, setFilter] = useState<string>('all');
   const { data: currencyListData } = useCurrencyList();
 
@@ -130,6 +138,15 @@ export default function NeedsAttentionPage() {
   const summary = (data?.summary ?? {}) as Record<string, number>;
 
   const filtered = filter === 'all' ? items : items.filter((i) => i.urgency === filter);
+
+  // Handed on in the order the api sent it. `BillAttentionReason` declares its
+  // cases in precedence order — unresolved charge, overdue, declaration to
+  // verify, quiet — and the endpoint already emits one row per bill at its most
+  // urgent reason, sorted. An unresolved charge outranks an overdue bill
+  // because the customer's money may already be gone while the bill still reads
+  // unpaid, and a client-side re-sort would silently undo that ranking.
+  const bills = billsData?.items ?? [];
+  const billSummary = (billsData?.summary ?? {}) as Record<string, number>;
 
   const refundRequests = refundRequestsData?.items ?? [];
   const reconciliationOrders = reconciliationData?.data ?? [];
@@ -153,6 +170,7 @@ export default function NeedsAttentionPage() {
     refetchUnpaidCollect();
     refetchReconciliation();
     refetchRefundRequests();
+    refetchBills();
   };
 
   const anyRefetching =
@@ -161,7 +179,8 @@ export default function NeedsAttentionPage() {
     isRefetchingUnpaidPrepayment ||
     isRefetchingUnpaidCollect ||
     isRefetchingReconciliation ||
-    isRefetchingRefundRequests;
+    isRefetchingRefundRequests ||
+    isRefetchingBills;
 
   return (
     <div className="space-y-6">
@@ -223,6 +242,17 @@ export default function NeedsAttentionPage() {
                 className="ml-1.5 bg-orange-100 px-1.5 py-0 text-xs text-orange-800"
               >
                 {refundRequests.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="bills">
+            {capitalize(modelLabel('period_bill', 2, false))}
+            {bills.length > 0 && (
+              <Badge
+                variant="secondary"
+                className="ml-1.5 bg-amber-100 px-1.5 py-0 text-xs text-amber-800"
+              >
+                {bills.length}
               </Badge>
             )}
           </TabsTrigger>
@@ -469,6 +499,35 @@ export default function NeedsAttentionPage() {
             <div className="space-y-4">
               {refundRequests.map((request) => (
                 <RefundRequestCard key={request.publicId} refundRequest={request} />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="bills" className="space-y-4">
+          {/* The api counts these per urgency across all four reasons, and the
+              breakdown is the triage signal a flat list cannot give: it says
+              how much of the queue is a customer's money possibly already gone
+              versus a bill that is merely quiet. Same shape the conflicts tab
+              renders its own summary in. */}
+          <div className="flex flex-wrap gap-3">
+            {URGENCY_LEVELS.map((level) => (
+              <Badge key={level} className={summaryStyles[level]} variant="secondary">
+                {billSummary[level] ?? 0} {t(`needs_attention.urgency.${level}`)}
+              </Badge>
+            ))}
+          </div>
+
+          {billsLoading ? (
+            <div className="text-muted-foreground py-12 text-center">{t('common:loading')}</div>
+          ) : bills.length === 0 ? (
+            <div className="text-muted-foreground py-12 text-center">
+              {t('payments:period_bill.attention_empty')}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {bills.map((item) => (
+                <BillAttentionCard key={item.bill.publicId} item={item} />
               ))}
             </div>
           )}

--- a/app/[lang]/(dashboard)/period-bills/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/period-bills/[id]/page.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+
+import {
+  TableHeader,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Table,
+} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PeriodBillStatusBadge } from '@/components/periodBills/PeriodBillStatusBadge';
+import { SettlementDestinationSummary } from '@/components/periodBills/SettlementDestinationSummary';
+import { VerifyDeclarationDialog } from '@/components/periodBills/VerifyDeclarationDialog';
+import { RecordBillPaymentDialog } from '@/components/periodBills/RecordBillPaymentDialog';
+import { CopyableReference } from '@/components/periodBills/CopyableReference';
+import { ProofViewer } from '@/components/periodBills/ProofViewer';
+import { usePeriodBill } from '@/hooks/periodBills';
+import { useOrderCurrencySymbol } from '@/hooks/currencies';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
+import { formatCurrency, formatDate } from '@/utils/format';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+export default function PeriodBillDetailPage() {
+  const params = useParams();
+  const { t, ready } = useTranslation('payments');
+  const router = useLocalizedRouter();
+  const publicId = params.id as string;
+
+  const { data: bill, isLoading, error } = usePeriodBill(publicId);
+  const baseSymbol = useOrderCurrencySymbol(null);
+
+  if (!ready || isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error || !bill) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        {resourceMessage('not_found', 'period_bill')}
+      </div>
+    );
+  }
+
+  const perCurrency = Object.entries(bill.perCurrencyTotals ?? {});
+  const lines = bill.lines ?? [];
+  const awaitingVerification = bill.status === Enums.PeriodBillStatus.AwaitingVerification;
+  // Only an issued bill that is still owed can be recorded as paid — the api
+  // refuses anything else with `errors.period_bill.not_settleable`. The queue
+  // never surfaces another status, but this route can be reached directly, and
+  // offering an act that is certain to be refused is not an affordance.
+  const settleable = bill.status === Enums.PeriodBillStatus.Issued || awaitingVerification;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push('/needs-attention')}>
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          {actionLabel('back')}
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-bold">{capitalize(modelLabel('period_bill'))}</h1>
+          <span className="font-mono text-sm">#{bill.publicId}</span>
+          <PeriodBillStatusBadge status={bill.status} />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {awaitingVerification && <VerifyDeclarationDialog bill={bill} />}
+          {settleable && <RecordBillPaymentDialog bill={bill} />}
+        </div>
+      </div>
+
+      {/* The three states an operator has to read differently. `Open` is not a
+          bill yet — nothing is owed until the period closes. */}
+      {bill.status === Enums.PeriodBillStatus.Open && (
+        <p className="text-muted-foreground text-sm">{t('period_bill.open_hint')}</p>
+      )}
+      {awaitingVerification && (
+        <p className="text-muted-foreground text-sm">
+          {t('period_bill.awaiting_verification_hint')}
+        </p>
+      )}
+      {bill.isOverdue && (
+        <p className="text-muted-foreground text-sm">{t('period_bill.overdue_hint')}</p>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{t('period_bill.title')}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t('period_bill.period_total')}</span>
+              <span className="font-mono">{formatCurrency(bill.baseAmount, baseSymbol)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t('period_bill.credit_applied')}</span>
+              <span className="font-mono">{formatCurrency(bill.creditApplied, baseSymbol)}</span>
+            </div>
+            <div className="flex justify-between font-medium">
+              <span>{t('period_bill.net_due')}</span>
+              <span className="font-mono">{formatCurrency(bill.netDue, baseSymbol)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t('period_bill.closed_on')}</span>
+              <span>{formatDate(bill.cutoffAt)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t('period_bill.due_on')}</span>
+              <span>{formatDate(bill.dueAt)}</span>
+            </div>
+            {/* Per agreed currency, never re-converted: a base line carries one
+                colón figure and a non-base line the rate frozen on its quote. */}
+            {perCurrency.map(([code, totals]) => (
+              <div key={code} className="flex justify-between">
+                <span className="text-muted-foreground">{code}</span>
+                <span className="font-mono">{totals.amount.toFixed(2)}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        {(bill.settlementMethod || bill.reference || bill.settlementDestination) && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">{validationAttribute('method')}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {bill.settlementMethod && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">{validationAttribute('method')}</span>
+                  <span>{t(`settlement_method.${bill.settlementMethod}`)}</span>
+                </div>
+              )}
+              {bill.reference && <CopyableReference reference={bill.reference} />}
+              {bill.settlementDestination && (
+                <SettlementDestinationSummary destination={bill.settlementDestination} />
+              )}
+              {bill.proofUrl && <ProofViewer publicId={bill.publicId} />}
+              {/* `notes` is stripped for a non-staff reader, so it is absent
+                  rather than null on those responses — never assumed present. */}
+              {bill.notes && <p className="text-muted-foreground text-xs">{bill.notes}</p>}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t('period_bill.lines_title')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {lines.length === 0 ? (
+            <p className="text-muted-foreground text-sm">{t('period_bill.empty')}</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{capitalize(modelLabel('order'))}</TableHead>
+                  <TableHead>{validationAttribute('currencyCode')}</TableHead>
+                  <TableHead className="text-right">{t('period_bill.line_rate')}</TableHead>
+                  <TableHead className="text-right">{t('period_bill.period_total')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {lines.map((line) => (
+                  <TableRow key={line.id}>
+                    <TableCell className="font-mono text-xs">#{line.orderPublicId}</TableCell>
+                    <TableCell>{line.currencyCode}</TableCell>
+                    <TableCell className="text-right font-mono">
+                      {line.fxRate === null ? '-' : line.fxRate.toFixed(6)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {line.amount.toFixed(2)} / {formatCurrency(line.baseAmount, baseSymbol)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/[lang]/(dashboard)/settings/page.tsx
+++ b/app/[lang]/(dashboard)/settings/page.tsx
@@ -7,7 +7,7 @@ import {
   SelectItem,
   Select,
 } from '@/components/ui/select';
-import { Globe, Coins, Clock, Truck, ChevronRight, Hourglass } from 'lucide-react';
+import { Globe, Coins, Clock, Truck, ChevronRight, Hourglass, Landmark } from 'lucide-react';
 
 import { useState } from 'react';
 import { Label } from '@/components/ui/label';
@@ -27,7 +27,13 @@ import {
   useUpdateIdleTime,
 } from '@/hooks/settings';
 import { Enums } from '@/data/app-enums';
-import { actionLabel, capitalize, vehicleTypeLabel } from '@/utils/lang';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  vehicleTypeLabel,
+} from '@/utils/lang';
 
 const languageCodes = ['en', 'es', 'fr'] as const;
 
@@ -275,6 +281,23 @@ export default function SettingsPage() {
             {t('common:currency_settings_description', {
               defaultValue: 'Manage currencies and exchange rates',
             })}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+      <Card
+        className="hover:bg-muted/50 cursor-pointer transition-colors"
+        onClick={() => router.push('/settings/payment-destinations')}
+      >
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Landmark className="h-5 w-5" />
+              <CardTitle>{capitalize(modelLabel('payment_destination', 2, false))}</CardTitle>
+            </div>
+            <ChevronRight className="text-muted-foreground h-5 w-5" />
+          </div>
+          <CardDescription>
+            {resourceMessage('click_to_manage', 'payment_destination', 2)}
           </CardDescription>
         </CardHeader>
       </Card>

--- a/app/[lang]/(dashboard)/settings/payment-destinations/page.tsx
+++ b/app/[lang]/(dashboard)/settings/payment-destinations/page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronLeft, Pencil, Plus, Trash2 } from 'lucide-react';
+
+import {
+  TableHeader,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Table,
+} from '@/components/ui/table';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { PaymentDestinationDialog } from '@/components/paymentDestinations/PaymentDestinationDialog';
+import { usePaymentDestinations, useDeletePaymentDestination } from '@/hooks/paymentDestinations';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
+import {
+  actionLabel,
+  capitalize,
+  modelLabel,
+  resourceMessage,
+  validationAttribute,
+} from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+type PaymentDestinationData = App.Data.PaymentDestination.PaymentDestinationData;
+
+/**
+ * Where customers are told to send money.
+ *
+ * Deactivating is the ordinary move rather than deleting: a bill records the
+ * destination it showed as a snapshot, so a removed row never rewrites history,
+ * but a deactivated one stays legible to whoever is reading an old bill.
+ */
+export default function PaymentDestinationsPage() {
+  const { t, ready } = useTranslation();
+  const router = useLocalizedRouter();
+
+  const { data: destinations, isLoading } = usePaymentDestinations();
+  const remove = useDeletePaymentDestination();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<PaymentDestinationData | undefined>(undefined);
+
+  if (!ready) return null;
+
+  const openCreate = () => {
+    setEditing(undefined);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (destination: PaymentDestinationData) => {
+    setEditing(destination);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = (destination: PaymentDestinationData) => {
+    if (destination.id == null) return;
+    if (!confirm(resourceMessage('confirm_delete', 'payment_destination'))) return;
+    remove.mutate(destination.id);
+  };
+
+  const rows = destinations ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push('/settings')}>
+          <ChevronLeft className="mr-1 h-4 w-4" />
+          {actionLabel('back')}
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-3xl font-bold">
+          {capitalize(modelLabel('payment_destination', 2, false))}
+        </h1>
+        <Button onClick={openCreate}>
+          <Plus className="mr-1 h-4 w-4" />
+          {resourceMessage('create', 'payment_destination')}
+        </Button>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6">
+          {isLoading ? (
+            <div className="text-muted-foreground py-12 text-center">{t('common:loading')}</div>
+          ) : rows.length === 0 ? (
+            <div className="text-muted-foreground py-12 text-center">
+              {resourceMessage('exists_yet', 'payment_destination', 0)}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{validationAttribute('method')}</TableHead>
+                  <TableHead>{validationAttribute('holderName')}</TableHead>
+                  <TableHead>{validationAttribute('accountNumber')}</TableHead>
+                  <TableHead>{validationAttribute('currencyCode')}</TableHead>
+                  <TableHead>{t('common:active')}</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((destination) => (
+                  <TableRow key={destination.id}>
+                    <TableCell>{t(`payments:settlement_method.${destination.method}`)}</TableCell>
+                    <TableCell>{destination.holderName}</TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {destination.method === Enums.SettlementMethod.SinpeMobile
+                        ? destination.phoneNumber
+                        : destination.accountNumber}
+                    </TableCell>
+                    <TableCell>{destination.currencyCode ?? '-'}</TableCell>
+                    <TableCell>
+                      <Badge variant={destination.active ? 'secondary' : 'outline'}>
+                        {destination.active ? t('common:active') : t('common:inactive')}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openEdit(destination)}
+                        aria-label={actionLabel('edit')}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(destination)}
+                        aria-label={actionLabel('delete')}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <PaymentDestinationDialog
+        destination={editing}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
+    </div>
+  );
+}

--- a/components/paymentDestinations/PaymentDestinationDialog.tsx
+++ b/components/paymentDestinations/PaymentDestinationDialog.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Dialog,
+} from '@/components/ui/dialog';
+import {
+  SelectTrigger,
+  SelectContent,
+  SelectValue,
+  SelectItem,
+  Select,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import {
+  useCreatePaymentDestination,
+  useUpdatePaymentDestination,
+} from '@/hooks/paymentDestinations';
+import { useCurrencyList } from '@/hooks/currencies';
+import { DESTINATION_METHODS } from '@/services/paymentDestinationService';
+import { actionLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+type PaymentDestinationData = App.Data.PaymentDestination.PaymentDestinationData;
+type SettlementMethod = App.Enums.SettlementMethod;
+
+interface FormState {
+  method: string;
+  currencyCode: string;
+  phoneNumber: string;
+  bankName: string;
+  accountNumber: string;
+  iban: string;
+  holderName: string;
+  legalId: string;
+  maxAmount: string;
+  active: boolean;
+  sortOrder: string;
+}
+
+function blankForm(): FormState {
+  return {
+    method: Enums.SettlementMethod.Transferencia,
+    currencyCode: '',
+    phoneNumber: '',
+    bankName: '',
+    accountNumber: '',
+    iban: '',
+    holderName: '',
+    legalId: '',
+    maxAmount: '',
+    active: true,
+    sortOrder: '',
+  };
+}
+
+function formFrom(destination: PaymentDestinationData): FormState {
+  return {
+    method: destination.method ?? Enums.SettlementMethod.Transferencia,
+    currencyCode: destination.currencyCode ?? '',
+    phoneNumber: destination.phoneNumber ?? '',
+    bankName: destination.bankName ?? '',
+    accountNumber: destination.accountNumber ?? '',
+    iban: destination.iban ?? '',
+    holderName: destination.holderName ?? '',
+    legalId: destination.legalId ?? '',
+    maxAmount: destination.maxAmount != null ? String(destination.maxAmount) : '',
+    active: destination.active ?? true,
+    sortOrder: destination.sortOrder != null ? String(destination.sortOrder) : '',
+  };
+}
+
+interface PaymentDestinationDialogProps {
+  /** Absent for a create, present for an edit. */
+  destination?: PaymentDestinationData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Create or edit a destination.
+ *
+ * `method` is editable only on create: it decides which of the other fields the
+ * row may carry, so changing it in place would leave a destination holding the
+ * wrong method's fields — the api refuses it outright (`'method' => prohibited`
+ * on the update DTO). Swapping a method means deactivating the row and creating
+ * a new one.
+ */
+export function PaymentDestinationDialog({
+  destination,
+  open,
+  onOpenChange,
+}: PaymentDestinationDialogProps) {
+  const { t } = useTranslation();
+  const isEdit = destination !== undefined;
+
+  const [form, setForm] = useState<FormState>(() =>
+    destination ? formFrom(destination) : blankForm()
+  );
+  const [seeded, setSeeded] = useState(false);
+
+  const create = useCreatePaymentDestination();
+  const update = useUpdatePaymentDestination();
+  const { data: currencyData } = useCurrencyList();
+
+  const currencies = (currencyData?.items ?? []).filter((currency) => currency.isEnabled);
+
+  if (open && !seeded) {
+    setForm(destination ? formFrom(destination) : blankForm());
+    setSeeded(true);
+  }
+  if (!open && seeded) {
+    setSeeded(false);
+  }
+
+  const set = <K extends keyof FormState>(field: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const isSinpe = form.method === Enums.SettlementMethod.SinpeMobile;
+
+  const isValid =
+    form.holderName.trim().length >= 2 &&
+    form.legalId.trim().length >= 2 &&
+    (isSinpe
+      ? form.phoneNumber.trim() !== ''
+      : form.currencyCode !== '' &&
+        form.bankName.trim() !== '' &&
+        form.accountNumber.trim() !== '');
+
+  const pending = create.isPending || update.isPending;
+
+  /**
+   * Only the fields this method admits are sent. Every sibling field is
+   * `prohibited` on the api side, so a stale SINPE phone number left on a
+   * transfer payload fails the whole request rather than being ignored.
+   */
+  const methodFields = isSinpe
+    ? { phoneNumber: form.phoneNumber.trim() }
+    : {
+        currencyCode: form.currencyCode,
+        bankName: form.bankName.trim(),
+        accountNumber: form.accountNumber.trim(),
+        iban: form.iban.trim() || null,
+      };
+
+  const shared = {
+    holderName: form.holderName.trim(),
+    legalId: form.legalId.trim(),
+    maxAmount: form.maxAmount.trim() === '' ? null : Number(form.maxAmount),
+    active: form.active,
+    sortOrder: form.sortOrder.trim() === '' ? null : Number(form.sortOrder),
+  };
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    const close = { onSuccess: () => onOpenChange(false) };
+
+    if (isEdit && destination?.id != null) {
+      update.mutate({ id: destination.id, data: { ...methodFields, ...shared } }, close);
+      return;
+    }
+
+    create.mutate({ method: form.method as SettlementMethod, ...methodFields, ...shared }, close);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* Every field carries its own label and the title names the act, so there
+          is nothing a description would add. Radix warns unless the opt-out is
+          explicit, which is what `aria-describedby={undefined}` is for. */}
+      <DialogContent className="max-w-md" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>
+            {resourceMessage(isEdit ? 'edit' : 'create', 'payment_destination')}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="destination-method">{validationAttribute('method')}</Label>
+            <Select
+              value={form.method}
+              onValueChange={(value) => set('method', value)}
+              disabled={isEdit}
+            >
+              <SelectTrigger id="destination-method" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DESTINATION_METHODS.map((method) => (
+                  <SelectItem key={method} value={method}>
+                    {t(`payments:settlement_method.${method}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {isSinpe ? (
+            <div className="grid gap-2">
+              <Label htmlFor="destination-phone">{validationAttribute('phoneNumber')}</Label>
+              <Input
+                id="destination-phone"
+                value={form.phoneNumber}
+                onChange={(e) => set('phoneNumber', e.target.value)}
+              />
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-2">
+                <Label htmlFor="destination-currency">{validationAttribute('currencyCode')}</Label>
+                <Select
+                  value={form.currencyCode}
+                  onValueChange={(value) => set('currencyCode', value)}
+                >
+                  <SelectTrigger id="destination-currency" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {currencies.map((currency) => (
+                      <SelectItem key={currency.code} value={currency.code ?? ''}>
+                        {currency.code}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="destination-bank">{validationAttribute('bankName')}</Label>
+                <Input
+                  id="destination-bank"
+                  value={form.bankName}
+                  onChange={(e) => set('bankName', e.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="destination-account">{validationAttribute('accountNumber')}</Label>
+                <Input
+                  id="destination-account"
+                  value={form.accountNumber}
+                  onChange={(e) => set('accountNumber', e.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="destination-iban">{validationAttribute('iban')}</Label>
+                <Input
+                  id="destination-iban"
+                  value={form.iban}
+                  onChange={(e) => set('iban', e.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          <div className="grid gap-2">
+            <Label htmlFor="destination-holder">{validationAttribute('holderName')}</Label>
+            <Input
+              id="destination-holder"
+              value={form.holderName}
+              onChange={(e) => set('holderName', e.target.value)}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="destination-legal-id">{validationAttribute('legalId')}</Label>
+            <Input
+              id="destination-legal-id"
+              value={form.legalId}
+              onChange={(e) => set('legalId', e.target.value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="destination-max">{validationAttribute('maxAmount')}</Label>
+              <Input
+                id="destination-max"
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.maxAmount}
+                onChange={(e) => set('maxAmount', e.target.value)}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="destination-sort">{validationAttribute('sortOrder')}</Label>
+              <Input
+                id="destination-sort"
+                type="number"
+                min="0"
+                step="1"
+                value={form.sortOrder}
+                onChange={(e) => set('sortOrder', e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Switch
+              id="destination-active"
+              checked={form.active}
+              onCheckedChange={(checked) => set('active', checked)}
+            />
+            <Label htmlFor="destination-active" className="font-normal">
+              {validationAttribute('active')}
+            </Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button disabled={!isValid || pending} onClick={handleSubmit}>
+            {actionLabel('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/paymentDestinations/__tests__/PaymentDestinationDialog.test.tsx
+++ b/components/paymentDestinations/__tests__/PaymentDestinationDialog.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PaymentDestinationDialog } from '../PaymentDestinationDialog';
+import { Enums } from '@/data/app-enums';
+
+type PaymentDestinationData = App.Data.PaymentDestination.PaymentDestinationData;
+
+// Radix's Select opens by capturing the pointer on the trigger, which
+// happy-dom doesn't implement — without these the popover silently never
+// opens under test, though it works fine in a real browser.
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  resourceMessage: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+vi.mock('@/hooks/paymentDestinations', () => ({
+  useCreatePaymentDestination: () => ({ mutate: createMutate, isPending: false }),
+  useUpdatePaymentDestination: () => ({ mutate: updateMutate, isPending: false }),
+}));
+
+vi.mock('@/hooks/currencies', () => ({
+  useCurrencyList: () => ({
+    data: { items: [{ code: 'CRC', symbol: '₡', isEnabled: true }] },
+  }),
+}));
+
+// `data/app-enums.ts` holds plain string constants; `generated.d.ts` declares
+// nominal TS enums over the same values, and the two are deliberately not
+// assignable to each other. Production code never needs the bridge — it reads
+// these values off DTOs, where they already carry the nominal type — so
+// fixtures cross that boundary once, here.
+const sinpeRow = {
+  id: 5,
+  method: Enums.SettlementMethod.SinpeMobile,
+  phoneNumber: '8888-8888',
+  holderName: 'Mandados SA',
+  legalId: '3-101-999',
+  active: true,
+} as PaymentDestinationData;
+
+function open(destination?: PaymentDestinationData) {
+  return render(<PaymentDestinationDialog destination={destination} open onOpenChange={vi.fn()} />);
+}
+
+beforeEach(() => {
+  createMutate.mockClear();
+  updateMutate.mockClear();
+});
+
+describe('PaymentDestinationDialog — the fields a method admits', () => {
+  // Every sibling field is `prohibited` on the api side, so sending a bank name
+  // on a SINPE row fails the whole request rather than being ignored.
+  it('asks a SINPE destination for a phone number and nothing bank-shaped', () => {
+    open(sinpeRow);
+
+    expect(screen.getByLabelText('phoneNumber')).toBeInTheDocument();
+    expect(screen.queryByLabelText('bankName')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('accountNumber')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('iban')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('currencyCode')).not.toBeInTheDocument();
+  });
+
+  it('asks a transfer destination for bank details and no phone number', () => {
+    open();
+
+    expect(screen.getByLabelText('bankName')).toBeInTheDocument();
+    expect(screen.getByLabelText('accountNumber')).toBeInTheDocument();
+    expect(screen.getByLabelText('iban')).toBeInTheDocument();
+    expect(screen.queryByLabelText('phoneNumber')).not.toBeInTheDocument();
+  });
+
+  it('sends only the fields the chosen method admits', async () => {
+    const user = userEvent.setup();
+    open(sinpeRow);
+
+    await user.click(screen.getByRole('button', { name: 'save' }));
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    const [args] = updateMutate.mock.calls[0];
+    expect(args.data).toHaveProperty('phoneNumber', '8888-8888');
+    expect(args.data).not.toHaveProperty('bankName');
+    expect(args.data).not.toHaveProperty('accountNumber');
+    expect(args.data).not.toHaveProperty('currencyCode');
+  });
+});
+
+describe('PaymentDestinationDialog — the method is immutable once created', () => {
+  // Changing it in place would leave a row carrying the wrong method's fields;
+  // the api answers `'method' => prohibited` on the update DTO. Swapping means
+  // deactivating and creating a new one.
+  it('locks the method on an existing destination', () => {
+    open(sinpeRow);
+
+    expect(screen.getByLabelText('method')).toBeDisabled();
+  });
+
+  it('leaves the method open on a new destination', () => {
+    open();
+
+    expect(screen.getByLabelText('method')).not.toBeDisabled();
+  });
+
+  it('never sends a method on an update', async () => {
+    const user = userEvent.setup();
+    open(sinpeRow);
+
+    await user.click(screen.getByRole('button', { name: 'save' }));
+
+    expect(updateMutate.mock.calls[0][0].data).not.toHaveProperty('method');
+  });
+});
+
+describe('PaymentDestinationDialog — refusing what the api would refuse', () => {
+  it('will not save a transfer destination missing its required bank fields', () => {
+    open();
+
+    expect(screen.getByRole('button', { name: 'save' })).toBeDisabled();
+  });
+
+  it('saves a complete SINPE destination', async () => {
+    const user = userEvent.setup();
+    open(sinpeRow);
+
+    expect(screen.getByRole('button', { name: 'save' })).not.toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'save' }));
+
+    expect(createMutate).not.toHaveBeenCalled();
+    expect(updateMutate).toHaveBeenCalled();
+  });
+});

--- a/components/periodBills/BillAttentionCard.tsx
+++ b/components/periodBills/BillAttentionCard.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { Building2, Clock, Eye, User } from 'lucide-react';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { UrgencyBadge } from '@/components/orders/UrgencyBadge';
+import { useLocalizedRouter } from '@/hooks/useLocalizedRouter';
+import { useOrderCurrencySymbol } from '@/hooks/currencies';
+import { formatCurrency, formatDate } from '@/utils/format';
+import { actionLabel } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+import { PeriodBillStatusBadge } from './PeriodBillStatusBadge';
+import { BillAttentionReasonBadge } from './BillAttentionReasonBadge';
+import { VerifyDeclarationDialog } from './VerifyDeclarationDialog';
+import { RecordBillPaymentDialog } from './RecordBillPaymentDialog';
+
+type BillNeedsAttentionData = App.Data.PeriodBill.BillNeedsAttentionData;
+
+interface BillAttentionCardProps {
+  item: BillNeedsAttentionData;
+}
+
+export function BillAttentionCard({ item }: BillAttentionCardProps) {
+  const { t } = useTranslation('payments');
+  const router = useLocalizedRouter();
+  const baseSymbol = useOrderCurrencySymbol(null);
+
+  const { bill, urgency, reason, ownerType, ownerName } = item;
+
+  const OwnerIcon = ownerType === 'business' ? Building2 : User;
+  const awaitingVerification = bill.status === Enums.PeriodBillStatus.AwaitingVerification;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-sm font-semibold">#{bill.publicId}</span>
+          <UrgencyBadge urgency={urgency} />
+          <BillAttentionReasonBadge reason={reason} />
+          <PeriodBillStatusBadge status={bill.status} />
+        </div>
+        <div className="text-muted-foreground mt-1 flex flex-wrap gap-x-3 text-sm">
+          <span className="flex items-center gap-1">
+            <OwnerIcon className="h-3.5 w-3.5" />
+            {ownerName ?? '-'}
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" />
+            {t('period_bill.due_on')} {formatDate(bill.dueAt)}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-baseline gap-x-4 text-sm">
+          <span>
+            <span className="text-muted-foreground">{t('period_bill.net_due')} </span>
+            <span className="font-mono font-medium">{formatCurrency(bill.netDue, baseSymbol)}</span>
+          </span>
+          {bill.creditApplied > 0 && (
+            <span className="text-muted-foreground text-xs">
+              {t('period_bill.credit_applied')} {formatCurrency(bill.creditApplied, baseSymbol)}
+            </span>
+          )}
+        </div>
+
+        {/* The state most likely to be misread: a declared transfer is not a
+            payment, and the clock has not stopped. */}
+        {awaitingVerification && (
+          <p className="text-muted-foreground text-xs">
+            {t('period_bill.awaiting_verification_hint')}
+          </p>
+        )}
+        {bill.isOverdue && (
+          <p className="text-muted-foreground text-xs">{t('period_bill.overdue_hint')}</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          {awaitingVerification && <VerifyDeclarationDialog bill={bill} />}
+          <RecordBillPaymentDialog bill={bill} />
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push(`/period-bills/${bill.publicId}`)}
+          >
+            <Eye className="mr-1 h-4 w-4" />
+            {actionLabel('view')}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/periodBills/BillAttentionReasonBadge.tsx
+++ b/components/periodBills/BillAttentionReasonBadge.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, CalendarClock, Receipt, Hourglass } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Enums } from '@/data/app-enums';
+
+type BillAttentionReason = App.Enums.BillAttentionReason;
+
+/**
+ * Why this bill is on the queue. One row per bill, at the most urgent reason
+ * it matches — a bill routinely matches several and the api picks.
+ *
+ * Keyed by the enum rather than by a fallback lookup: every case is listed, so
+ * a case added to `BillAttentionReason` breaks the build here rather than
+ * rendering an unstyled badge nobody notices.
+ */
+const reasonConfig: Record<BillAttentionReason, { icon: typeof AlertCircle; className: string }> = {
+  [Enums.BillAttentionReason.UnresolvedCharge]: {
+    icon: AlertCircle,
+    className: 'bg-red-50 text-red-700 border-red-200',
+  },
+  [Enums.BillAttentionReason.Overdue]: {
+    icon: CalendarClock,
+    className: 'bg-orange-50 text-orange-700 border-orange-200',
+  },
+  [Enums.BillAttentionReason.DeclarationToVerify]: {
+    icon: Receipt,
+    className: 'bg-amber-50 text-amber-700 border-amber-200',
+  },
+  [Enums.BillAttentionReason.Quiet]: {
+    icon: Hourglass,
+    className: 'bg-gray-50 text-gray-700 border-gray-200',
+  },
+};
+
+interface BillAttentionReasonBadgeProps {
+  reason: BillAttentionReason;
+}
+
+export function BillAttentionReasonBadge({ reason }: BillAttentionReasonBadgeProps) {
+  const { t } = useTranslation('payments');
+
+  const { icon: Icon, className } = reasonConfig[reason];
+
+  return (
+    <Badge variant="outline" className={className}>
+      <Icon className="mr-1 h-3 w-3" />
+      {t(`bill_attention_reason.${reason}`)}
+    </Badge>
+  );
+}

--- a/components/periodBills/CopyableReference.tsx
+++ b/components/periodBills/CopyableReference.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { crudErrorMessage, validationAttribute } from '@/utils/lang';
+
+interface CopyableReferenceProps {
+  reference: string;
+}
+
+/**
+ * The reference the customer gave, in a form an operator can paste straight
+ * into a bank's search box.
+ *
+ * Copyable rather than merely displayed because this is the whole point of the
+ * verification row: finding the transfer in the bank is a search on this exact
+ * string, and re-typing it by eye is where a verification goes wrong.
+ */
+export function CopyableReference({ reference }: CopyableReferenceProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    // The clipboard write rejects outright when the permission is denied, and
+    // an unhandled rejection here would leave the operator with a button that
+    // silently did nothing. Guarded the way ShareTrackingLinkDialog guards its
+    // own copy.
+    try {
+      await navigator.clipboard.writeText(reference);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(crudErrorMessage('updating', 'period_bill'));
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground text-xs">{validationAttribute('reference')}</span>
+      <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-sm">{reference}</code>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2"
+        onClick={handleCopy}
+        aria-label={validationAttribute('reference')}
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      </Button>
+    </div>
+  );
+}

--- a/components/periodBills/PeriodBillStatusBadge.tsx
+++ b/components/periodBills/PeriodBillStatusBadge.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { statusLabel } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+type PeriodBillStatus = App.Enums.PeriodBillStatus;
+
+/**
+ * `AwaitingVerification` gets its own colour rather than reading as paid: the
+ * customer has claimed a transfer nobody has found yet, and the due date is
+ * still running.
+ */
+const statusStyles: Record<PeriodBillStatus, string> = {
+  [Enums.PeriodBillStatus.Open]: 'bg-gray-100 text-gray-700 border-gray-200',
+  [Enums.PeriodBillStatus.Issued]: 'bg-blue-100 text-blue-800 border-blue-200',
+  [Enums.PeriodBillStatus.AwaitingVerification]: 'bg-amber-100 text-amber-800 border-amber-200',
+  [Enums.PeriodBillStatus.Paid]: 'bg-green-100 text-green-800 border-green-200',
+};
+
+interface PeriodBillStatusBadgeProps {
+  status: PeriodBillStatus;
+}
+
+export function PeriodBillStatusBadge({ status }: PeriodBillStatusBadgeProps) {
+  return (
+    <Badge variant="outline" className={statusStyles[status]}>
+      {statusLabel(status)}
+    </Badge>
+  );
+}

--- a/components/periodBills/ProofViewer.tsx
+++ b/components/periodBills/ProofViewer.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FileText, Loader2 } from 'lucide-react';
+
+import {
+  DialogDescription,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Dialog,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useBillProof } from '@/hooks/periodBills';
+import { validationAttribute } from '@/utils/lang';
+
+interface ProofViewerProps {
+  publicId: string;
+}
+
+/**
+ * The comprobante, opened through the **authenticated stream route**.
+ *
+ * `PeriodBillData.proofUrl` names `GET period-bills/{bill}/proof`, which sits
+ * behind `auth:sanctum` on a private disk. Handed to an `<img src>` or an
+ * `<a href>` the browser sends no Authorization header and the api answers
+ * 401 — so nothing here ever points the DOM at that url. The bytes are pulled
+ * with the token attached and rendered from an object URL.
+ *
+ * Corroboration, not evidence: an operator confirms a payment by finding it in
+ * the bank against the reference and the amount. The image is what makes that
+ * search quick, not what settles the question — so it loads only when asked
+ * for, and its absence never blocks a verification.
+ */
+export function ProofViewer({ publicId }: ProofViewerProps) {
+  const { t } = useTranslation('payments');
+  const [open, setOpen] = useState(false);
+  const proof = useBillProof(publicId, open);
+
+  const label = validationAttribute('proof');
+  const isPdf = proof.contentType === 'application/pdf';
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <FileText className="mr-1 h-4 w-4" />
+        {t('proof')}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{label}</DialogTitle>
+            <DialogDescription>{t('period_bill.awaiting_verification_hint')}</DialogDescription>
+          </DialogHeader>
+
+          {proof.isLoading && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          )}
+
+          {/* A load FAILURE, never an absence. This viewer only mounts when
+              `proofUrl` is set, so the api has already said a comprobante
+              exists — "no proof is attached" is the one thing that cannot be
+              true here, and told it an operator would stop looking instead of
+              retrying a 401 or a dropped connection. */}
+          {proof.isError && (
+            <p className="text-muted-foreground py-12 text-center text-sm">
+              {t('resource:failed_to_load', { resource: validationAttribute('proof', false) })}
+            </p>
+          )}
+
+          {proof.url &&
+            (isPdf ? (
+              <object data={proof.url} type="application/pdf" className="h-[70vh] w-full">
+                <a href={proof.url} download>
+                  {label}
+                </a>
+              </object>
+            ) : (
+              // eslint-disable-next-line @next/next/no-img-element -- an object URL over fetched bytes; next/image optimizes remote urls it can re-request, and this one is revoked on unmount
+              <img src={proof.url} alt={label} className="max-h-[70vh] w-full object-contain" />
+            ))}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/periodBills/RecordBillPaymentDialog.tsx
+++ b/components/periodBills/RecordBillPaymentDialog.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { HandCoins } from 'lucide-react';
+
+import {
+  DialogDescription,
+  DialogTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Dialog,
+} from '@/components/ui/dialog';
+import {
+  SelectTrigger,
+  SelectContent,
+  SelectValue,
+  SelectItem,
+  Select,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useSettlePeriodBill } from '@/hooks/periodBills';
+import { usePaymentDestinations } from '@/hooks/paymentDestinations';
+import { DESTINATION_METHODS } from '@/services/paymentDestinationService';
+import { useCurrencyList } from '@/hooks/currencies';
+import { actionLabel, validationAttribute } from '@/utils/lang';
+import { Enums } from '@/data/app-enums';
+
+type PeriodBillData = App.Data.PeriodBill.PeriodBillData;
+type SettlementMethod = App.Enums.SettlementMethod;
+
+/**
+ * Everything but `Credit`, derived rather than listed — the same rule
+ * `SettlementMethod::recordableByHandCases()` states on the api side. Credit is
+ * a tender the ledger has to have actually moved for, and only the bill's close
+ * moves it; recording it here would mark a bill paid with money nothing was
+ * spent from. Cash is in, and is admin-only for the opposite reason: the
+ * operator who received it is the only party who can say so at all.
+ */
+const RECORDABLE_METHODS = Object.values(Enums.SettlementMethod).filter(
+  (method) => method !== Enums.SettlementMethod.Credit
+);
+
+const NO_DESTINATION = 'none';
+
+interface RecordBillPaymentDialogProps {
+  bill: PeriodBillData;
+}
+
+/** Record a bill settled out of band (admin only). */
+export function RecordBillPaymentDialog({ bill }: RecordBillPaymentDialogProps) {
+  const { t } = useTranslation('payments');
+  const [open, setOpen] = useState(false);
+  const settle = useSettlePeriodBill();
+
+  const { data: currencyData } = useCurrencyList();
+  const { data: destinations } = usePaymentDestinations();
+
+  const [method, setMethod] = useState<string>(Enums.SettlementMethod.Transferencia);
+  const [currencyCode, setCurrencyCode] = useState('');
+  const [reference, setReference] = useState('');
+  const [destinationId, setDestinationId] = useState<string>(NO_DESTINATION);
+  const [notes, setNotes] = useState('');
+  const [proof, setProof] = useState<File | null>(null);
+
+  const currencies = (currencyData?.items ?? []).filter((currency) => currency.isEnabled);
+  const takesDestination = DESTINATION_METHODS.includes(method);
+  // Pinned to the method and to an active row, because the api's own
+  // `Rule::exists()` is: a destination belonging to another method fails.
+  const availableDestinations = (destinations ?? []).filter(
+    (destination) => destination.active && destination.method === method
+  );
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setMethod(Enums.SettlementMethod.Transferencia);
+      setCurrencyCode(bill.currencyCode ?? '');
+      setReference(bill.reference ?? '');
+      setDestinationId(NO_DESTINATION);
+      // Seeded from the bill for the same reason `reference` is: the api writes
+      // `notes` UNCONDITIONALLY on settle, approve and reject — unlike
+      // `reference`, `proof_path` and `settlement_destination`, which each fall
+      // back to the bill's existing value when the act carries none. Left blank
+      // here, submitting would silently null a note an earlier act recorded,
+      // including a rejection reason the customer has already been sent.
+      setNotes(bill.notes ?? '');
+      setProof(null);
+    }
+    setOpen(isOpen);
+  };
+
+  const handleMethodChange = (value: string) => {
+    setMethod(value);
+    // A destination belongs to exactly one method, so keeping the old choice
+    // across a method change would send one the api is certain to refuse.
+    setDestinationId(NO_DESTINATION);
+  };
+
+  const handleSubmit = () => {
+    settle.mutate(
+      {
+        publicId: bill.publicId,
+        data: {
+          method: method as SettlementMethod,
+          currencyCode,
+          reference: reference.trim() || null,
+          destinationId:
+            takesDestination && destinationId !== NO_DESTINATION ? Number(destinationId) : null,
+          notes: notes.trim() || null,
+          proof,
+        },
+      },
+      { onSuccess: () => setOpen(false) }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <HandCoins className="mr-1 h-4 w-4" />
+          {t('manual.record_button')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('manual.record_title')}</DialogTitle>
+          <DialogDescription>{t('period_bill.title')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="settle-method">{validationAttribute('method')}</Label>
+            <Select value={method} onValueChange={handleMethodChange}>
+              <SelectTrigger id="settle-method" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RECORDABLE_METHODS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {t(`settlement_method.${value}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="settle-currency">{validationAttribute('currencyCode')}</Label>
+            <Select value={currencyCode} onValueChange={setCurrencyCode}>
+              <SelectTrigger id="settle-currency" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {currencies.map((currency) => (
+                  <SelectItem key={currency.code} value={currency.code ?? ''}>
+                    {currency.code}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {takesDestination && (
+            <div className="grid gap-2">
+              <Label htmlFor="settle-destination">{validationAttribute('destinationId')}</Label>
+              <Select value={destinationId} onValueChange={setDestinationId}>
+                <SelectTrigger id="settle-destination" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_DESTINATION}>{t('common:none')}</SelectItem>
+                  {availableDestinations.map((destination) => (
+                    <SelectItem key={destination.id} value={String(destination.id)}>
+                      {destination.holderName} — {destination.bankName ?? destination.phoneNumber}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="grid gap-2">
+            <Label htmlFor="settle-reference">{validationAttribute('reference')}</Label>
+            <Input
+              id="settle-reference"
+              value={reference}
+              onChange={(e) => setReference(e.target.value)}
+              placeholder={t('manual.reference_placeholder')}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="settle-proof">{t('record.proof_label')}</Label>
+            <Input
+              id="settle-proof"
+              type="file"
+              accept="image/*,application/pdf"
+              onChange={(e) => setProof(e.target.files?.[0] ?? null)}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="settle-notes">{validationAttribute('notes')}</Label>
+            <Textarea
+              id="settle-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              placeholder={t('manual.notes_placeholder')}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {actionLabel('cancel')}
+          </Button>
+          <Button disabled={settle.isPending || currencyCode === ''} onClick={handleSubmit}>
+            {t('record.submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/periodBills/SettlementDestinationSummary.tsx
+++ b/components/periodBills/SettlementDestinationSummary.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { validationAttribute } from '@/utils/lang';
+
+type PeriodBillData = App.Data.PeriodBill.PeriodBillData;
+type SettlementDestination = NonNullable<PeriodBillData['settlementDestination']>;
+
+interface SettlementDestinationSummaryProps {
+  destination: SettlementDestination;
+}
+
+/**
+ * Where the customer was told to send the money.
+ *
+ * A **snapshot** the bill recorded, not a live row: destinations are edited and
+ * deactivated while a bill's history must not move. It is shown because it is
+ * the only record of which account an operator should be looking in — the
+ * declared reference is meaningless against the wrong statement.
+ */
+export function SettlementDestinationSummary({ destination }: SettlementDestinationSummaryProps) {
+  const { t } = useTranslation('payments');
+
+  const fields: Array<[string, string | null]> = [
+    [validationAttribute('holderName'), destination.holderName],
+    [validationAttribute('legalId'), destination.legalId],
+    [validationAttribute('phoneNumber'), destination.phoneNumber],
+    [validationAttribute('bankName'), destination.bankName],
+    [validationAttribute('accountNumber'), destination.accountNumber],
+    [validationAttribute('iban'), destination.iban],
+    [validationAttribute('currencyCode'), destination.currencyCode],
+  ];
+
+  return (
+    <div className="bg-muted/50 space-y-1 rounded-md p-3">
+      <div className="flex items-center gap-2 text-xs font-semibold">
+        <span>{validationAttribute('destinationId')}</span>
+        <span className="text-muted-foreground font-normal">
+          {t(`settlement_method.${destination.method}`)}
+        </span>
+      </div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs">
+        {fields
+          .filter(([, value]) => value)
+          .map(([label, value]) => (
+            <div key={label} className="contents">
+              <dt className="text-muted-foreground">{label}</dt>
+              <dd className="font-mono">{value}</dd>
+            </div>
+          ))}
+      </dl>
+    </div>
+  );
+}

--- a/components/periodBills/VerifyDeclarationDialog.tsx
+++ b/components/periodBills/VerifyDeclarationDialog.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, ShieldCheck } from 'lucide-react';
+
+import {
+  DialogDescription,
+  DialogTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Dialog,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { usePeriodBill, useApproveDeclaration, useRejectDeclaration } from '@/hooks/periodBills';
+import { useOrderCurrencySymbol } from '@/hooks/currencies';
+import { actionLabel, validationAttribute } from '@/utils/lang';
+import { formatCurrency } from '@/utils/format';
+
+import { CopyableReference } from './CopyableReference';
+import { SettlementDestinationSummary } from './SettlementDestinationSummary';
+import { ProofViewer } from './ProofViewer';
+
+type PeriodBillData = App.Data.PeriodBill.PeriodBillData;
+
+interface VerifyDeclarationDialogProps {
+  bill: PeriodBillData;
+}
+
+function AmountRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono font-medium">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * The verification row, as a dialog: everything an operator needs to find the
+ * declared payment in the bank, and the two outcomes.
+ *
+ * It re-fetches the bill on open because the queue deliberately loads no lines
+ * — `getNeedsAttention()` selects `with('owner')` only, so `perCurrencyTotals`
+ * is absent from every row. The exact figure in the currency the customer says
+ * they sent lives on the detail, and "the exact amount" is the whole reason
+ * this row exists.
+ */
+export function VerifyDeclarationDialog({ bill }: VerifyDeclarationDialogProps) {
+  const { t } = useTranslation('payments');
+  const [open, setOpen] = useState(false);
+  const [notes, setNotes] = useState('');
+
+  const detail = usePeriodBill(open ? bill.publicId : '');
+  const approve = useApproveDeclaration();
+  const reject = useRejectDeclaration();
+
+  // The row's own copy until the detail lands, so the dialog is never blank.
+  const shown = detail.data ?? bill;
+  const baseSymbol = useOrderCurrencySymbol(null);
+  const declaredSymbol = useOrderCurrencySymbol(shown.currencyCode);
+
+  const pending = approve.isPending || reject.isPending;
+  // `notes` is required on a rejection and optional on an approval, because a
+  // rejection is what reaches the customer.
+  const canReject = notes.trim().length > 0 && !pending;
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) setNotes('');
+    setOpen(isOpen);
+  };
+
+  const close = () => setOpen(false);
+
+  const perCurrency = Object.entries(shown.perCurrencyTotals ?? {});
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <ShieldCheck className="mr-1 h-4 w-4" />
+          {actionLabel('verify')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('period_bill.title')}</DialogTitle>
+          <DialogDescription>{t('period_bill.awaiting_verification_hint')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="flex flex-wrap items-center gap-3">
+            {shown.settlementMethod && (
+              <span className="text-sm font-medium">
+                {t(`settlement_method.${shown.settlementMethod}`)}
+              </span>
+            )}
+            {shown.reference && <CopyableReference reference={shown.reference} />}
+          </div>
+
+          <div className="space-y-1">
+            <AmountRow
+              label={t('period_bill.period_total')}
+              value={formatCurrency(shown.baseAmount, baseSymbol)}
+            />
+            {shown.creditApplied > 0 && (
+              <AmountRow
+                label={t('period_bill.credit_applied')}
+                value={`-${formatCurrency(shown.creditApplied, baseSymbol)}`}
+              />
+            )}
+            <AmountRow
+              label={t('period_bill.net_due')}
+              value={formatCurrency(shown.netDue, baseSymbol)}
+            />
+            {/* The figure to look for in the bank when the customer paid in
+                their own currency rather than in base. */}
+            {perCurrency
+              .filter(([code]) => code === shown.currencyCode)
+              .map(([code, totals]) => (
+                <AmountRow
+                  key={code}
+                  label={code}
+                  value={formatCurrency(totals.amount, declaredSymbol)}
+                />
+              ))}
+          </div>
+
+          {shown.settlementDestination && (
+            <SettlementDestinationSummary destination={shown.settlementDestination} />
+          )}
+
+          {shown.proofUrl && <ProofViewer publicId={shown.publicId} />}
+
+          {/* Shown rather than pre-filled. The api writes `notes`
+              unconditionally on approve and reject, so whatever an earlier act
+              recorded is about to be replaced — and an operator cannot weigh
+              that without seeing it. Pre-filling would be worse here than in
+              the by-hand record: on a rejection this field reaches the
+              customer, and re-sending someone else's sentence as your own is
+              not a recovery from data loss. */}
+          {shown.notes && (
+            <p className="text-muted-foreground bg-muted/50 rounded-md p-2 text-xs">
+              {shown.notes}
+            </p>
+          )}
+
+          <div className="grid gap-2">
+            <Label htmlFor="verify-notes">{validationAttribute('notes')}</Label>
+            <Textarea
+              id="verify-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+            />
+          </div>
+
+          {detail.isLoading && (
+            <div className="text-muted-foreground flex items-center gap-2 text-xs">
+              <Loader2 className="h-3 w-3 animate-spin" />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="destructive"
+            disabled={!canReject}
+            onClick={() =>
+              reject.mutate({ publicId: shown.publicId, notes: notes.trim() }, { onSuccess: close })
+            }
+          >
+            {actionLabel('reject')}
+          </Button>
+          <Button
+            disabled={pending}
+            onClick={() =>
+              approve.mutate(
+                { publicId: shown.publicId, notes: notes.trim() || null },
+                { onSuccess: close }
+              )
+            }
+          >
+            {actionLabel('approve')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/periodBills/__tests__/BillAttentionCard.test.tsx
+++ b/components/periodBills/__tests__/BillAttentionCard.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { BillAttentionCard } from '../BillAttentionCard';
+import { Enums } from '@/data/app-enums';
+
+type BillNeedsAttentionData = App.Data.PeriodBill.BillNeedsAttentionData;
+type PeriodBillData = App.Data.PeriodBill.PeriodBillData;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  statusLabel: (key: string) => `statuses:${key}`,
+}));
+
+vi.mock('@/hooks/currencies', () => ({
+  useOrderCurrencySymbol: () => '₡',
+}));
+
+vi.mock('@/hooks/useLocalizedRouter', () => ({
+  useLocalizedRouter: () => ({ push: vi.fn(), lang: 'en' }),
+}));
+
+// The two acts have their own coverage; this test is about what the row says.
+vi.mock('../VerifyDeclarationDialog', () => ({
+  VerifyDeclarationDialog: () => <div data-testid="verify-dialog" />,
+}));
+vi.mock('../RecordBillPaymentDialog', () => ({
+  RecordBillPaymentDialog: () => <div data-testid="record-dialog" />,
+}));
+
+// `data/app-enums.ts` holds plain string constants; `generated.d.ts` declares
+// nominal TS enums over the same values, and the two are deliberately not
+// assignable to each other. Production code never needs the bridge — it reads
+// these values off DTOs, where they already carry the nominal type — so
+// fixtures cross that boundary once, here.
+const URGENCY_FOR_REASON: Record<string, string> = {
+  [Enums.BillAttentionReason.UnresolvedCharge]: Enums.AttentionUrgency.Critical,
+  [Enums.BillAttentionReason.Overdue]: Enums.AttentionUrgency.High,
+  [Enums.BillAttentionReason.DeclarationToVerify]: Enums.AttentionUrgency.Medium,
+  [Enums.BillAttentionReason.Quiet]: Enums.AttentionUrgency.Low,
+};
+
+function item(reason: string, overrides: Partial<PeriodBillData> = {}): BillNeedsAttentionData {
+  return {
+    bill: {
+      publicId: 'pb-1',
+      cutoffAt: '2026-02-01T00:00:00Z',
+      dueAt: '2026-02-08T00:00:00Z',
+      baseAmount: 18000,
+      creditApplied: 0,
+      netDue: 18000,
+      isOverdue: false,
+      currencyCode: null,
+      status: Enums.PeriodBillStatus.Issued,
+      settlementMethod: null,
+      reference: null,
+      proofUrl: null,
+      settlementDestination: null,
+      ...overrides,
+    } as PeriodBillData,
+    urgency: URGENCY_FOR_REASON[reason],
+    reason,
+    ownerType: 'business',
+    ownerPublicId: 'biz-1',
+    ownerName: 'Acme SA',
+  } as BillNeedsAttentionData;
+}
+
+describe('BillAttentionCard — every reason the api can send', () => {
+  // Driven off the enum rather than a written list, so a case added to
+  // `BillAttentionReason` without a label or a rank fails here.
+  it.each(Object.values(Enums.BillAttentionReason))('renders %s with its urgency', (reason) => {
+    render(<BillAttentionCard item={item(reason)} />);
+
+    expect(screen.getByText(`bill_attention_reason.${reason}`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`needs_attention.urgency.${URGENCY_FOR_REASON[reason]}`)
+    ).toBeInTheDocument();
+  });
+
+  it('names the account the bill belongs to', () => {
+    render(<BillAttentionCard item={item(Enums.BillAttentionReason.Quiet)} />);
+
+    expect(screen.getByText('Acme SA')).toBeInTheDocument();
+    expect(screen.getByText('#pb-1')).toBeInTheDocument();
+  });
+});
+
+describe('BillAttentionCard — the state most likely to be misread', () => {
+  // A declared transfer is a claim, not a payment: the clock keeps running and
+  // the row has to say so rather than reading as settled.
+  it('offers verification and says the due date has not moved on a declaration', () => {
+    render(
+      <BillAttentionCard
+        item={item(Enums.BillAttentionReason.DeclarationToVerify, {
+          status: Enums.PeriodBillStatus.AwaitingVerification as App.Enums.PeriodBillStatus,
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('verify-dialog')).toBeInTheDocument();
+    expect(screen.getByText('period_bill.awaiting_verification_hint')).toBeInTheDocument();
+  });
+
+  it('offers no verification on a bill with nothing declared', () => {
+    render(<BillAttentionCard item={item(Enums.BillAttentionReason.Quiet)} />);
+
+    expect(screen.queryByTestId('verify-dialog')).not.toBeInTheDocument();
+    // Recording a payment received out of band is always available to an admin.
+    expect(screen.getByTestId('record-dialog')).toBeInTheDocument();
+  });
+
+  it('flags an overdue bill', () => {
+    render(
+      <BillAttentionCard item={item(Enums.BillAttentionReason.Overdue, { isOverdue: true })} />
+    );
+
+    expect(screen.getByText('period_bill.overdue_hint')).toBeInTheDocument();
+  });
+});

--- a/components/periodBills/__tests__/ProofViewer.test.tsx
+++ b/components/periodBills/__tests__/ProofViewer.test.tsx
@@ -104,13 +104,17 @@ describe('ProofViewer — the comprobante opens through the authenticated route'
     expect(screen.queryByAltText('proof')).not.toBeInTheDocument();
   });
 
-  it('reports a missing comprobante instead of showing an empty frame', async () => {
-    vi.mocked(PeriodBillService.fetchProof).mockRejectedValue(new Error('404'));
+  // A load FAILURE, never an absence: this viewer only mounts when `proofUrl`
+  // is set, so the api has already said a comprobante exists. Told "no proof is
+  // attached", an operator stops looking instead of retrying a 401.
+  it('reports a failed load rather than claiming there is no comprobante', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockRejectedValue(new Error('401'));
     const user = userEvent.setup();
 
     render(<ProofViewer publicId="pb-1" />, { wrapper });
     await user.click(screen.getByRole('button', { name: 'proof' }));
 
-    expect(await screen.findByText('errors:period_bill.proof_missing')).toBeInTheDocument();
+    expect(await screen.findByText('resource:failed_to_load')).toBeInTheDocument();
+    expect(screen.queryByText('errors:period_bill.proof_missing')).not.toBeInTheDocument();
   });
 });

--- a/components/periodBills/__tests__/ProofViewer.test.tsx
+++ b/components/periodBills/__tests__/ProofViewer.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import { ProofViewer } from '../ProofViewer';
+import { PeriodBillService } from '@/services/periodBillService';
+
+const OBJECT_URL = 'blob:mock-object-url';
+
+/**
+ * Every url this component puts in the DOM, from any attribute a browser would
+ * fetch. `PeriodBillData.proofUrl` is an authenticated stream on a private
+ * disk — reached from the DOM it carries no Authorization header and comes back
+ * 401 — so the property under test is that all of these are object URLs over
+ * bytes already fetched, and none is an http(s) route.
+ */
+function fetchableUrls(): string[] {
+  return Array.from(document.querySelectorAll('[src], [href], [data]'))
+    .flatMap((element) => [
+      element.getAttribute('src'),
+      element.getAttribute('href'),
+      element.getAttribute('data'),
+    ])
+    .filter((value): value is string => value !== null);
+}
+
+vi.mock('@/services/periodBillService', () => ({
+  PeriodBillService: { fetchProof: vi.fn() },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  validationAttribute: (key: string) => key,
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const createObjectURL = vi.fn(() => OBJECT_URL);
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(PeriodBillService.fetchProof).mockReset();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ProofViewer — the comprobante opens through the authenticated route', () => {
+  it('fetches the bytes through the service and never points the DOM at the route', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockResolvedValue(
+      new Blob(['bytes'], { type: 'image/png' })
+    );
+    const user = userEvent.setup();
+
+    render(<ProofViewer publicId="pb-1" />, { wrapper });
+    await user.click(screen.getByRole('button', { name: 'proof' }));
+
+    await waitFor(() => expect(PeriodBillService.fetchProof).toHaveBeenCalledWith('pb-1'));
+
+    const image = await screen.findByAltText('proof');
+    expect(image).toHaveAttribute('src', OBJECT_URL);
+
+    // The load-bearing half: a plain src/href at the api route renders fine
+    // under test and 401s in a browser, so what is asserted is that nothing
+    // fetchable points anywhere but at the bytes already in hand.
+    const urls = fetchableUrls();
+    expect(urls).not.toHaveLength(0);
+    expect(urls.every((url) => url.startsWith('blob:'))).toBe(true);
+  });
+
+  it('does not fetch anything until an operator asks to see it', () => {
+    vi.mocked(PeriodBillService.fetchProof).mockResolvedValue(new Blob(['bytes']));
+
+    render(<ProofViewer publicId="pb-1" />, { wrapper });
+
+    expect(PeriodBillService.fetchProof).not.toHaveBeenCalled();
+  });
+
+  it('embeds a PDF comprobante rather than rendering it as a broken image', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockResolvedValue(
+      new Blob(['%PDF'], { type: 'application/pdf' })
+    );
+    const user = userEvent.setup();
+
+    const { container } = render(<ProofViewer publicId="pb-1" />, { wrapper });
+    await user.click(screen.getByRole('button', { name: 'proof' }));
+
+    await waitFor(() => expect(container.ownerDocument.querySelector('object')).not.toBeNull());
+    expect(container.ownerDocument.querySelector('object')).toHaveAttribute('data', OBJECT_URL);
+    expect(screen.queryByAltText('proof')).not.toBeInTheDocument();
+  });
+
+  it('reports a missing comprobante instead of showing an empty frame', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockRejectedValue(new Error('404'));
+    const user = userEvent.setup();
+
+    render(<ProofViewer publicId="pb-1" />, { wrapper });
+    await user.click(screen.getByRole('button', { name: 'proof' }));
+
+    expect(await screen.findByText('errors:period_bill.proof_missing')).toBeInTheDocument();
+  });
+});

--- a/components/periodBills/__tests__/VerifyDeclarationDialog.test.tsx
+++ b/components/periodBills/__tests__/VerifyDeclarationDialog.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { VerifyDeclarationDialog } from '../VerifyDeclarationDialog';
+import { Enums } from '@/data/app-enums';
+
+type PeriodBillData = App.Data.PeriodBill.PeriodBillData;
+
+/** The authenticated stream route the api puts on `proofUrl`. */
+const PROOF_ROUTE = 'https://api.mandados.test/period-bills/pb-1/proof';
+
+const approveMutate = vi.fn();
+const rejectMutate = vi.fn();
+let detail: PeriodBillData | undefined;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+vi.mock('@/hooks/currencies', () => ({
+  useOrderCurrencySymbol: () => '₡',
+}));
+
+vi.mock('@/hooks/periodBills', () => ({
+  usePeriodBill: () => ({ data: detail, isLoading: false }),
+  useApproveDeclaration: () => ({ mutate: approveMutate, isPending: false }),
+  useRejectDeclaration: () => ({ mutate: rejectMutate, isPending: false }),
+}));
+
+// Its own test proves the comprobante loads through the authenticated route.
+vi.mock('../ProofViewer', () => ({
+  ProofViewer: () => <div data-testid="proof-viewer" />,
+}));
+
+function bill(overrides: Partial<PeriodBillData> = {}): PeriodBillData {
+  return {
+    publicId: 'pb-1',
+    cutoffAt: '2026-02-01T00:00:00Z',
+    dueAt: '2026-02-08T00:00:00Z',
+    baseAmount: 18000,
+    creditApplied: 3000,
+    netDue: 15000,
+    isOverdue: false,
+    currencyCode: 'CRC',
+    status: Enums.PeriodBillStatus.AwaitingVerification,
+    settlementMethod: Enums.SettlementMethod.Transferencia,
+    reference: 'REF-42',
+    proofUrl: PROOF_ROUTE,
+    settlementDestination: {
+      id: 3,
+      method: Enums.SettlementMethod.Transferencia,
+      currencyCode: 'CRC',
+      phoneNumber: null,
+      bankName: 'Banco Nacional',
+      accountNumber: '100-2003',
+      iban: null,
+      holderName: 'Mandados SA',
+      legalId: '3-101-999',
+    },
+    ...overrides,
+  } as PeriodBillData;
+}
+
+async function open(data: PeriodBillData = bill()) {
+  const user = userEvent.setup();
+  detail = data;
+  render(<VerifyDeclarationDialog bill={data} />);
+  await user.click(screen.getByRole('button', { name: 'verify' }));
+  return user;
+}
+
+beforeEach(() => {
+  approveMutate.mockClear();
+  rejectMutate.mockClear();
+  detail = undefined;
+});
+
+describe('VerifyDeclarationDialog — finding the payment in the bank', () => {
+  it('shows the reference, the exact amount and where the customer was told to send it', async () => {
+    await open();
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('REF-42')).toBeInTheDocument();
+    expect(within(dialog).getByText('₡15,000.00')).toBeInTheDocument();
+    expect(within(dialog).getByText('Banco Nacional')).toBeInTheDocument();
+    expect(within(dialog).getByText('100-2003')).toBeInTheDocument();
+    expect(within(dialog).getByText('Mandados SA')).toBeInTheDocument();
+  });
+
+  // The comprobante is corroboration, not evidence: it goes through the
+  // authenticated stream, and the raw route must never reach the DOM, where it
+  // renders under test and 401s in a browser.
+  it('never points the DOM at the proof route', async () => {
+    await open();
+
+    expect(screen.getByTestId('proof-viewer')).toBeInTheDocument();
+    expect(document.body.innerHTML).not.toContain(PROOF_ROUTE);
+  });
+
+  it('offers no comprobante when the bill carries none', async () => {
+    await open(bill({ proofUrl: null }));
+
+    expect(screen.queryByTestId('proof-viewer')).not.toBeInTheDocument();
+  });
+});
+
+describe('VerifyDeclarationDialog — the two outcomes', () => {
+  // The asymmetry is the api's and it is deliberate: a rejection reaches the
+  // customer, so it carries a reason; an approval agrees with what they already
+  // stated and needs none.
+  it('refuses to reject without a reason', async () => {
+    await open();
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('button', { name: 'reject' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'approve' })).not.toBeDisabled();
+  });
+
+  it('sends the reason with a rejection', async () => {
+    const user = await open();
+
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByLabelText('notes'), 'not in the account');
+    await user.click(within(dialog).getByRole('button', { name: 'reject' }));
+
+    expect(rejectMutate).toHaveBeenCalledWith(
+      { publicId: 'pb-1', notes: 'not in the account' },
+      expect.anything()
+    );
+  });
+
+  it('approves with a null note rather than an empty string', async () => {
+    const user = await open();
+
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'approve' }));
+
+    expect(approveMutate).toHaveBeenCalledWith(
+      { publicId: 'pb-1', notes: null },
+      expect.anything()
+    );
+  });
+});

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -91,6 +91,12 @@ export const Enums = {
     DELIVERY: 'delivery',
     INSTRUCTIONS: 'instructions',
   },
+  BillAttentionReason: {
+    UnresolvedCharge: 'unresolved_charge',
+    Overdue: 'overdue',
+    DeclarationToVerify: 'declaration_to_verify',
+    Quiet: 'quiet',
+  },
   BillingCycle: {
     PerOrder: 'per_order',
     Weekly: 'weekly',
@@ -331,13 +337,19 @@ export const Enums = {
     VOIDED: 'voided',
     CHARGEBACK: 'chargeback',
   },
+  PeriodBillChargeOutcome: {
+    Settled: 'settled',
+    Declined: 'declined',
+    Unresolved: 'unresolved',
+    NoUsableCard: 'no_usable_card',
+    NotPayable: 'not_payable',
+    Unsupported: 'unsupported',
+  },
   PeriodBillStatus: {
     Open: 'open',
     Issued: 'issued',
     AwaitingVerification: 'awaiting_verification',
     Paid: 'paid',
-    Failed: 'failed',
-    Uncollectible: 'uncollectible',
   },
   PricingCalculationMode: {
     CUMULATIVE: 'cumulative',
@@ -423,6 +435,7 @@ export const Enums = {
     SinpeMobile: 'sinpe_mobile',
     Transferencia: 'transferencia',
     Cash: 'cash',
+    Credit: 'credit',
   },
   TipoIdentificacion: {
     Fisica: '01',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,8 +16,12 @@ app/admin/
 │   │   ├── businesses/   # Business management
 │   │   ├── catalogs/     # Catalog management
 │   │   ├── pricing/      # Pricing rules
+│   │   ├── period-bills/ # Period bill detail (deferred billing)
 │   │   ├── notifications/# Notification history
 │   │   └── settings/     # Admin settings
+│   │       ├── currencies/
+│   │       ├── payment-destinations/  # Where customers are told to send money
+│   │       └── service-window/
 │   └── layout.tsx        # Root layout with providers
 ├── components/
 │   ├── ui/               # shadcn/ui components
@@ -244,6 +248,54 @@ NotificationService.markAllAsRead(); // PATCH /notifications/read-all
 NotificationService.destroy(id); // DELETE /notifications/{id}
 ```
 
+### Period Bill Service
+
+```typescript
+import { PeriodBillService } from '@/services/periodBillService';
+
+PeriodBillService.needsAttention(); // GET /period-bills/needs-attention (staff)
+PeriodBillService.getById(publicId); // GET /period-bills/{publicId}
+PeriodBillService.settle(publicId, data); // POST .../settle   (admin, multipart)
+PeriodBillService.approveDeclaration(publicId, notes); // POST .../approve (admin)
+PeriodBillService.rejectDeclaration(publicId, notes); // POST .../reject  (admin)
+PeriodBillService.fetchProof(publicId); // GET .../proof  → Blob
+```
+
+Two things about this service are load-bearing:
+
+- **`needsAttention()` is a pass-through and must stay one.** The api returns one
+  row per bill at its most urgent reason, already sorted: `BillAttentionReason`
+  declares its cases in precedence order (unresolved charge → overdue →
+  declaration to verify → quiet) and the endpoint sorts by urgency then due
+  date. An unresolved charge outranks an overdue bill because the customer's
+  money may already be gone while the bill still reads unpaid. **Never re-sort
+  these rows client-side** — it silently discards a ranking nothing else states.
+- **`fetchProof()` bypasses `api.get()` on purpose.** `PeriodBillData.proofUrl`
+  names an authenticated stream route on a private disk, not a storage URL:
+  rendered as a plain `href` or `<img src>` the browser sends no Authorization
+  header and the api answers 401. `api.get()` parses JSON and returns `{}` for a
+  byte stream, so the bytes are fetched here with the token attached and handed
+  to `useBillProof()`, which wraps them in an object URL and revokes it on
+  unmount. `services/uploadService.ts` is the existing precedent for a service
+  doing its own authenticated `fetch`.
+
+### Payment Destination Service
+
+```typescript
+import { PaymentDestinationService } from '@/services/paymentDestinationService';
+
+PaymentDestinationService.list(); // GET /payment-destinations (staff, walks pages)
+PaymentDestinationService.create(data); // POST   (admin)
+PaymentDestinationService.update(id, data); // PATCH  (admin) — `method` is immutable
+PaymentDestinationService.destroy(id); // DELETE (admin) — soft delete
+```
+
+Addressed by numeric `id`, not a public id. The api paginates the index at a
+fixed 15 and reads no `per_page`, so `list()` walks the pages rather than
+truncating. `method` decides which other fields a row may carry and cannot be
+changed after creation — swapping one means deactivating the row and creating a
+new one.
+
 ### Other Services
 
 - `DriverService` - Driver CRUD + approval
@@ -423,6 +475,45 @@ const { data, isLoading } = useNotifications({
 
 // Unread count (for bell badge)
 const { data: count } = useUnreadCount();
+```
+
+### Period Bills
+
+```typescript
+import {
+  useBillsNeedingAttention,
+  usePeriodBill,
+  useSettlePeriodBill,
+  useApproveDeclaration,
+  useRejectDeclaration,
+  useBillProof,
+} from '@/hooks/periodBills';
+
+// The sixth Needs Attention tab. Rows arrive ordered by the api — render them
+// as they come; see the Period Bill Service note above.
+const { data } = useBillsNeedingAttention(); // { items, summary } keyed by AttentionUrgency
+
+// The detail. The queue loads no lines, so `perCurrencyTotals` and `lines` are
+// absent on a queue row and present only here.
+const { data: bill } = usePeriodBill(publicId);
+
+// The comprobante, fetched through the authenticated route and revoked on unmount.
+const proof = useBillProof(publicId, isViewerOpen); // { url, contentType, isLoading, isError }
+```
+
+Query key is `['period-bills', ...]`; every act invalidates the whole key,
+because approving, rejecting or recording a payment all change which bills need
+a person.
+
+### Payment Destinations
+
+```typescript
+import {
+  usePaymentDestinations,
+  useCreatePaymentDestination,
+  useUpdatePaymentDestination,
+  useDeletePaymentDestination,
+} from '@/hooks/paymentDestinations';
 ```
 
 ---

--- a/hooks/paymentDestinations/index.ts
+++ b/hooks/paymentDestinations/index.ts
@@ -1,0 +1,2 @@
+export * from './usePaymentDestinations';
+export * from './usePaymentDestinationMutations';

--- a/hooks/paymentDestinations/usePaymentDestinationMutations.ts
+++ b/hooks/paymentDestinations/usePaymentDestinationMutations.ts
@@ -1,0 +1,37 @@
+import { PaymentDestinationService } from '@/services/paymentDestinationService';
+import { useResourceMutation } from '@/hooks/useResourceMutation';
+
+type StorePaymentDestinationData = App.Data.PaymentDestination.StorePaymentDestinationData;
+type UpdatePaymentDestinationData = App.Data.PaymentDestination.UpdatePaymentDestinationData;
+
+const DESTINATION_MUTATION = {
+  queryKey: 'payment-destinations',
+  resource: 'payment_destination',
+} as const;
+
+export function useCreatePaymentDestination() {
+  return useResourceMutation<StorePaymentDestinationData>(
+    (data) => PaymentDestinationService.create(data),
+    { ...DESTINATION_MUTATION, successAction: 'created', errorAction: 'creating' }
+  );
+}
+
+interface UpdateArgs {
+  id: number;
+  data: UpdatePaymentDestinationData;
+}
+
+export function useUpdatePaymentDestination() {
+  return useResourceMutation<UpdateArgs>(
+    ({ id, data }) => PaymentDestinationService.update(id, data),
+    { ...DESTINATION_MUTATION, successAction: 'updated', errorAction: 'updating' }
+  );
+}
+
+export function useDeletePaymentDestination() {
+  return useResourceMutation<number>((id) => PaymentDestinationService.destroy(id), {
+    ...DESTINATION_MUTATION,
+    successAction: 'deleted',
+    errorAction: 'deleting',
+  });
+}

--- a/hooks/paymentDestinations/usePaymentDestinations.ts
+++ b/hooks/paymentDestinations/usePaymentDestinations.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { PaymentDestinationService } from '@/services/paymentDestinationService';
+
+/** Every destination, active and deactivated alike. */
+export function usePaymentDestinations() {
+  return useQuery({
+    queryKey: ['payment-destinations'],
+    queryFn: () => PaymentDestinationService.list(),
+  });
+}

--- a/hooks/periodBills/__tests__/useBillProof.test.tsx
+++ b/hooks/periodBills/__tests__/useBillProof.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useBillProof } from '../useBillProof';
+import { PeriodBillService } from '@/services/periodBillService';
+
+const OBJECT_URL = 'blob:mock-object-url';
+
+vi.mock('@/services/periodBillService', () => ({
+  PeriodBillService: { fetchProof: vi.fn() },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const createObjectURL = vi.fn(() => OBJECT_URL);
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(PeriodBillService.fetchProof).mockReset();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useBillProof', () => {
+  it('fetches nothing while the viewer is closed', () => {
+    renderHook(() => useBillProof('pb-1', false), { wrapper });
+
+    expect(PeriodBillService.fetchProof).not.toHaveBeenCalled();
+  });
+
+  it('wraps the fetched bytes in an object URL and reports their type', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockResolvedValue(
+      new Blob(['bytes'], { type: 'application/pdf' })
+    );
+
+    const { result } = renderHook(() => useBillProof('pb-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.url).toBe(OBJECT_URL));
+    expect(result.current.contentType).toBe('application/pdf');
+  });
+
+  // An object URL pins its blob in memory until it is revoked, and a
+  // verification workspace opens many of these in a sitting.
+  it('releases the object URL when the viewer goes away', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockResolvedValue(new Blob(['bytes']));
+
+    const { result, unmount } = renderHook(() => useBillProof('pb-1', true), { wrapper });
+    await waitFor(() => expect(result.current.url).toBe(OBJECT_URL));
+
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(OBJECT_URL);
+  });
+
+  it('reports a failure rather than an empty url that reads as "no proof"', async () => {
+    vi.mocked(PeriodBillService.fetchProof).mockRejectedValue(new Error('401'));
+
+    const { result } = renderHook(() => useBillProof('pb-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.url).toBeNull();
+  });
+});

--- a/hooks/periodBills/__tests__/usePeriodBillMutations.test.tsx
+++ b/hooks/periodBills/__tests__/usePeriodBillMutations.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { toast } from 'sonner';
+
+import { useRejectDeclaration, useSettlePeriodBill } from '../usePeriodBillMutations';
+import { PeriodBillService } from '@/services/periodBillService';
+import { ApiError } from '@/lib/api/error';
+import { Enums } from '@/data/app-enums';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/services/periodBillService', () => ({
+  PeriodBillService: {
+    settle: vi.fn(),
+    approveDeclaration: vi.fn(),
+    rejectDeclaration: vi.fn(),
+  },
+}));
+
+// The real helpers resolve translations from the api at runtime (see
+// config/i18next.ts), which this test suite has no server for.
+vi.mock('@/utils/lang', () => ({
+  crudSuccessMessage: (action: string, resource: string) => `${action}:${resource}`,
+  crudErrorMessage: (action: string, resource: string) => `${action}:${resource}`,
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.success).mockClear();
+  vi.mocked(PeriodBillService.settle).mockReset();
+  vi.mocked(PeriodBillService.rejectDeclaration).mockReset();
+});
+
+// Every refusal on these routes is one the operator can act on — a currency
+// this bill cannot settle in, a destination belonging to another method, a
+// bucket still open — and each arrives from the api already translated.
+// Replacing it with a generic "error updating" throws away the only part that
+// says what to do differently.
+describe('period-bill acts — refusal reporting', () => {
+  it("shows the api's own explanation when a settlement is refused", async () => {
+    const refusal = 'This bill can only be settled in CRC.';
+    vi.mocked(PeriodBillService.settle).mockRejectedValue(new ApiError(refusal, 422));
+
+    const { result } = renderHook(() => useSettlePeriodBill(), { wrapper });
+    result.current.mutate({
+      publicId: 'pb-1',
+      data: {
+        method: Enums.SettlementMethod.Cash as App.Enums.SettlementMethod,
+        currencyCode: 'USD',
+      },
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith(refusal);
+  });
+
+  it('falls back to the generic message when the failure carries none', async () => {
+    vi.mocked(PeriodBillService.settle).mockRejectedValue(new Error('Network request failed'));
+
+    const { result } = renderHook(() => useSettlePeriodBill(), { wrapper });
+    result.current.mutate({
+      publicId: 'pb-1',
+      data: {
+        method: Enums.SettlementMethod.Cash as App.Enums.SettlementMethod,
+        currencyCode: 'CRC',
+      },
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith('updating:period_bill');
+  });
+
+  it('reports a rejection under the act the operator pressed, not a denial', async () => {
+    vi.mocked(PeriodBillService.rejectDeclaration).mockResolvedValue(
+      {} as App.Data.PeriodBill.PeriodBillData
+    );
+
+    const { result } = renderHook(() => useRejectDeclaration(), { wrapper });
+    result.current.mutate({ publicId: 'pb-1', notes: 'not in the account' });
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(toast.success).toHaveBeenCalledWith('rejected:period_bill');
+  });
+});

--- a/hooks/periodBills/index.ts
+++ b/hooks/periodBills/index.ts
@@ -1,0 +1,4 @@
+export * from './useBillsNeedingAttention';
+export * from './usePeriodBill';
+export * from './usePeriodBillMutations';
+export * from './useBillProof';

--- a/hooks/periodBills/useBillProof.ts
+++ b/hooks/periodBills/useBillProof.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { PeriodBillService } from '@/services/periodBillService';
+
+export interface BillProof {
+  /** An object URL for the fetched bytes — safe to hand to `<img>` or `<object>`. */
+  url: string | null;
+  /** So a PDF comprobante can be embedded rather than shown as a broken image. */
+  contentType: string | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Load a bill's comprobante for display.
+ *
+ * `PeriodBillData.proofUrl` is an **authenticated stream route**, not a
+ * storage URL: pointed at directly by `<img src>` or `<a href>` the browser
+ * sends no Authorization header and the api answers 401. So the bytes are
+ * fetched with the token attached and wrapped in an object URL here.
+ *
+ * The URL is *derived* from the blob during render rather than pushed into
+ * state from an effect — an effect that calls `setState` synchronously
+ * cascades a second render, and there is nothing here to synchronize *into*
+ * React. The one thing that genuinely belongs in an effect is releasing the
+ * URL, which is an external resource with a lifetime.
+ *
+ * @param publicId the bill's public id
+ * @param enabled  false while the viewer is closed, so nothing is fetched
+ *                 until an operator asks to see it
+ */
+export function useBillProof(publicId: string, enabled: boolean): BillProof {
+  const query = useQuery({
+    // Deliberately OUTSIDE the ['period-bills'] prefix. The bytes are
+    // immutable content addressed by bill id, not part of the bill's mutable
+    // state, and under that prefix every settle/approve/reject invalidation
+    // matched it — re-fetching the whole comprobante, and churning its object
+    // URL, whenever an act landed while the viewer was open.
+    queryKey: ['period-bill-proof', publicId],
+    queryFn: () => PeriodBillService.fetchProof(publicId),
+    enabled: enabled && publicId !== '',
+    staleTime: Infinity,
+  });
+
+  const blob = query.data;
+  const url = useMemo(() => (blob ? URL.createObjectURL(blob) : null), [blob]);
+
+  useEffect(() => {
+    if (!url) return;
+
+    return () => URL.revokeObjectURL(url);
+  }, [url]);
+
+  return {
+    url,
+    contentType: blob?.type ?? null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/hooks/periodBills/useBillsNeedingAttention.ts
+++ b/hooks/periodBills/useBillsNeedingAttention.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { PeriodBillService } from '@/services/periodBillService';
+
+/**
+ * Every bill that needs a person, across all accounts.
+ *
+ * The rows arrive ordered by the api and are handed on untouched — see
+ * `BillsNeedingAttention.items` for why re-sorting them would be a defect.
+ */
+export function useBillsNeedingAttention() {
+  return useQuery({
+    queryKey: ['period-bills', 'needs-attention'],
+    queryFn: () => PeriodBillService.needsAttention(),
+    staleTime: 30_000,
+  });
+}

--- a/hooks/periodBills/usePeriodBill.ts
+++ b/hooks/periodBills/usePeriodBill.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { PeriodBillService } from '@/services/periodBillService';
+
+/** One bill, with its lines and per-currency totals. */
+export function usePeriodBill(publicId: string) {
+  return useQuery({
+    queryKey: ['period-bills', publicId],
+    queryFn: () => PeriodBillService.getById(publicId),
+    enabled: publicId !== '',
+  });
+}

--- a/hooks/periodBills/usePeriodBillMutations.ts
+++ b/hooks/periodBills/usePeriodBillMutations.ts
@@ -1,0 +1,55 @@
+import { PeriodBillService, type SettlePeriodBillParams } from '@/services/periodBillService';
+import { useResourceMutation } from '@/hooks/useResourceMutation';
+
+/**
+ * Approving, rejecting and recording a payment all change which bills need a
+ * person, so each invalidates the whole `period-bills` prefix rather than one
+ * row. The comprobante is deliberately keyed outside that prefix — see
+ * `useBillProof` — so an open proof is not re-fetched by an act on its bill.
+ */
+const BILL_MUTATION = {
+  queryKey: 'period-bills',
+  resource: 'period_bill',
+} as const;
+
+interface SettleArgs {
+  publicId: string;
+  data: SettlePeriodBillParams;
+}
+
+/** Record a payment received out of band (admin only). */
+export function useSettlePeriodBill() {
+  return useResourceMutation<SettleArgs>(
+    ({ publicId, data }) => PeriodBillService.settle(publicId, data),
+    { ...BILL_MUTATION, successAction: 'updated', errorAction: 'updating' }
+  );
+}
+
+interface ApproveArgs {
+  publicId: string;
+  notes: string | null;
+}
+
+/** The transfer was found in the bank. */
+export function useApproveDeclaration() {
+  return useResourceMutation<ApproveArgs>(
+    ({ publicId, notes }) => PeriodBillService.approveDeclaration(publicId, notes),
+    { ...BILL_MUTATION, successAction: 'approved', errorAction: 'approving' }
+  );
+}
+
+interface RejectArgs {
+  publicId: string;
+  notes: string;
+}
+
+/**
+ * The transfer could not be found. `notes` is required rather than optional
+ * because the reason reaches the customer.
+ */
+export function useRejectDeclaration() {
+  return useResourceMutation<RejectArgs>(
+    ({ publicId, notes }) => PeriodBillService.rejectDeclaration(publicId, notes),
+    { ...BILL_MUTATION, successAction: 'rejected', errorAction: 'rejecting' }
+  );
+}

--- a/hooks/useResourceMutation.ts
+++ b/hooks/useResourceMutation.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { isApiError } from '@/lib/api/error';
+import { crudErrorMessage, crudSuccessMessage } from '@/utils/lang';
+
+interface ResourceMutationOptions {
+  /** The query-key prefix to invalidate once the act succeeds. */
+  queryKey: string;
+  /** The `models:*` key naming what was acted on, for the toast. */
+  resource: string;
+  /** A `common:actions.*` past-tense key — `created`, `updated`, `rejected`. */
+  successAction: string;
+  /** The matching `resource:error.*` key — `creating`, `updating`, `rejecting`. */
+  errorAction: string;
+}
+
+/**
+ * A write against one resource: invalidate its queries, then say what happened.
+ *
+ * The api refuses these for reasons an operator can act on — a currency a bill
+ * cannot settle in, a destination belonging to another method, a bucket still
+ * open — and each refusal arrives already translated. Surfacing the api's own
+ * message rather than a generic "error updating" keeps the only part that says
+ * what to change.
+ */
+export function useResourceMutation<TArgs>(
+  act: (args: TArgs) => Promise<unknown>,
+  { queryKey, resource, successAction, errorAction }: ResourceMutationOptions
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: act,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey] });
+      toast.success(crudSuccessMessage(successAction, resource));
+    },
+    onError: (error) => {
+      if (isApiError(error)) {
+        toast.error(error.message);
+      } else {
+        toast.error(crudErrorMessage(errorAction, resource));
+      }
+    },
+  });
+}

--- a/services/__tests__/paymentDestinationService.test.ts
+++ b/services/__tests__/paymentDestinationService.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { PaymentDestinationService } from '../paymentDestinationService';
+import { api } from '@/lib/api/client';
+import { Enums } from '@/data/app-enums';
+
+type PaymentDestinationData = App.Data.PaymentDestination.PaymentDestinationData;
+
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+function page(items: PaymentDestinationData[], currentPage: number, lastPage: number) {
+  return { items, meta: { currentPage, lastPage } };
+}
+
+// `data/app-enums.ts` holds plain string constants; `generated.d.ts` declares
+// nominal TS enums over the same values, and the two are deliberately not
+// assignable to each other. Production code never needs the bridge — it reads
+// these values off DTOs, where they already carry the nominal type — so
+// fixtures cross that boundary once, here.
+function destination(id: number): PaymentDestinationData {
+  return {
+    id,
+    method: Enums.SettlementMethod.Transferencia,
+    active: true,
+  } as PaymentDestinationData;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PaymentDestinationService.list', () => {
+  // The api paginates this at a fixed 15 and reads no `per_page`. Deactivated
+  // rows are kept forever, so truncating at page one would eventually hide live
+  // destinations behind retired ones.
+  it('walks every page rather than returning the first', async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce(page([destination(1), destination(2)], 1, 3))
+      .mockResolvedValueOnce(page([destination(3)], 2, 3))
+      .mockResolvedValueOnce(page([destination(4)], 3, 3));
+
+    const result = await PaymentDestinationService.list();
+
+    expect(result.map((row) => row.id)).toEqual([1, 2, 3, 4]);
+    expect(api.get).toHaveBeenCalledTimes(3);
+    expect(api.get).toHaveBeenNthCalledWith(1, '/payment-destinations?page=1');
+    expect(api.get).toHaveBeenNthCalledWith(3, '/payment-destinations?page=3');
+  });
+
+  it('stops after one request when there is only one page', async () => {
+    vi.mocked(api.get).mockResolvedValue(page([destination(1)], 1, 1));
+
+    await PaymentDestinationService.list();
+
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not loop forever when the response carries no meta', async () => {
+    vi.mocked(api.get).mockResolvedValue({ items: [destination(1)] });
+
+    const result = await PaymentDestinationService.list();
+
+    expect(result).toHaveLength(1);
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PaymentDestinationService writes', () => {
+  it('creates against the collection route', async () => {
+    vi.mocked(api.post).mockResolvedValue({ item: destination(1) });
+
+    await PaymentDestinationService.create({
+      method: Enums.SettlementMethod.SinpeMobile as App.Enums.SettlementMethod,
+      phoneNumber: '8888-8888',
+      holderName: 'Mandados SA',
+      legalId: '3-101-999',
+    });
+
+    expect(api.post).toHaveBeenCalledWith('/payment-destinations', {
+      method: Enums.SettlementMethod.SinpeMobile,
+      phoneNumber: '8888-8888',
+      holderName: 'Mandados SA',
+      legalId: '3-101-999',
+    });
+  });
+
+  it('updates by numeric id — a destination has no public id', async () => {
+    vi.mocked(api.patch).mockResolvedValue({ item: destination(7) });
+
+    await PaymentDestinationService.update(7, { active: false });
+
+    expect(api.patch).toHaveBeenCalledWith('/payment-destinations/7', { active: false });
+  });
+
+  it('deletes by numeric id', async () => {
+    vi.mocked(api.destroy).mockResolvedValue({ message: '', status: 204, extra: {} });
+
+    await PaymentDestinationService.destroy(7);
+
+    expect(api.destroy).toHaveBeenCalledWith('/payment-destinations/7');
+  });
+});

--- a/services/__tests__/periodBillService.test.ts
+++ b/services/__tests__/periodBillService.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { PeriodBillService } from '../periodBillService';
+import { api } from '@/lib/api/client';
+import { Enums } from '@/data/app-enums';
+
+type BillNeedsAttentionData = App.Data.PeriodBill.BillNeedsAttentionData;
+
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    postMultipart: vi.fn(),
+  },
+}));
+
+// `data/app-enums.ts` holds plain string constants; `generated.d.ts` declares
+// nominal TS enums over the same values, and the two are deliberately not
+// assignable to each other. Production code never needs the bridge — it reads
+// these values off DTOs, where they already carry the nominal type — so
+// fixtures cross that boundary once, here.
+function row(
+  publicId: string,
+  reason: string,
+  urgency: string,
+  dueAt: string
+): BillNeedsAttentionData {
+  return {
+    bill: { publicId, dueAt },
+    urgency,
+    reason,
+    ownerType: 'business',
+    ownerPublicId: `owner-${publicId}`,
+    ownerName: `Owner ${publicId}`,
+  } as BillNeedsAttentionData;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PeriodBillService.needsAttention', () => {
+  it('hits the exact route literal the api registers', async () => {
+    vi.mocked(api.get).mockResolvedValue({ items: [], extra: { summary: {} } });
+
+    await PeriodBillService.needsAttention();
+
+    expect(api.get).toHaveBeenCalledWith('/period-bills/needs-attention');
+  });
+
+  // The ordering is the API's: `BillAttentionReason` declares its cases in
+  // precedence order and the endpoint emits one row per bill at its most urgent
+  // reason, already sorted. This pins that the service is a pass-through — the
+  // fixture is deliberately in an order that every plausible client-side sort
+  // (by dueAt, by publicId) would change.
+  it('returns the rows in the order the api sent them, unsorted', async () => {
+    const unresolved = row(
+      'pb-zz',
+      Enums.BillAttentionReason.UnresolvedCharge,
+      Enums.AttentionUrgency.Critical,
+      '2030-01-01T00:00:00Z'
+    );
+    const overdue = row(
+      'pb-aa',
+      Enums.BillAttentionReason.Overdue,
+      Enums.AttentionUrgency.High,
+      '2020-01-01T00:00:00Z'
+    );
+
+    vi.mocked(api.get).mockResolvedValue({
+      items: [unresolved, overdue],
+      extra: { summary: { critical: 1, high: 1, medium: 0, low: 0 } },
+    });
+
+    const result = await PeriodBillService.needsAttention();
+
+    expect(result.items.map((item) => item.bill.publicId)).toEqual(['pb-zz', 'pb-aa']);
+    expect(result.summary).toEqual({ critical: 1, high: 1, medium: 0, low: 0 });
+  });
+
+  it('survives a response carrying no summary', async () => {
+    vi.mocked(api.get).mockResolvedValue({ items: [] });
+
+    const result = await PeriodBillService.needsAttention();
+
+    expect(result.summary).toEqual({});
+  });
+});
+
+describe('PeriodBillService.settle', () => {
+  // The api's request DTOs declare no input mapper, so `SettlePeriodBillData`
+  // validates `currencyCode`/`destinationId` verbatim. A snake_case key is
+  // silently dropped rather than rejected, which is why this is pinned.
+  it('sends the method-specific fields under their camelCase names', async () => {
+    vi.mocked(api.postMultipart).mockResolvedValue({ item: {} });
+
+    await PeriodBillService.settle('pb-1', {
+      method: Enums.SettlementMethod.Transferencia as App.Enums.SettlementMethod,
+      currencyCode: 'CRC',
+      reference: 'REF-9',
+      destinationId: 7,
+      notes: 'seen in the bank',
+    });
+
+    const [url, formData] = vi.mocked(api.postMultipart).mock.calls[0];
+    expect(url).toBe('/period-bills/pb-1/settle');
+    expect((formData as FormData).get('currencyCode')).toBe('CRC');
+    expect((formData as FormData).get('destinationId')).toBe('7');
+    expect((formData as FormData).get('method')).toBe(Enums.SettlementMethod.Transferencia);
+    expect((formData as FormData).get('reference')).toBe('REF-9');
+    expect((formData as FormData).get('currency_code')).toBeNull();
+    expect((formData as FormData).get('destination_id')).toBeNull();
+  });
+
+  it('omits an absent destination rather than sending an empty one', async () => {
+    vi.mocked(api.postMultipart).mockResolvedValue({ item: {} });
+
+    await PeriodBillService.settle('pb-1', {
+      method: Enums.SettlementMethod.Cash as App.Enums.SettlementMethod,
+      currencyCode: 'CRC',
+      destinationId: null,
+    });
+
+    const formData = vi.mocked(api.postMultipart).mock.calls[0][1] as FormData;
+    expect(formData.get('destinationId')).toBeNull();
+  });
+});
+
+describe('PeriodBillService verification acts', () => {
+  it('approves with an optional note', async () => {
+    vi.mocked(api.post).mockResolvedValue({ item: {} });
+
+    await PeriodBillService.approveDeclaration('pb-1', null);
+
+    expect(api.post).toHaveBeenCalledWith('/period-bills/pb-1/approve', { notes: null });
+  });
+
+  it('rejects with the reason that reaches the customer', async () => {
+    vi.mocked(api.post).mockResolvedValue({ item: {} });
+
+    await PeriodBillService.rejectDeclaration('pb-1', 'not in the account');
+
+    expect(api.post).toHaveBeenCalledWith('/period-bills/pb-1/reject', {
+      notes: 'not in the account',
+    });
+  });
+});
+
+describe('PeriodBillService.fetchProof', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    window.localStorage.setItem(
+      'admin-auth-storage',
+      JSON.stringify({ state: { token: 'tok-123' } })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  // `PeriodBillData.proofUrl` names an authenticated stream route on a private
+  // disk. The bytes cannot come through `api.get()`, which parses JSON, and a
+  // request without the bearer token is answered 401 — so the header is the
+  // whole point of this method.
+  it('requests the proof route with the bearer token attached', async () => {
+    fetchMock.mockResolvedValue({ ok: true, blob: async () => new Blob(['x']) });
+
+    await PeriodBillService.fetchProof('pb-1');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/period-bills/pb-1/proof');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-123');
+  });
+
+  it('throws rather than returning an error body as if it were the file', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, blob: async () => new Blob() });
+
+    await expect(PeriodBillService.fetchProof('pb-1')).rejects.toThrow('404');
+  });
+});

--- a/services/paymentDestinationService.ts
+++ b/services/paymentDestinationService.ts
@@ -1,0 +1,81 @@
+import { api } from '@/lib/api/client';
+import { Enums } from '@/data/app-enums';
+
+type PaymentDestinationData = App.Data.PaymentDestination.PaymentDestinationData;
+type StorePaymentDestinationData = App.Data.PaymentDestination.StorePaymentDestinationData;
+type UpdatePaymentDestinationData = App.Data.PaymentDestination.UpdatePaymentDestinationData;
+type Paginated<T> = Api.Response.Paginated<T>;
+type Single<T> = Api.Response.Single<T>;
+
+/**
+ * The only two settlement methods a destination can exist for.
+ *
+ * Card and cash never carry one and credit never leaves the system, which is
+ * why `StorePaymentDestinationData`'s `Rule::in()` admits exactly these two and
+ * why every other field on a destination is `prohibited` under any other
+ * method. Stated once here because two surfaces need it: the form that creates
+ * a destination, and the settle dialog that decides whether to offer one at all.
+ */
+export const DESTINATION_METHODS: string[] = [
+  Enums.SettlementMethod.SinpeMobile,
+  Enums.SettlementMethod.Transferencia,
+];
+
+/**
+ * Where a customer is told to send money — several SINPE Móvil numbers,
+ * several bank accounts. Read by staff, written by admins.
+ *
+ * `method` is absent from the update payload on purpose: it decides which
+ * other fields a row may carry, so swapping it in place would leave a
+ * destination holding the wrong method's fields. Changing a method means
+ * deactivating the row and creating a new one.
+ */
+export const PaymentDestinationService = {
+  /**
+   * Every destination, active and deactivated alike.
+   *
+   * The api paginates this at a **fixed 15** and reads no `per_page`, so the
+   * pages are walked here rather than truncated: deactivated rows are kept
+   * forever (a bill's history must stay readable) and would eventually push
+   * live destinations off page one.
+   */
+  async list(): Promise<PaymentDestinationData[]> {
+    const items: PaymentDestinationData[] = [];
+    let page = 1;
+    let lastPage = 1;
+
+    do {
+      const response = await api.get<Paginated<PaymentDestinationData>>(
+        `/payment-destinations?page=${page}`
+      );
+      items.push(...response.items);
+      lastPage = response.meta?.lastPage ?? 1;
+      page += 1;
+    } while (page <= lastPage);
+
+    return items;
+  },
+
+  async create(data: StorePaymentDestinationData): Promise<PaymentDestinationData> {
+    const response = await api.post<Single<PaymentDestinationData>>('/payment-destinations', data);
+    return response.item;
+  },
+
+  async update(id: number, data: UpdatePaymentDestinationData): Promise<PaymentDestinationData> {
+    const response = await api.patch<Single<PaymentDestinationData>>(
+      `/payment-destinations/${id}`,
+      data
+    );
+    return response.item;
+  },
+
+  /**
+   * Soft-delete a destination. A bill records the destination it showed as a
+   * snapshot rather than a foreign key, so removing a row never rewrites a
+   * bill's history — but deactivating is still the ordinary move, because a
+   * deactivated row stays visible to whoever is reading old bills.
+   */
+  async destroy(id: number): Promise<void> {
+    await api.destroy<Api.Response.SuccessBasic>(`/payment-destinations/${id}`);
+  },
+};

--- a/services/periodBillService.ts
+++ b/services/periodBillService.ts
@@ -1,0 +1,145 @@
+import { api } from '@/lib/api/client';
+
+type PeriodBillData = App.Data.PeriodBill.PeriodBillData;
+type BillNeedsAttentionData = App.Data.PeriodBill.BillNeedsAttentionData;
+type AttentionUrgency = App.Enums.AttentionUrgency;
+type SettlementMethod = App.Enums.SettlementMethod;
+type Multiple<T> = Api.Response.Multiple<T>;
+type Single<T> = Api.Response.Single<T>;
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.mandados.cr';
+
+/** How many bills sit at each urgency, counted by the API across all reasons. */
+export type BillAttentionSummary = Partial<Record<AttentionUrgency, number>>;
+
+export interface BillsNeedingAttention {
+  /**
+   * One row per bill, at the most urgent reason it matches, **already ordered
+   * by the API**: `BillAttentionReason` declares its cases in precedence order
+   * (unresolved charge, overdue, declaration to verify, quiet) and the endpoint
+   * sorts by it. Render this array as it arrives — re-sorting client-side
+   * silently discards the ranking, and an unresolved charge outranks an overdue
+   * bill because the customer's money may already be gone.
+   */
+  items: BillNeedsAttentionData[];
+  summary: BillAttentionSummary;
+}
+
+export interface SettlePeriodBillParams {
+  method: SettlementMethod;
+  currencyCode: string;
+  reference?: string | null;
+  destinationId?: number | null;
+  notes?: string | null;
+  proof?: File | null;
+}
+
+/**
+ * Read the bearer token the way `lib/api/client.ts` and `services/uploadService.ts`
+ * both do. Needed here because the comprobante is a byte stream: `api.get()`
+ * parses JSON and returns `{}` for anything else, so it cannot carry the file.
+ */
+function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem('admin-auth-storage');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return parsed?.state?.token || null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export const PeriodBillService = {
+  /**
+   * Every bill that needs a person, across all accounts (staff only). The API
+   * takes no page and no filter, and its ordering is the contract — see
+   * {@link BillsNeedingAttention.items}.
+   */
+  async needsAttention(): Promise<BillsNeedingAttention> {
+    const response = await api.get<Multiple<BillNeedsAttentionData>>(
+      '/period-bills/needs-attention'
+    );
+    const extra = (response.extra ?? {}) as { summary?: BillAttentionSummary };
+
+    return {
+      items: response.items,
+      summary: extra.summary ?? {},
+    };
+  },
+
+  /** One bill with its lines and per-currency totals. Bound on `publicId`. */
+  async getById(publicId: string): Promise<PeriodBillData> {
+    const response = await api.get<Single<PeriodBillData>>(`/period-bills/${publicId}`);
+    return response.item;
+  },
+
+  /**
+   * Record a payment received elsewhere (admin only). Cash is admin-only by
+   * the API's own allowlist — a customer cannot prove it.
+   */
+  async settle(publicId: string, data: SettlePeriodBillParams): Promise<PeriodBillData> {
+    // Keys are camelCase: the api's request DTOs declare no input mapper, so
+    // `SettlePeriodBillData::rules()` validates `currencyCode`/`destinationId`
+    // verbatim. A snake_case key is silently dropped, not rejected.
+    const formData = new FormData();
+    formData.append('method', data.method);
+    formData.append('currencyCode', data.currencyCode);
+    if (data.reference) formData.append('reference', data.reference);
+    if (data.destinationId != null) formData.append('destinationId', String(data.destinationId));
+    if (data.notes) formData.append('notes', data.notes);
+    if (data.proof) formData.append('proof', data.proof);
+
+    const response = await api.postMultipart<Single<PeriodBillData>>(
+      `/period-bills/${publicId}/settle`,
+      formData
+    );
+    return response.item;
+  },
+
+  /** Confirm a declared transfer was found in the bank (admin only). */
+  async approveDeclaration(publicId: string, notes: string | null): Promise<PeriodBillData> {
+    const response = await api.post<Single<PeriodBillData>>(`/period-bills/${publicId}/approve`, {
+      notes,
+    });
+    return response.item;
+  },
+
+  /**
+   * Refuse a declared transfer (admin only). The reason is mandatory — it
+   * reaches the customer in the declaration-resolved notification.
+   */
+  async rejectDeclaration(publicId: string, notes: string): Promise<PeriodBillData> {
+    const response = await api.post<Single<PeriodBillData>>(`/period-bills/${publicId}/reject`, {
+      notes,
+    });
+    return response.item;
+  },
+
+  /**
+   * Fetch the comprobante as a blob.
+   *
+   * `PeriodBillData.proofUrl` names an **authenticated stream route**, not a
+   * storage URL — handed to an `<img src>` or an `<a href>` the browser sends
+   * no Authorization header and the API answers 401. So the bytes are pulled
+   * here with the token attached and handed to the caller as an object URL.
+   */
+  async fetchProof(publicId: string): Promise<Blob> {
+    const token = getToken();
+    const response = await fetch(`${API_URL}/period-bills/${publicId}/proof`, {
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to load proof (${response.status})`);
+    }
+
+    return response.blob();
+  },
+};

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -804,6 +804,29 @@ declare namespace App.Data.PaymentDestination {
   };
 }
 declare namespace App.Data.PeriodBill {
+  export type ApprovePeriodBillDeclarationData = {
+    notes: string | null;
+  };
+  export type BillNeedsAttentionData = {
+    bill: App.Data.PeriodBill.PeriodBillData;
+    urgency: App.Enums.AttentionUrgency;
+    reason: App.Enums.BillAttentionReason;
+    ownerType: string;
+    ownerPublicId: string | null;
+    ownerName: string | null;
+  };
+  export type DeclarePeriodBillPaymentData = {
+    method: App.Enums.SettlementMethod;
+    currencyCode: string;
+    reference: string;
+    destinationId: number | null;
+    proof: any | null;
+  };
+  export type PayPeriodBillData = {
+    method: App.Enums.SettlementMethod;
+    currencyCode: string;
+    paymentMethodId: string | null;
+  };
   export type PeriodBillData = {
     id: number;
     publicId: string;
@@ -822,9 +845,24 @@ declare namespace App.Data.PeriodBill {
     reference: string | null;
     proofPath: string | null;
     proofUrl: string | null;
+    settlementDestination: {
+      id: number;
+      method: string;
+      currencyCode: string | null;
+      phoneNumber: string | null;
+      bankName: string | null;
+      accountNumber: string | null;
+      iban: string | null;
+      holderName: string;
+      legalId: string;
+    } | null;
     notes?: string | null;
     perCurrencyTotals?: Record<string, { amount: number; baseAmount: number }>;
     lines?: Array<App.Data.PeriodBill.PeriodBillLineData>;
+  };
+  export type PeriodBillDestinationQueryData = {
+    method: App.Enums.SettlementMethod;
+    currencyCode: string;
   };
   export type PeriodBillLineData = {
     id: number;
@@ -833,6 +871,17 @@ declare namespace App.Data.PeriodBill {
     currencyCode: string;
     fxRate: number | null;
     baseAmount: number;
+  };
+  export type RejectPeriodBillDeclarationData = {
+    notes: string;
+  };
+  export type SettlePeriodBillData = {
+    method: App.Enums.SettlementMethod;
+    currencyCode: string;
+    reference: string | null;
+    destinationId: number | null;
+    proof: any | null;
+    notes: string | null;
   };
 }
 declare namespace App.Data.Pricing {
@@ -1372,6 +1421,12 @@ declare namespace App.Enums {
     DELIVERY = 'delivery',
     INSTRUCTIONS = 'instructions',
   }
+  export enum BillAttentionReason {
+    UnresolvedCharge = 'unresolved_charge',
+    Overdue = 'overdue',
+    DeclarationToVerify = 'declaration_to_verify',
+    Quiet = 'quiet',
+  }
   export enum BillingCycle {
     PerOrder = 'per_order',
     Weekly = 'weekly',
@@ -1612,13 +1667,19 @@ declare namespace App.Enums {
     VOIDED = 'voided',
     CHARGEBACK = 'chargeback',
   }
+  export enum PeriodBillChargeOutcome {
+    Settled = 'settled',
+    Declined = 'declined',
+    Unresolved = 'unresolved',
+    NoUsableCard = 'no_usable_card',
+    NotPayable = 'not_payable',
+    Unsupported = 'unsupported',
+  }
   export enum PeriodBillStatus {
     Open = 'open',
     Issued = 'issued',
     AwaitingVerification = 'awaiting_verification',
     Paid = 'paid',
-    Failed = 'failed',
-    Uncollectible = 'uncollectible',
   }
   export enum PricingCalculationMode {
     CUMULATIVE = 'cumulative',
@@ -1704,6 +1765,7 @@ declare namespace App.Enums {
     SinpeMobile = 'sinpe_mobile',
     Transferencia = 'transferencia',
     Cash = 'cash',
+    Credit = 'credit',
   }
   export enum TipoIdentificacion {
     Fisica = '01',


### PR DESCRIPTION
Refs #212

**Goal:** an admin opens Needs Attention, sees every bill that needs a person, and can verify a declared transfer without leaving the workspace.

## The sync

`types/generated.d.ts` copied byte-identical from api@`ba5c013`; `data/app-enums.ts` regenerated with `npm run gen:enums`. Neither hand-edited, neither formatted — `.prettierignore` keeps prettier off all three declaration files, and byte-identity was re-verified after `npm run format`.

Contract delta **+64/−2**. Added: seven DTOs, `BillAttentionReason`, `PeriodBillChargeOutcome`, `SettlementMethod.Credit`. Removed: `PeriodBillStatus.Failed` and `.Uncollectible`.

The removal is a **verified** no-op here, not an assumed one: each matches zero lines outside `node_modules`/`.next`, and the only three files mentioning `PeriodBill` at all are generated. `types/response.d.ts` and `types/notifications.d.ts` were already byte-identical and needed no change. The scoped check was green immediately after the sync, before any feature code.

## The operator surface

A sixth Needs Attention tab, built the same way as the five before it — hardcoded `TabsTrigger` with a count badge, plain `useState`, wired into the existing "Refresh all" handler and its combined refetching flag. The five existing tabs are untouched.

- **Precedence belongs to the API and the UI does not re-sort it.** The endpoint emits one row per bill at its most urgent reason, already sorted. Pinned by a test whose fixture is built so any plausible client-side sort would visibly reorder it — the unresolved-charge row carries both the later due date and the later-sorting public id. Proven red against an injected re-sort, not merely green as written.
- **The verification row** carries a copyable reference, the exact amount in the currency the customer says they sent (the dialog re-fetches the bill, because the queue loads no lines and `perCurrencyTotals` is absent on a queue row), and `settlementDestination` — the only record of where the customer was told to pay.
- **The comprobante opens through the authenticated stream.** `proofUrl` never reaches the DOM; a test asserts every fetchable attribute in the rendered dialog is a `blob:` URL, and it was proven red against a plain route `src`.
- A bill detail route, and payment-destination CRUD under settings behind the existing `RequireAdmin` layout.

## Verify

- `npm run check` — **exit 0**
- `npm run test:run` — gate verdict commented below
- Test files **17 → 26** (`*.test.ts(x)` outside `node_modules`/`.next`), re-measured at this branch's own fork point rather than carried forward.

## Notes for the reviewer

- **One key in this diff lives in api, not here.** `payments:period_bill.attention_empty` landed in api PR #274; nothing in this PR carries it and nothing in this gate proves it exists.
- `PeriodBillService.fetchProof()` adds a **third** copy of `getToken()` in this repo. The DRY fix is a `getBlob()` on `lib/api/client.ts`, which this slice is fenced from; filed as **#44**.
- The `/* eslint-env */` warning in `public/firebase-messaging-sw.js` (an error under eslint v10) is untouched and filed as **#45**.
- One suppression is added: `components/periodBills/ProofViewer.tsx`, `@next/next/no-img-element`, with a written justification — the source is an object URL over already-fetched bytes, revoked on unmount, which `next/image` cannot re-request.