### PR TITLE
docs(guide): describe the billing work operators now do

### DIFF
--- a/content/guide/guide.en.md
+++ b/content/guide/guide.en.md
@@ -75,29 +75,40 @@ The primary navigation lives in the left rail. It's organized from most to least
   <div class="card"><strong class="card-title">Pricing Rules</strong><p>Tariff configuration by distance, tier, window, etc.</p></div>
   <div class="card"><strong class="card-title">Notifications</strong><p>System events surfaced to operations.</p></div>
   <div class="card"><strong class="card-title">Audit Logs</strong><p>Who did what and when.</p></div>
-  <div class="card"><strong class="card-title">Settings</strong><p>Currencies, service windows, language, profile.</p></div>
+  <div class="card"><strong class="card-title">Guide</strong><p>This manual, inside the panel.</p></div>
+  <div class="card"><strong class="card-title">Settings</strong><p>Currencies, payment destinations, service windows, language.</p></div>
 </div>
+
+_Settings sits on its own at the foot of the rail, below the list._
 
 ---
 
 ## Needs Attention <span class="pill green">the most important screen</span> {#needs-attention}
 
-**This is the screen where an administrator spends most of the day.** Any order that needs manual intervention shows up here, organized into tabs by action type.
+**This is the screen where an administrator spends most of the day.** Anything that needs manual intervention shows up here — an order, or an account's bill — organized into tabs by action type.
 
 <figure>
   <img src="/guide/screenshots/22-needs-attention.png" alt="Needs Attention tabs" />
-  <figcaption><em>Needs Attention</em> tabs. The number on each tab shows how many orders are waiting for action.</figcaption>
+  <figcaption><em>Needs Attention</em> tabs. The number on each tab shows how many orders are waiting for action. This capture predates the sixth tab — the current list is the table below.</figcaption>
 </figure>
 
-### The five tabs {#five-tabs}
+### The tabs {#tabs}
 
-| Tab                 | What it holds                                                                                                                                          | Expected action                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| **Conflicts**       | Orders the system couldn't dispatch automatically or that hit feasibility issues (impossible window, no driver available, distance out of range).      | Review the reason, reassign manually, adjust the window, or dismiss the order.            |
-| **Reconciliation**  | <span class="pill blue">Completed</span> orders where the driver delivered but the charged amount must be adjusted to match the actual purchase price. | Open the reconciliation dialog, enter the real per-line prices, generate the final quote. |
-| **Not Yet Quoted**  | Orders the customer just created that don't have a quote yet.                                                                                          | Verify each stop's address, create the quote, and send it to the customer.                |
-| **Not Yet Paid**    | Delivered orders that haven't been paid by the customer.                                                                                               | Follow up on collection, mark as paid when settled.                                       |
-| **Refund Requests** | Customer claims requesting a full or partial refund.                                                                                                   | Review evidence (proof of delivery, photos), approve or reject.                           |
+They read left to right, and the table below has one row per tab — if the panel shows you a tab this table doesn't name, the guide is out of date and worth reporting.
+
+| Tab                 | What it holds                                                                                                                                                                                    | Expected action                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| **Conflicts**       | Orders the system couldn't dispatch automatically or that hit feasibility issues (impossible window, no driver available, distance out of range).                                                | Review the reason, reassign manually, adjust the window, or dismiss the order.                       |
+| **Reconciliation**  | <span class="pill blue">Completed</span> orders where the driver delivered but the charged amount must be adjusted to match the actual purchase price.                                           | Open the reconciliation dialog, enter the real per-line prices, generate the final quote.            |
+| **Not Yet Quoted**  | Orders the customer just created that don't have a quote yet.                                                                                                                                    | Verify each stop's address, create the quote, and send it to the customer.                           |
+| **Not Yet Paid**    | Two groups, one under the other: orders that have a quote and are still unpaid, and orders set to collect on delivery (the driver takes the money at the door, in cash or by SINPE Móvil).       | Follow up on collection, mark as paid when settled.                                                  |
+| **Refund Requests** | Customer claims requesting a full or partial refund.                                                                                                                                             | Review evidence (proof of delivery, photos), approve or reject.                                      |
+| **Period bills**    | Bills of accounts billed by period instead of per order: a declared payment waiting to be checked, a bill past its due date, a bill quietly unpaid, or a card charge the gateway never resolved. | [Work the bill](#period-bills) — verify the declaration, or record the payment that already arrived. |
+
+<div class="callout warn">
+<strong>An on-account order is not an unpaid order</strong>
+Orders billed to an account never appear in <em>Not Yet Paid</em>. They carry <span class="pill blue">On Account</span>, which means somebody <em>is</em> paying for them — on a period bill. Chase those from the <em>Period bills</em> tab, not this one.
+</div>
 
 ### Severity filters {#severity-filters}
 
@@ -144,7 +155,7 @@ When the order arrives, the _Not Yet Quoted_ tab counter goes up. That's the fir
 
 <figure>
   <img src="/guide/screenshots/22-needs-attention.png" alt="Needs Attention with badge on Not Yet Quoted" />
-  <figcaption>The <em>Not Yet Quoted</em> tab shows <strong>1</strong> — one order awaiting a quote.</figcaption>
+  <figcaption>The <em>Not Yet Quoted</em> tab shows <strong>1</strong> — one order awaiting a quote. (Same capture as above, so it predates the sixth tab.)</figcaption>
 </figure>
 
 ### Step 1.2 — Open the order detail {#step-1-2}
@@ -369,7 +380,109 @@ When you confirm the dialog, the system:
 
 <div class="callout tip">
 <strong>Payments are "authorized" before delivery</strong>
-When the quote is accepted, the payment gateway authorizes a hold for the quoted amount but <em>doesn't charge yet</em>. Reconciliation is what fires the final capture: at exactly the right amount, no more and no less. This avoids refunds and surprise charges.
+When the quote is accepted, the payment gateway authorizes a hold for the quoted amount but <em>doesn't charge yet</em>. Reconciliation is what fires the final capture: at exactly the right amount, no more and no less. This avoids refunds and surprise charges. <strong>This is the per-order path</strong>; an account billed by period takes no hold at all — see <a href="#period-bills">Billing on account</a>.
+</div>
+
+---
+
+## Billing on account {#period-bills}
+
+Most customers pay per order: the quote is authorized when they accept it and captured at [reconciliation](#reconcile). **An account can instead be billed by period** — it orders all week or all month, nothing is charged per delivery, and one bill covering every order in the period closes at the end of it.
+
+Two things follow, and both change what you see on screen:
+
+- An order billed this way is stamped <span class="pill blue">On Account</span> rather than <span class="pill amber">Unpaid</span>. It is **not** an unpaid order: somebody is paying for it, on a bill that hasn't closed yet.
+- Nobody is asked to collect at the door, so the driver's collect step is suppressed. That's deliberate, not a missing prompt.
+
+<div class="callout info">
+<strong>Nothing is charged automatically</strong>
+The bill closes and sends itself — that is the only automatic part. The <em>money</em> is always an act a person performs: the customer pays it from their app, or an administrator records a payment that arrived some other way. <strong>No saved card is ever charged in the background.</strong> A card saved to check out a delivery is not permission to settle an account balance, so a bill that goes unpaid is followed up by a person, like any other invoice.
+</div>
+
+### The life of a bill {#bill-states}
+
+| Internal code           | Label                                                 | Meaning                                                                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `open`                  | <span class="pill gray">Open</span>                   | The period is still running. Orders join the bill as they're approved and the total moves. **Nothing is owed yet** — an open bill has no due date.                                                       |
+| `issued`                | <span class="pill blue">Issued</span>                 | The period closed. The total is frozen, any account credit has been applied, a due date is stamped and the customer has been notified.                                                                   |
+| `awaiting_verification` | <span class="pill amber">Awaiting Verification</span> | The customer says they sent a transfer and attached a comprobante — the proof of payment. **This is not paid.** The due date hasn't moved and the clock is still running.                                |
+| `paid`                  | <span class="pill green">Paid</span>                  | Settled. Every order on the bill flips to <span class="pill green">Paid</span> in the same movement, stamped with how the bill was settled — a bill settles all at once or not at all, never half of it. |
+
+The close runs on the period's clock at **03:00**, with no operator in the loop. That's what makes silence meaningful: nobody has to remember to close a period, so a bill that didn't close is a fault worth reporting. The due date is **7 days** after the close, and a reminder goes to the customer at 08:00 as it approaches.
+
+### The Period bills tab {#bills-tab}
+
+The last tab of [Needs Attention](#needs-attention) is the billing queue. **One row per bill, showing only the most urgent thing wrong with it** — a bill routinely matches more than one of the rows below, and the queue picks the loudest rather than listing it twice.
+
+| Badge                   | Urgency                                | What happened                                                                                                                                                                   | What you do                                                                                                                  |
+| ----------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Charge unresolved**   | <span class="pill red">Critical</span> | The customer pressed Pay and the gateway never said what happened. **Their money may already be gone while the bill still reads unpaid**, and nothing resolves this on its own. | Look for a charge against this bill in the gateway before anything else. Don't ask the customer to pay again until you know. |
+| **Overdue**             | <span class="pill amber">High</span>   | Past the due date and still owing. **The account is blocked from ordering.**                                                                                                    | Follow the money up. Verifying a declaration or recording a payment settles the bill and unblocks the account.               |
+| **Payment to verify**   | <span class="pill blue">Medium</span>  | The customer declared a transfer and attached a comprobante.                                                                                                                    | Find it in the bank, then approve or reject — see below.                                                                     |
+| **Unpaid, not yet due** | <span class="pill gray">Low</span>     | Closed a couple of days ago, unpaid, and not due yet.                                                                                                                           | Call them. **This is the valuable one** — nothing is wrong yet, and it's the state that prevents the other two.              |
+
+Rows are ordered most urgent first, then by oldest due date. The urgency counters above the list are the triage signal a flat list can't give you: they say how much of the queue is a customer's money possibly already gone versus a bill that's merely quiet.
+
+<div class="callout warn">
+<strong>Reading the queue is staff; acting on a bill is admin</strong>
+Any staff operator can open this tab and read a bill. <em>Verify</em>, <em>Approve</em>, <em>Reject</em> and <em>Record payment</em> are restricted to administrators — recording that money arrived on an account, and adjudicating a customer's claim that it did, are accounting acts rather than operational ones. If you can see a bill but not the buttons, that's the reason.
+</div>
+
+### Verifying a declared payment {#verify-declaration}
+
+A declaration is a **claim, not a payment**: the customer says they sent money and offers a reference and a comprobante. Nothing settles until somebody finds the transfer.
+
+Click `Verify` on the bill's row (or on the bill detail). The dialog gives you everything the search needs:
+
+1. **The method** — SINPE Móvil or Bank transfer. It tells you which rail to look in.
+2. **The reference**, with a copy button beside it. Copy it rather than re-typing it: the bank will only find the transfer on a character-for-character match, and re-typing from memory is where a verification goes wrong.
+3. **The amount to look for** — period total, credit applied, and net due in colones. If the customer paid in their own currency, the figure in _that_ currency is shown too, and that is the number that will be on the statement.
+4. **Where they were told to send it** — the destination the bill recorded, so you look in the right account. It's a snapshot the bill kept rather than a live row, so it stays readable even after that destination has been edited or deactivated.
+5. **The comprobante**, behind a button. It is **corroboration, not evidence**: what settles the question is finding the payment in the bank. It loads only when you ask for it, and its absence never blocks you.
+
+Then one of two outcomes:
+
+- **Approve** — the bill becomes <span class="pill green">Paid</span> and every order on it settles with it. A note is optional.
+- **Reject** — **a reason is required**, and the button stays disabled until you write one. That reason reaches the customer, and it is the whole point: a claim rejected without one comes straight back as the same file uploaded again.
+
+<div class="callout warn">
+<strong>The note field replaces what's already there</strong>
+Approving or rejecting overwrites the bill's note. Whatever note it carries is shown above the field but deliberately not pre-filled — read it before you write, and don't re-send someone else's sentence as your own.
+</div>
+
+### Recording a payment that arrived out of band {#record-bill-payment}
+
+Use `Record payment` when the money reached you some other way — cash across the counter, a transfer you've already matched in the bank, a card taken over the phone. This is you asserting a fact rather than filing a claim, so it settles the bill immediately, with no verification step behind it.
+
+| Field                   | Notes                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Payment method**      | Card, SINPE Móvil, Bank transfer or Cash.                                                                                                                                                   |
+| **Currency**            | Required — the form won't submit without it. It records _which_ of the bill's already-frozen figures was actually paid, not a rate looked up now.                                           |
+| **Payment destination** | Offered for SINPE Móvil and Bank transfer only, and filtered to the active destinations of that method. Changing the method clears the choice, because a destination belongs to one method. |
+| **Reference**           | Optional, and pre-filled from the bill when it already has one.                                                                                                                             |
+| **Proof of payment**    | Optional here. A customer declaring a transfer must attach one; you already received the money, so your record is the fact.                                                                 |
+| **Notes**               | Pre-filled from the bill, because submitting writes this field whatever you do — leave it blank and you'd silently erase a note an earlier act recorded, a rejection reason included.       |
+
+<div class="callout info">
+<strong>Account credit is not on the method list, on purpose</strong>
+Credit only counts as paid once the period's close has actually applied it against the bill, and nothing else applies it. Recording it by hand would mark a bill paid with money nothing was spent from, so the panel doesn't offer it.
+</div>
+
+Cash is on the operator's list and absent from the customer's, and the asymmetry is the point: **a customer cannot prove they handed over cash.** The administrator who received it is the only person who can say it happened at all. Card runs the other way round — the customer can pay by card themselves, in the app, and you can also record one you took elsewhere.
+
+### The bill detail screen {#bill-detail}
+
+`View` on any row opens the bill at `/period-bills/<code>`. **There is no bill list in the sidebar** — the _Period bills_ tab is how you reach one, and the back arrow returns you to it. The same `Verify` and `Record payment` buttons sit in the header, and only for a bill that can still take them: a bill already <span class="pill green">Paid</span> offers neither.
+
+Three parts:
+
+- **Period bill** — period total, credit applied, net due, the date it closed, the date it's due, and one row per currency the bill's lines were agreed in.
+- **Payment method** — appears only once there's something to show: the method, the copyable reference, the destination snapshot, the comprobante, the note.
+- **What this bill covers** — one row per order, with the order code, the currency it was agreed in, the exchange rate frozen on its quote, and the amount in both that currency and colones.
+
+<div class="callout info">
+<strong>Amounts are never re-converted</strong>
+A line agreed in colones carries one colón figure and needed no rate — which is why the rate column shows a dash on those rows rather than today's rate. A line agreed in another currency carries that amount, the rate frozen on its quote, and the colón amount derived from it at that moment. Nothing is looked up when the money arrives, so a bill can always state what it is owed before anyone pays it.
 </div>
 
 ---
@@ -569,7 +682,7 @@ Business accounts. Businesses can have:
 
 - Multiple authorized users who can create orders.
 - Negotiated tariffs different from the public rate.
-- Consolidated monthly billing.
+- Consolidated billing by period instead of per order — see [Billing on account](#period-bills).
 - Their own directory of frequent addresses.
 
 ---
@@ -647,10 +760,21 @@ Immutable record of every administrative action. Useful for:
 
 <figure>
   <img src="/guide/screenshots/15-settings.png" alt="General settings" />
-  <figcaption><em>Settings</em> screen. Three cards: <em>Language</em> (inline selector), <em>Currency Settings</em>, and <em>Service Window</em> (the latter two open sub-pages via the right-arrow).</figcaption>
+  <figcaption><em>Settings</em> screen. The screenshot predates three of the cards now on it — the current list is below.</figcaption>
 </figure>
 
-This is where global operational parameters live. Note: the list is intentionally short — only what an administrator needs to change by hand. The rest of the behavior (rates, per-order windows, dispatch feasibility) is modeled in its own sections.
+This is where global operational parameters live. The list is intentionally short — only what an administrator needs to change by hand. The rest of the behavior (rates, per-order windows, dispatch feasibility) is modeled in its own sections.
+
+The cards, top to bottom. The first three are edited in place; the last three carry a right-arrow and open a sub-page.
+
+| Card                        | What it sets                                                                                                                                                                                                                              |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Language**                | The interface language for the administrator using it — see below.                                                                                                                                                                        |
+| **Supported Vehicle Types** | Which vehicle types a driver in this fleet may be assigned. Tick the ones you operate and save.                                                                                                                                           |
+| **Waiting time**            | Rate per minute and tolerance beyond the estimate, for time a driver spends waiting at a stop past what it was quoted for. Set the rate to zero and waiting isn't charged at all. A price-list decision, made once — not a per-order one. |
+| **Currency Settings** →     | Which currencies the platform accepts, how rates are obtained, and how each rounds.                                                                                                                                                       |
+| **Payment destinations** →  | Where customers are told to send money for a period bill.                                                                                                                                                                                 |
+| **Service Window** →        | When the platform accepts new orders, and what happens to orders left without a driver.                                                                                                                                                   |
 
 ### Language
 
@@ -716,6 +840,27 @@ Rounding affects how amounts are presented to the customer, not how they're stor
 The rate is entered as <em>how many units of the base currency equal 1 unit of this currency</em>. If you accidentally enter it inverted (e.g. <code>0.002</code> instead of <code>490</code>), the preview paints an amber warning suggesting the inverse value.
 </div>
 
+### Payment destinations {#settings-payment-destinations}
+
+Declaring a transfer without a destination asks somebody to pay and doesn't say where, so this list is what makes SINPE Móvil and bank transfer usable at all. These are the company's own accounts, not anything the customer registers.
+
+The table lists every destination with its method, holder, account number (or phone number, for SINPE Móvil), currency and active state. `+ Create` opens the form; the pencil edits a row and the bin deletes one.
+
+The form's fields depend on the method:
+
+| Method            | Fields it takes                                                                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| **SINPE Móvil**   | Phone number. No currency — SINPE Móvil receives colones and nothing else.                         |
+| **Bank transfer** | Currency, bank name, account number, and IBAN if there is one.                                     |
+| **Both**          | Holder name and legal id (both required), a maximum amount, a sort order, and the _active_ switch. |
+
+The **maximum amount** is the per-transfer cap — SINPE Móvil has a real one, and a destination over it simply isn't offered for a bill that large. It's a filter on amount, not on which bills may use the method: a bill stated in dollars paid by SINPE Móvil is just being paid in colones.
+
+<div class="callout warn">
+<strong>Deactivate rather than delete, and create rather than re-point</strong>
+A bill records the destination it showed the customer as a <em>snapshot</em>, so deleting a row never rewrites an old bill — but a deactivated row stays legible to whoever is reading one. And the <em>method</em> can't be changed after creation: it decides which of the other fields the row may carry, so switching it in place would leave a destination holding the wrong method's details. To move a destination to another method, deactivate it and create a new one.
+</div>
+
 ### Service Window {#settings-service-window}
 
 <figure>
@@ -754,6 +899,8 @@ The threshold only counts hours inside the service window. An order arriving at 
 
 ## State glossary {#state-glossary}
 
+A bill's own states are not here — they live with the workflow that uses them, in [The life of a bill](#bill-states).
+
 ### Order states {#order-states}
 
 | Internal code                                             | Label                                                | Meaning                                                  |
@@ -775,12 +922,18 @@ The threshold only counts hours inside the service window. An order arriving at 
 
 ### Payment states {#payment-states}
 
-| Code            | Label                                         | Meaning                                            |
-| --------------- | --------------------------------------------- | -------------------------------------------------- |
-| `unpaid`        | <span class="pill amber">Unpaid</span>        | No payment recorded.                               |
-| `paid`          | <span class="pill green">Paid</span>          | Full charge received.                              |
-| `surcharge_due` | <span class="pill amber">Surcharge Due</span> | After reconciliation there's a balance to collect. |
-| `refunded`      | <span class="pill gray">Refunded</span>       | Full refund issued.                                |
+All eight, in the order the system declares them.
+
+| Code            | Label                                         | Meaning                                                                                                                                                                                               |
+| --------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unpaid`        | <span class="pill amber">Unpaid</span>        | No payment recorded.                                                                                                                                                                                  |
+| `authorized`    | <span class="pill blue">Authorized</span>     | A card hold is placed for the quoted amount. **No money has moved** — a hold expires on its own, and reconciliation is what captures it.                                                              |
+| `paid`          | <span class="pill green">Paid</span>          | Full charge received.                                                                                                                                                                                 |
+| `on_account`    | <span class="pill blue">On Account</span>     | Billed to the account instead of charged: the order is a line on that period's bill, and becomes <span class="pill green">Paid</span> when the bill settles. See [Billing on account](#period-bills). |
+| `surcharge_due` | <span class="pill amber">Surcharge Due</span> | After reconciliation there's a balance to collect.                                                                                                                                                    |
+| `refunded`      | <span class="pill gray">Refunded</span>       | Full refund issued.                                                                                                                                                                                   |
+| `voided`        | <span class="pill gray">Voided</span>         | The card hold was released without ever being charged — a cancellation before capture.                                                                                                                |
+| `chargeback`    | <span class="pill red">Chargeback</span>      | The customer disputed the charge with their bank and the money was pulled back.                                                                                                                       |
 
 ---
 
@@ -813,6 +966,18 @@ Because reconciliation found the real product cost was higher than the initial q
 ### How are delivery PINs generated? {#faq-pin-generation}
 
 Automatically when the order is created — a unique 6-digit code per order. The customer sees it in their app and the driver asks for it on delivery. It's the recipient's identity check.
+
+### A customer says they paid their bill, but it still shows as unpaid — what now? {#faq-declared-not-paid}
+
+Check the bill's state first. <span class="pill amber">Awaiting Verification</span> means their claim arrived and is waiting on **us** — find the transfer in the bank and [approve it](#verify-declaration); the due date is still running until you do, so this is not a wait to leave sitting. If the bill is still <span class="pill blue">Issued</span> with no declaration on it, their payment never reached us as a claim: ask for the reference and the comprobante, or [record it yourself](#record-bill-payment) if you can already see the money.
+
+### Can I settle a bill with the customer's account credit? {#faq-credit-settle}
+
+No, and there's deliberately no option for it. Credit is applied by the period's close, automatically — the bill you're looking at already shows _Credit applied_ and a _Net due_ with the credit taken off. See [Account credit is not on the method list](#record-bill-payment) for why it can't be recorded by hand.
+
+### Why is this account blocked from ordering? {#faq-account-blocked}
+
+One of two reasons, and the account surface tells the customer which: a bill on the account is **past its due date**, or what the account is on the hook for — its unpaid bills plus what this period has run up so far — has reached the limit set for it. The block bites at order creation, so the customer sees it before assembling an order rather than after. Settling the overdue bill clears the first; raising the limit or settling bills clears the second.
 
 ### Can I create an order from the panel without the customer initiating one? {#faq-admin-create}
 

--- a/content/guide/guide.es.md
+++ b/content/guide/guide.es.md
@@ -75,29 +75,40 @@ La navegación principal vive en la barra izquierda. Está organizada de mayor a
   <div class="card"><strong class="card-title">Reglas de Precios</strong><p>Configuración de tarifas por distancia, tier, ventana, etc.</p></div>
   <div class="card"><strong class="card-title">Notificaciones</strong><p>Eventos del sistema dirigidos a operación.</p></div>
   <div class="card"><strong class="card-title">Registros de auditoría</strong><p>Quién hizo qué y cuándo.</p></div>
-  <div class="card"><strong class="card-title">Configuraciones</strong><p>Monedas, ventanas de servicio, idioma, perfil.</p></div>
+  <div class="card"><strong class="card-title">Guía</strong><p>Este manual, dentro del panel.</p></div>
+  <div class="card"><strong class="card-title">Configuraciones</strong><p>Monedas, destinos de pago, ventanas de servicio, idioma.</p></div>
 </div>
+
+_Configuraciones va aparte, al pie de la barra, debajo del listado._
 
 ---
 
 ## Necesita Atención <span class="pill green">la pantalla más importante</span> {#needs-attention}
 
-**Esta es la pantalla donde un administrador pasa la mayor parte de su día.** Cualquier orden que requiera intervención manual aparece aquí, organizada en pestañas por tipo de acción.
+**Esta es la pantalla donde un administrador pasa la mayor parte de su día.** Todo lo que requiera intervención manual aparece aquí — una orden, o la factura de una cuenta — organizado en pestañas por tipo de acción.
 
 <figure>
   <img src="/guide/screenshots/22-needs-attention.png" alt="Pestañas de Necesita Atención" />
-  <figcaption>Pestañas de <em>Necesita Atención</em>. El número en cada pestaña indica cuántas órdenes esperan acción.</figcaption>
+  <figcaption>Pestañas de <em>Necesita Atención</em>. El número en cada pestaña indica cuántas órdenes esperan acción. Esta captura es anterior a la sexta pestaña — el listado vigente es la tabla de abajo.</figcaption>
 </figure>
 
-### Las cinco pestañas {#five-tabs}
+### Las pestañas {#tabs}
 
-| Pestaña                      | Qué contiene                                                                                                                                                              | Acción esperada                                                                                   |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Conflictos**               | Órdenes que el sistema no pudo despachar automáticamente o que tienen problemas de factibilidad (ventana imposible, sin conductor disponible, distancia excede el rango). | Revisar el motivo, reasignar manualmente, ajustar la ventana o desestimar la orden.               |
-| **Conciliación**             | Órdenes <span class="pill blue">Completada</span> donde el conductor entregó pero el monto cobrado debe ajustarse al monto real de los productos comprados.               | Abrir el diálogo de conciliación, ingresar precios reales por línea, generar la cotización final. |
-| **Sin Cotizar**              | Órdenes que el cliente acaba de crear y que aún no tienen cotización.                                                                                                     | Verificar direcciones de cada parada, crear la cotización y enviarla al cliente.                  |
-| **Sin Pagar**                | Órdenes entregadas que aún no han sido pagadas por el cliente.                                                                                                            | Dar seguimiento al cobro, marcar como pagado cuando corresponda.                                  |
-| **Solicitudes de Reembolso** | Reclamos de clientes que solicitan devolución total o parcial.                                                                                                            | Revisar evidencia (prueba de entrega, fotos), aprobar o rechazar.                                 |
+Se leen de izquierda a derecha, y la tabla de abajo tiene una fila por pestaña — si el panel le muestra una pestaña que esta tabla no nombra, la guía está desactualizada y vale la pena reportarlo.
+
+| Pestaña                      | Qué contiene                                                                                                                                                                                                                | Acción esperada                                                                                    |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Conflictos**               | Órdenes que el sistema no pudo despachar automáticamente o que tienen problemas de factibilidad (ventana imposible, sin conductor disponible, distancia excede el rango).                                                   | Revisar el motivo, reasignar manualmente, ajustar la ventana o desestimar la orden.                |
+| **Conciliación**             | Órdenes <span class="pill blue">Completada</span> donde el conductor entregó pero el monto cobrado debe ajustarse al monto real de los productos comprados.                                                                 | Abrir el diálogo de conciliación, ingresar precios reales por línea, generar la cotización final.  |
+| **Sin Cotizar**              | Órdenes que el cliente acaba de crear y que aún no tienen cotización.                                                                                                                                                       | Verificar direcciones de cada parada, crear la cotización y enviarla al cliente.                   |
+| **Sin Pagar**                | Dos grupos, uno debajo del otro: órdenes que ya tienen cotización y siguen sin pagar, y órdenes marcadas para cobrar contra entrega (el conductor recibe el dinero en la puerta, en efectivo o por SINPE Móvil).            | Dar seguimiento al cobro, marcar como pagado cuando corresponda.                                   |
+| **Solicitudes de Reembolso** | Reclamos de clientes que solicitan devolución total o parcial.                                                                                                                                                              | Revisar evidencia (prueba de entrega, fotos), aprobar o rechazar.                                  |
+| **Facturas del período**     | Facturas de cuentas que se facturan por período en vez de por orden: un pago declarado pendiente de revisar, una factura vencida, una factura sin pagar en silencio, o un cobro con tarjeta que la pasarela nunca resolvió. | [Trabajar la factura](#period-bills) — verificar la declaración, o registrar el pago que ya entró. |
+
+<div class="callout warn">
+<strong>Una orden a cuenta no es una orden sin pagar</strong>
+Las órdenes facturadas a una cuenta nunca aparecen en <em>Sin Pagar</em>. Llevan <span class="pill blue">A Cuenta</span>, que significa que alguien <em>sí</em> las está pagando — en una factura del período. Esas se persiguen desde la pestaña <em>Facturas del período</em>, no desde esta.
+</div>
 
 ### Filtros de severidad {#severity-filters}
 
@@ -369,7 +380,109 @@ Al confirmar el diálogo, el sistema:
 
 <div class="callout tip">
 <strong>El pago se «autoriza» antes de la entrega</strong>
-Cuando la cotización es aceptada, la pasarela autoriza un cargo con el monto cotizado pero <em>no lo cobra todavía</em>. La conciliación es la que dispara la captura final: por el monto correcto, ni más ni menos. Esto evita reembolsos o cargos sorpresa.
+Cuando la cotización es aceptada, la pasarela autoriza un cargo con el monto cotizado pero <em>no lo cobra todavía</em>. La conciliación es la que dispara la captura final: por el monto correcto, ni más ni menos. Esto evita reembolsos o cargos sorpresa. <strong>Esta es la ruta por orden</strong>; una cuenta facturada por período no lleva ninguna autorización — vea <a href="#period-bills">Facturación a cuenta</a>.
+</div>
+
+---
+
+## Facturación a cuenta {#period-bills}
+
+La mayoría de los clientes paga por orden: la cotización se autoriza cuando la aceptan y se captura en la [conciliación](#reconcile). **Una cuenta puede en cambio facturarse por período** — pide toda la semana o todo el mes, no se cobra nada por entrega, y al final del período cierra una sola factura que cubre todas las órdenes.
+
+De ahí se desprenden dos cosas, y ambas cambian lo que usted ve en pantalla:
+
+- Una orden facturada así queda marcada <span class="pill blue">A Cuenta</span> y no <span class="pill amber">Sin Pagar</span>. **No** es una orden sin pagar: alguien sí la está pagando, en una factura que todavía no cierra.
+- A nadie se le pide cobrar en la puerta, así que el paso de cobro del conductor se suprime. Eso es deliberado, no un aviso que falta.
+
+<div class="callout info">
+<strong>Nada se cobra automáticamente</strong>
+La factura cierra y se envía sola — esa es la única parte automática. El <em>dinero</em> siempre es un acto que ejecuta una persona: el cliente la paga desde su app, o un administrador registra un pago que llegó por otra vía. <strong>Nunca se cobra en segundo plano una tarjeta guardada.</strong> Una tarjeta guardada para pagar una entrega no es permiso para saldar el balance de una cuenta, así que una factura que queda sin pagar la persigue una persona, como cualquier otra factura.
+</div>
+
+### La vida de una factura {#bill-states}
+
+| Código interno          | Etiqueta                                               | Significado                                                                                                                                                                                                  |
+| ----------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `open`                  | <span class="pill gray">Abierta</span>                 | El período sigue corriendo. Las órdenes se suman a la factura conforme se aprueban y el total se mueve. **Todavía no se debe nada** — una factura abierta no tiene fecha de vencimiento.                     |
+| `issued`                | <span class="pill blue">Emitida</span>                 | El período cerró. El total quedó congelado, se aplicó el crédito de la cuenta si había, se estampó la fecha de vencimiento y se notificó al cliente.                                                         |
+| `awaiting_verification` | <span class="pill amber">Verificación Pendiente</span> | El cliente dice que envió una transferencia y adjuntó un comprobante. **Esto no es pagado.** La fecha de vencimiento no se movió y el reloj sigue corriendo.                                                 |
+| `paid`                  | <span class="pill green">Pagado</span>                 | Saldada. Todas las órdenes de la factura pasan a <span class="pill green">Pagado</span> en el mismo movimiento, con el método de pago estampado — una factura se salda entera o no se salda, nunca a medias. |
+
+El cierre corre con el reloj del período a las **03:00**, sin operador de por medio. Eso es lo que hace que el silencio signifique algo: nadie tiene que acordarse de cerrar un período, así que una factura que no cerró es una falla que vale la pena reportar. El vencimiento es **7 días** después del cierre, y a las 08:00 sale un recordatorio al cliente conforme se acerca.
+
+### La pestaña Facturas del período {#bills-tab}
+
+La última pestaña de [Necesita Atención](#needs-attention) es la cola de facturación. **Una fila por factura, mostrando solo lo más urgente que tiene mal** — una factura calza rutinariamente con más de una de las filas de abajo, y la cola escoge la más fuerte en vez de listarla dos veces.
+
+| Distintivo                  | Urgencia                              | Qué pasó                                                                                                                                                                         | Qué hace usted                                                                                                             |
+| --------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Cobro sin resolver**      | <span class="pill red">Crítico</span> | El cliente presionó Pagar y la pasarela nunca dijo qué pasó. **Su dinero puede haber salido ya mientras la factura sigue diciendo sin pagar**, y nada resuelve esto por sí solo. | Busque un cobro contra esta factura en la pasarela antes que nada. No le pida al cliente que pague de nuevo hasta saberlo. |
+| **Vencida**                 | <span class="pill amber">Alto</span>  | Pasada la fecha de vencimiento y todavía con saldo pendiente. **La cuenta está bloqueada para pedir.**                                                                           | Dé seguimiento al dinero. Verificar una declaración o registrar un pago salda la factura y desbloquea la cuenta.           |
+| **Pago por verificar**      | <span class="pill blue">Medio</span>  | El cliente declaró una transferencia y adjuntó un comprobante.                                                                                                                   | Encuéntrela en el banco y luego apruebe o rechace — vea abajo.                                                             |
+| **Sin pagar, aún no vence** | <span class="pill gray">Bajo</span>   | Cerró hace un par de días, sin pagar, y todavía no vence.                                                                                                                        | Llámelos. **Esta es la valiosa** — todavía no hay nada mal, y es el estado que evita los otros dos.                        |
+
+Las filas van de más urgente a menos, y luego por vencimiento más viejo. Los contadores de urgencia arriba del listado son la señal de triaje que una lista plana no da: dicen cuánto de la cola es dinero de un cliente posiblemente ya perdido y cuánto es una factura simplemente callada.
+
+<div class="callout warn">
+<strong>Leer la cola es de staff; actuar sobre una factura es de administrador</strong>
+Cualquier operador de staff puede abrir esta pestaña y leer una factura. <em>Verificar</em>, <em>Aprobar</em>, <em>Rechazar</em> y <em>Registrar Pago</em> están restringidos a administradores — registrar que entró dinero a una cuenta, y resolver el reclamo de un cliente de que entró, son actos contables y no operativos. Si usted ve la factura pero no los botones, esa es la razón.
+</div>
+
+### Verificar un pago declarado {#verify-declaration}
+
+Una declaración es un **reclamo, no un pago**: el cliente dice que mandó dinero y ofrece una referencia y un comprobante. Nada se salda hasta que alguien encuentre la transferencia.
+
+Presione `Verificar` en la fila de la factura (o en el detalle de la factura). El diálogo le da todo lo que la búsqueda necesita:
+
+1. **El método** — SINPE Móvil o Transferencia bancaria. Le dice en qué canal buscar.
+2. **La referencia**, con un botón de copiar al lado. Cópiela en vez de volver a digitarla: el banco solo la encuentra si coincide carácter por carácter, y digitarla de memoria es donde se tuerce una verificación.
+3. **El monto que hay que buscar** — total del período, crédito aplicado y monto a pagar en colones. Si el cliente pagó en su propia moneda, también se muestra la cifra en _esa_ moneda, y ese es el número que va a estar en el estado de cuenta.
+4. **Dónde se le dijo que lo enviara** — el destino que la factura registró, para que busque en la cuenta correcta. Es una foto que la factura guardó y no una fila viva, así que sigue legible aunque ese destino se haya editado o desactivado.
+5. **El comprobante**, detrás de un botón. Es **corroboración, no evidencia**: lo que resuelve la pregunta es encontrar el pago en el banco. Carga solo cuando usted lo pide, y su ausencia nunca lo bloquea.
+
+Y luego uno de dos desenlaces:
+
+- **Aprobar** — la factura pasa a <span class="pill green">Pagado</span> y todas sus órdenes se saldan con ella. La nota es opcional.
+- **Rechazar** — **el motivo es obligatorio**, y el botón queda deshabilitado hasta que usted escriba uno. Ese motivo le llega al cliente, y ese es todo el punto: un reclamo rechazado sin motivo regresa igualito, con el mismo archivo subido de nuevo.
+
+<div class="callout warn">
+<strong>El campo de notas reemplaza lo que ya está</strong>
+Aprobar o rechazar sobrescribe la nota de la factura. La nota que traiga se muestra encima del campo pero a propósito no se precarga — léala antes de escribir, y no reenvíe la frase de otra persona como si fuera suya.
+</div>
+
+### Registrar un pago que entró por otra vía {#record-bill-payment}
+
+Use `Registrar Pago` cuando el dinero le llegó por otro lado — efectivo en el mostrador, una transferencia que usted ya casó en el banco, una tarjeta cobrada por teléfono. Aquí usted está afirmando un hecho y no presentando un reclamo, así que salda la factura de inmediato, sin verificación posterior.
+
+| Campo                   | Notas                                                                                                                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Método de pago**      | Tarjeta, SINPE Móvil, Transferencia bancaria o Efectivo.                                                                                                                                        |
+| **Moneda**              | Obligatoria — el formulario no envía sin ella. Registra _cuál_ de las cifras ya congeladas de la factura fue la que se pagó, no un tipo de cambio consultado ahora.                             |
+| **Destino de pago**     | Se ofrece solo para SINPE Móvil y Transferencia bancaria, y limitado a los destinos activos de ese método. Cambiar el método limpia la selección, porque un destino pertenece a un solo método. |
+| **Referencia**          | Opcional, y precargada de la factura cuando ya trae una.                                                                                                                                        |
+| **Comprobante de pago** | Opcional aquí. Un cliente que declara una transferencia tiene que adjuntarlo; usted ya recibió el dinero, así que su registro es el hecho.                                                      |
+| **Notas**               | Precargada de la factura, porque enviar escribe este campo haga lo que haga — dejarlo en blanco borraría en silencio una nota que dejó un acto anterior, motivo de rechazo incluido.            |
+
+<div class="callout info">
+<strong>El crédito de la cuenta no está en la lista de métodos, a propósito</strong>
+El crédito solo cuenta como pagado una vez que el cierre del período lo aplicó de verdad contra la factura, y nada más lo aplica. Registrarlo a mano marcaría una factura como pagada con dinero que nunca se gastó, así que el panel no lo ofrece.
+</div>
+
+El efectivo está en la lista del operador y ausente en la del cliente, y la asimetría es el punto: **un cliente no puede probar que entregó efectivo.** El administrador que lo recibió es la única persona que puede decir que pasó. La tarjeta va al revés — el cliente puede pagar con tarjeta él mismo, en la app, y usted también puede registrar una que cobró por otro lado.
+
+### La pantalla de detalle de la factura {#bill-detail}
+
+`Ver` en cualquier fila abre la factura en `/period-bills/<código>`. **No hay listado de facturas en la barra lateral** — la pestaña _Facturas del período_ es como se llega a una, y la flecha de regreso lo devuelve ahí. Los mismos botones `Verificar` y `Registrar Pago` están en el encabezado, y solo para una factura que todavía los admite: una ya <span class="pill green">Pagado</span> no ofrece ninguno.
+
+Tres partes:
+
+- **Factura del período** — total del período, crédito aplicado, monto a pagar, la fecha en que cerró, la fecha en que vence, y una fila por cada moneda en que se acordaron sus líneas.
+- **Método de pago** — aparece solo cuando ya hay algo que mostrar: el método, la referencia copiable, la foto del destino, el comprobante, la nota.
+- **Qué cubre esta factura** — una fila por orden, con el código de la orden, la moneda en que se acordó, el tipo de cambio congelado en su cotización, y el monto tanto en esa moneda como en colones.
+
+<div class="callout info">
+<strong>Los montos nunca se reconvierten</strong>
+Una línea acordada en colones lleva una sola cifra en colones y no necesitó tipo de cambio — por eso la columna de tipo de cambio muestra un guion en esas filas y no el del día. Una línea acordada en otra moneda lleva ese monto, el tipo de cambio congelado en su cotización, y el monto en colones derivado de ahí en ese momento. Nada se consulta cuando llega el dinero, así que una factura siempre puede decir cuánto se le debe antes de que alguien pague.
 </div>
 
 ---
@@ -569,7 +682,7 @@ Cuentas de empresa. Las empresas pueden tener:
 
 - Múltiples usuarios autorizados a crear órdenes.
 - Tarifas negociadas distintas a las del público general.
-- Facturación consolidada mensual.
+- Facturación consolidada por período en vez de por orden — vea [Facturación a cuenta](#period-bills).
 - Catálogo de direcciones frecuentes propio.
 
 ---
@@ -647,10 +760,21 @@ Registro inmutable de todas las acciones administrativas. Útil para:
 
 <figure>
   <img src="/guide/screenshots/15-settings.png" alt="Configuraciones generales" />
-  <figcaption>Pantalla <em>Configuraciones</em>. Tres tarjetas: <em>Idioma</em> (selector inline), <em>Configuración de Moneda</em> y <em>Ventana de Servicio</em> (ambas abren subpáginas con la flecha derecha).</figcaption>
+  <figcaption>Pantalla <em>Configuraciones</em>. La captura es anterior a tres de las tarjetas que hoy tiene — el listado vigente está abajo.</figcaption>
 </figure>
 
-Aquí viven los parámetros globales de la operación. Ojo: la lista es corta a propósito — solo lo que un administrador necesita cambiar a mano. El resto del comportamiento (tarifas, ventanas por orden, factibilidad de despacho) se modela en sus propias secciones.
+Aquí viven los parámetros globales de la operación. La lista es corta a propósito — solo lo que un administrador necesita cambiar a mano. El resto del comportamiento (tarifas, ventanas por orden, factibilidad de despacho) se modela en sus propias secciones.
+
+Las tarjetas, de arriba abajo. Las tres primeras se editan ahí mismo; las tres últimas llevan flecha derecha y abren una subpágina.
+
+| Tarjeta                         | Qué configura                                                                                                                                                                                                                                        |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Idioma**                      | El idioma de la interfaz para el administrador que la usa — vea abajo.                                                                                                                                                                               |
+| **Tipos de Vehículo Admitidos** | Qué tipos de vehículo puede tener asignado un conductor de esta flota. Marque los que opera y guarde.                                                                                                                                                |
+| **Tiempo de espera**            | Tarifa por minuto y tolerancia sobre lo estimado, para el tiempo que un conductor espera en una parada más allá de lo cotizado. Ponga la tarifa en cero y la espera no se cobra. Es una decisión de lista de precios, tomada una vez — no por orden. |
+| **Configuración de Moneda** →   | Qué monedas acepta la plataforma, cómo se obtienen los tipos de cambio y cómo redondea cada una.                                                                                                                                                     |
+| **Destinos de pago** →          | Dónde se le dice al cliente que envíe el dinero de una factura del período.                                                                                                                                                                          |
+| **Ventana de Servicio** →       | Cuándo acepta la plataforma nuevas órdenes, y qué pasa con las que se quedan sin conductor.                                                                                                                                                          |
 
 ### Idioma
 
@@ -716,6 +840,27 @@ El redondeo afecta cómo se presentan los importes al cliente final, no cómo se
 La tasa se ingresa como <em>cuántas unidades de la moneda base equivalen a 1 unidad de esta moneda</em>. Si por error se ingresa al revés (p. ej. <code>0.002</code> en lugar de <code>490</code>), la vista previa pinta una alerta ámbar sugiriendo el valor inverso.
 </div>
 
+### Destinos de pago {#settings-payment-destinations}
+
+Declarar una transferencia sin destino le pide a alguien que pague y no le dice adónde, así que este listado es lo que hace usables SINPE Móvil y la transferencia bancaria. Son las cuentas de la empresa, no algo que registre el cliente.
+
+La tabla lista cada destino con su método, titular, número de cuenta (o número de teléfono, para SINPE Móvil), moneda y estado activo. `+ Crear` abre el formulario; el lápiz edita una fila y el basurero la elimina.
+
+Los campos del formulario dependen del método:
+
+| Método                     | Campos que admite                                                                                                     |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **SINPE Móvil**            | Número de teléfono. Sin moneda — SINPE Móvil recibe colones y nada más.                                               |
+| **Transferencia bancaria** | Moneda, nombre del banco, número de cuenta, e IBAN si lo hay.                                                         |
+| **Ambos**                  | Nombre del titular e identificación legal (ambos obligatorios), un monto máximo, un orden, y el interruptor _activo_. |
+
+El **monto máximo** es el tope por transferencia — SINPE Móvil tiene uno real, y un destino por debajo de lo que cuesta la factura simplemente no se ofrece. Es un filtro sobre el monto, no sobre qué facturas pueden usar el método: una factura expresada en dólares pagada por SINPE Móvil solo se está pagando en colones.
+
+<div class="callout warn">
+<strong>Desactivar en vez de borrar, y crear en vez de reapuntar</strong>
+La factura registra como <em>foto</em> el destino que le mostró al cliente, así que borrar una fila nunca reescribe una factura vieja — pero una fila desactivada sigue siendo legible para quien lea esa factura. Y el <em>método</em> no se puede cambiar después de creado: decide cuáles de los otros campos puede llevar la fila, así que cambiarlo ahí mismo dejaría un destino con los datos del método equivocado. Para pasar un destino a otro método, desactívelo y cree uno nuevo.
+</div>
+
 ### Ventana de Servicio {#settings-service-window}
 
 <figure>
@@ -754,6 +899,8 @@ El umbral se cuenta solo durante horas dentro de la ventana de servicio. Una ord
 
 ## Glosario de estados {#state-glossary}
 
+Los estados de la factura no están aquí — viven junto al flujo que los usa, en [La vida de una factura](#bill-states).
+
 ### Estados de la orden {#order-states}
 
 | Código interno                                            | Etiqueta                                               | Significado                                                     |
@@ -775,12 +922,18 @@ El umbral se cuenta solo durante horas dentro de la ventana de servicio. Una ord
 
 ### Estados de pago {#payment-states}
 
-| Código          | Etiqueta                                             | Significado                               |
-| --------------- | ---------------------------------------------------- | ----------------------------------------- |
-| `unpaid`        | <span class="pill amber">Sin Pagar</span>            | Sin pago registrado.                      |
-| `paid`          | <span class="pill green">Pagado</span>               | Cobro completo recibido.                  |
-| `surcharge_due` | <span class="pill amber">Sobrecargo Pendiente</span> | Tras conciliación quedó saldo por cobrar. |
-| `refunded`      | <span class="pill gray">Reembolsada</span>           | Devolución total ejecutada.               |
+Los ocho, en el orden en que el sistema los declara.
+
+| Código          | Etiqueta                                          | Significado                                                                                                                                                                                                          |
+| --------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unpaid`        | <span class="pill amber">Sin Pagar</span>         | Sin pago registrado.                                                                                                                                                                                                 |
+| `authorized`    | <span class="pill blue">Autorizado</span>         | Hay una retención de tarjeta por el monto cotizado. **No se ha movido dinero** — una retención vence sola, y la conciliación es la que captura.                                                                      |
+| `paid`          | <span class="pill green">Pagado</span>            | Cobro completo recibido.                                                                                                                                                                                             |
+| `on_account`    | <span class="pill blue">A Cuenta</span>           | Facturada a la cuenta en vez de cobrada: la orden es una línea de la factura de ese período, y pasa a <span class="pill green">Pagado</span> cuando esa factura se salda. Vea [Facturación a cuenta](#period-bills). |
+| `surcharge_due` | <span class="pill amber">Recargo Pendiente</span> | Tras conciliación quedó saldo por cobrar.                                                                                                                                                                            |
+| `refunded`      | <span class="pill gray">Reembolsado</span>        | Devolución total ejecutada.                                                                                                                                                                                          |
+| `voided`        | <span class="pill gray">Anulado</span>            | La retención de tarjeta se liberó sin llegar a cobrarse — una cancelación antes de la captura.                                                                                                                       |
+| `chargeback`    | <span class="pill red">Contracargo</span>         | El cliente disputó el cobro con su banco y el dinero se devolvió.                                                                                                                                                    |
 
 ---
 
@@ -813,6 +966,18 @@ Porque la conciliación detectó que el monto real de productos fue mayor a la c
 ### ¿Cómo se generan los PIN de entrega? {#faq-pin-generation}
 
 Automáticamente al crear la orden — un código de 6 dígitos único por orden. Se muestra al cliente en su app y al conductor durante la entrega. Sirve como verificación de identidad del receptor.
+
+### El cliente dice que pagó su factura, pero sigue apareciendo sin pagar — ¿qué hago? {#faq-declared-not-paid}
+
+Primero revise el estado de la factura. <span class="pill amber">Verificación Pendiente</span> significa que su reclamo llegó y ahora nos toca resolverlo a **nosotros** — encuentre la transferencia en el banco y [apruébela](#verify-declaration); el vencimiento sigue corriendo mientras tanto, así que no es un pendiente para dejar de lado. Si la factura sigue <span class="pill blue">Emitida</span> y sin declaración encima, el pago nunca nos llegó como reclamo: pida la referencia y el comprobante, o [regístrelo usted](#record-bill-payment) si ya puede ver el dinero.
+
+### ¿Puedo saldar una factura con el crédito de la cuenta del cliente? {#faq-credit-settle}
+
+No, y a propósito no hay opción para hacerlo. El crédito lo aplica el cierre del período, automáticamente — la factura que está viendo ya muestra _Crédito aplicado_ y un _Monto a pagar_ con el crédito descontado. Vea [El crédito de la cuenta no está en la lista de métodos](#record-bill-payment) para saber por qué no se puede registrar a mano.
+
+### ¿Por qué está bloqueada esta cuenta para pedir? {#faq-account-blocked}
+
+Por una de dos razones, y la pantalla de la cuenta le dice al cliente cuál: una factura de la cuenta está **vencida**, o lo que la cuenta tiene comprometido — sus facturas sin pagar más lo que lleva acumulado este período — llegó al límite fijado para ella. El bloqueo actúa al crear la orden, así que el cliente lo ve antes de armarla y no después. Saldar la factura vencida resuelve lo primero; subir el límite o saldar facturas resuelve lo segundo.
 
 ### ¿Puedo crear una orden desde el panel sin que el cliente la inicie? {#faq-admin-create}
 

--- a/content/guide/guide.fr.md
+++ b/content/guide/guide.fr.md
@@ -75,29 +75,40 @@ La navigation principale vit dans la barre de gauche. Elle est organisée du plu
   <div class="card"><strong class="card-title">Règles de tarification</strong><p>Configuration des tarifs par distance, palier, fenêtre, etc.</p></div>
   <div class="card"><strong class="card-title">Notifications</strong><p>Événements système destinés aux opérations.</p></div>
   <div class="card"><strong class="card-title">Journaux d'audit</strong><p>Qui a fait quoi et quand.</p></div>
-  <div class="card"><strong class="card-title">Paramètres</strong><p>Devises, fenêtres de service, langue, profil.</p></div>
+  <div class="card"><strong class="card-title">Guide</strong><p>Ce manuel, à l'intérieur du panneau.</p></div>
+  <div class="card"><strong class="card-title">Paramètres</strong><p>Devises, destinations de paiement, fenêtres de service, langue.</p></div>
 </div>
+
+_Paramètres se tient à part, au pied de la barre, sous la liste._
 
 ---
 
 ## Demande l'attention <span class="pill green">l'écran le plus important</span> {#needs-attention}
 
-**C'est l'écran où un administrateur passe la majeure partie de la journée.** Toute commande qui exige une intervention manuelle apparaît ici, classée en onglets selon le type d'action.
+**C'est l'écran où un administrateur passe la majeure partie de la journée.** Tout ce qui exige une intervention manuelle apparaît ici — une commande, ou la facture d'un compte — classé en onglets selon le type d'action.
 
 <figure>
   <img src="/guide/screenshots/22-needs-attention.png" alt="Onglets de Demande l'attention" />
-  <figcaption>Onglets de <em>Demande l'attention</em>. Le nombre sur chaque onglet indique combien de commandes attendent une action.</figcaption>
+  <figcaption>Onglets de <em>Demande l'attention</em>. Le nombre sur chaque onglet indique combien de commandes attendent une action. Cette capture est antérieure au sixième onglet — la liste à jour est le tableau ci-dessous.</figcaption>
 </figure>
 
-### Les cinq onglets {#five-tabs}
+### Les onglets {#tabs}
 
-| Onglet                        | Contenu                                                                                                                                                                     | Action attendue                                                                           |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **Conflits**                  | Commandes que le système n'a pas pu répartir automatiquement ou qui ont des problèmes de faisabilité (fenêtre impossible, aucun chauffeur disponible, distance hors plage). | Examiner le motif, réaffecter manuellement, ajuster la fenêtre ou écarter la commande.    |
-| **Conciliation**              | Commandes <span class="pill blue">Terminée</span> où le chauffeur a livré mais le montant facturé doit être ajusté au coût réel des produits achetés.                       | Ouvrir la boîte de conciliation, saisir les prix réels par ligne, générer le devis final. |
-| **Non Cotées**                | Commandes que le client vient de créer et qui n'ont pas encore de devis.                                                                                                    | Vérifier les adresses de chaque arrêt, créer le devis et l'envoyer au client.             |
-| **Non Payées**                | Commandes livrées mais non encore payées par le client.                                                                                                                     | Faire le suivi de l'encaissement, marquer comme payée le moment venu.                     |
-| **Demandes de remboursement** | Réclamations de clients demandant un remboursement total ou partiel.                                                                                                        | Examiner les preuves (preuve de livraison, photos), approuver ou rejeter.                 |
+Ils se lisent de gauche à droite, et le tableau ci-dessous a une ligne par onglet — si le panneau vous montre un onglet que ce tableau ne nomme pas, le guide est périmé et cela vaut la peine de le signaler.
+
+| Onglet                        | Contenu                                                                                                                                                                                                               | Action attendue                                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Conflits**                  | Commandes que le système n'a pas pu répartir automatiquement ou qui ont des problèmes de faisabilité (fenêtre impossible, aucun chauffeur disponible, distance hors plage).                                           | Examiner le motif, réaffecter manuellement, ajuster la fenêtre ou écarter la commande.               |
+| **Conciliation**              | Commandes <span class="pill blue">Terminée</span> où le chauffeur a livré mais le montant facturé doit être ajusté au coût réel des produits achetés.                                                                 | Ouvrir la boîte de conciliation, saisir les prix réels par ligne, générer le devis final.            |
+| **Non Cotées**                | Commandes que le client vient de créer et qui n'ont pas encore de devis.                                                                                                                                              | Vérifier les adresses de chaque arrêt, créer le devis et l'envoyer au client.                        |
+| **Non Payées**                | Deux groupes, l'un sous l'autre : commandes qui ont un devis et restent impayées, et commandes réglées à la livraison (le chauffeur prend l'argent à la porte, en espèces ou par SINPE Móvil).                        | Faire le suivi de l'encaissement, marquer comme payée le moment venu.                                |
+| **Demandes de remboursement** | Réclamations de clients demandant un remboursement total ou partiel.                                                                                                                                                  | Examiner les preuves (preuve de livraison, photos), approuver ou rejeter.                            |
+| **Factures de période**       | Factures des comptes facturés par période plutôt qu'à la commande : un paiement déclaré à contrôler, une facture échue, une facture impayée en silence, ou un paiement par carte que la passerelle n'a jamais résolu. | [Traiter la facture](#period-bills) — vérifier la déclaration, ou enregistrer le paiement déjà reçu. |
+
+<div class="callout warn">
+<strong>Une commande sur compte n'est pas une commande impayée</strong>
+Les commandes facturées à un compte n'apparaissent jamais dans <em>Non Payées</em>. Elles portent <span class="pill blue">Sur Compte</span>, ce qui veut dire que quelqu'un les paie <em>bel et bien</em> — sur une facture de période. Celles-là se relancent depuis l'onglet <em>Factures de période</em>, pas depuis celui-ci.
+</div>
 
 ### Filtres de sévérité {#severity-filters}
 
@@ -369,7 +380,109 @@ Depuis le détail d'une commande terminée avec paiement autorisé, un bouton `C
 
 <div class="callout tip">
 <strong>Le paiement est « autorisé » avant la livraison</strong>
-Quand le devis est accepté, la passerelle de paiement autorise une retenue pour le montant coté mais <em>ne facture pas encore</em>. La conciliation déclenche la capture finale : au montant exact, ni plus ni moins. Cela évite les remboursements et les charges surprises.
+Quand le devis est accepté, la passerelle de paiement autorise une retenue pour le montant coté mais <em>ne facture pas encore</em>. La conciliation déclenche la capture finale : au montant exact, ni plus ni moins. Cela évite les remboursements et les charges surprises. <strong>C'est le parcours à la commande</strong> ; un compte facturé par période ne prend aucune retenue — voir <a href="#period-bills">Facturation sur compte</a>.
+</div>
+
+---
+
+## Facturation sur compte {#period-bills}
+
+La plupart des clients paient à la commande : le devis est autorisé quand ils l'acceptent et capturé à la [conciliation](#reconcile). **Un compte peut au contraire être facturé par période** — il commande toute la semaine ou tout le mois, rien n'est facturé par livraison, et une seule facture couvrant toutes les commandes de la période se clôture à la fin de celle-ci.
+
+Deux choses en découlent, et toutes deux changent ce que vous voyez à l'écran :
+
+- Une commande facturée ainsi porte <span class="pill blue">Sur Compte</span> et non <span class="pill amber">Non Payé</span>. Ce n'est **pas** une commande impayée : quelqu'un la paie, sur une facture qui n'est pas encore clôturée.
+- On ne demande à personne d'encaisser à la porte, donc l'étape d'encaissement du chauffeur est supprimée. C'est délibéré, ce n'est pas une invite manquante.
+
+<div class="callout info">
+<strong>Rien n'est facturé automatiquement</strong>
+La facture se clôture et s'envoie toute seule — c'est la seule part automatique. L'<em>argent</em> est toujours un acte qu'une personne accomplit : le client la paie depuis son application, ou un administrateur enregistre un paiement arrivé par une autre voie. <strong>Aucune carte enregistrée n'est jamais débitée en arrière-plan.</strong> Une carte enregistrée pour régler une livraison n'est pas une permission de solder le compte, donc une facture qui reste impayée est relancée par une personne, comme n'importe quelle autre facture.
+</div>
+
+### La vie d'une facture {#bill-states}
+
+| Code interne            | Étiquette                                               | Signification                                                                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `open`                  | <span class="pill gray">Ouverte</span>                  | La période court encore. Les commandes rejoignent la facture au fur et à mesure qu'elles sont approuvées et le total bouge. **Rien n'est dû pour l'instant** — une facture ouverte n'a pas d'échéance. |
+| `issued`                | <span class="pill blue">Émise</span>                    | La période est clôturée. Le total est figé, le crédit du compte a été appliqué s'il y en avait, une échéance est apposée et le client a été notifié.                                                   |
+| `awaiting_verification` | <span class="pill amber">Vérification en Attente</span> | Le client dit avoir envoyé un virement et a joint un justificatif. **Ce n'est pas payé.** L'échéance n'a pas bougé et le compte à rebours continue.                                                    |
+| `paid`                  | <span class="pill green">Payé</span>                    | Soldée. Toutes les commandes de la facture passent à <span class="pill green">Payé</span> dans le même mouvement, avec le moyen de paiement apposé — une facture se solde entièrement ou pas du tout.  |
+
+La clôture suit l'horloge de la période, à **03:00**, sans opérateur dans la boucle. C'est ce qui donne du sens au silence : personne n'a à penser à clôturer une période, donc une facture qui ne s'est pas clôturée est une anomalie à signaler. L'échéance tombe **7 jours** après la clôture, et un rappel part au client à 08:00 à mesure qu'elle approche.
+
+### L'onglet Factures de période {#bills-tab}
+
+Le dernier onglet de [Demande l'attention](#needs-attention) est la file de facturation. **Une ligne par facture, ne montrant que le plus urgent de ce qui cloche** — une facture correspond couramment à plusieurs des lignes ci-dessous, et la file retient la plus forte plutôt que de la lister deux fois.
+
+| Badge                         | Urgence                                | Ce qui s'est passé                                                                                                                                                                                                     | Ce que vous faites                                                                                                          |
+| ----------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Paiement non résolu**       | <span class="pill red">Critique</span> | Le client a appuyé sur Payer et la passerelle n'a jamais dit ce qui s'était passé. **Son argent est peut-être déjà parti alors que la facture est toujours indiquée comme impayée**, et rien ne résout cela tout seul. | Cherchez d'abord un paiement contre cette facture dans la passerelle. Ne redemandez pas au client de payer avant de savoir. |
+| **En retard**                 | <span class="pill amber">Élevé</span>  | Échéance dépassée et somme toujours due. **Le compte est bloqué pour commander.**                                                                                                                                      | Relancez. Vérifier une déclaration ou enregistrer un paiement solde la facture et débloque le compte.                       |
+| **Paiement à vérifier**       | <span class="pill blue">Moyen</span>   | Le client a déclaré un virement et joint un justificatif.                                                                                                                                                              | Retrouvez-le à la banque, puis approuvez ou rejetez — voir ci-dessous.                                                      |
+| **Impayée, pas encore échue** | <span class="pill gray">Faible</span>  | Clôturée il y a deux ou trois jours, impayée, et pas encore échue.                                                                                                                                                     | Appelez-les. **C'est la précieuse** — rien ne cloche encore, et c'est l'état qui évite les deux autres.                     |
+
+Les lignes vont de la plus urgente à la moins, puis par échéance la plus ancienne. Les compteurs d'urgence au-dessus de la liste sont le signal de tri qu'une liste plate ne donne pas : ils disent quelle part de la file est de l'argent client peut-être déjà parti, et quelle part n'est qu'une facture silencieuse.
+
+<div class="callout warn">
+<strong>Lire la file relève du personnel ; agir sur une facture relève de l'administrateur</strong>
+N'importe quel opérateur du personnel peut ouvrir cet onglet et lire une facture. <em>Vérifier</em>, <em>Approuver</em>, <em>Rejeter</em> et <em>Enregistrer le Paiement</em> sont réservés aux administrateurs — constater que de l'argent est arrivé sur un compte, et trancher la réclamation d'un client affirmant que c'est le cas, sont des actes comptables et non opérationnels. Si vous voyez la facture mais pas les boutons, c'est la raison.
+</div>
+
+### Vérifier un paiement déclaré {#verify-declaration}
+
+Une déclaration est une **réclamation, pas un paiement** : le client dit avoir envoyé de l'argent et propose une référence et un justificatif. Rien n'est soldé tant que quelqu'un n'a pas retrouvé le virement.
+
+Cliquez sur `Vérifier` sur la ligne de la facture (ou sur son détail). La boîte de dialogue vous donne tout ce dont la recherche a besoin :
+
+1. **Le moyen** — SINPE Móvil ou Virement bancaire. Il vous dit dans quel canal chercher.
+2. **La référence**, avec un bouton de copie à côté. Copiez-la plutôt que de la retaper : la banque ne le retrouvera que sur une correspondance exacte, caractère pour caractère, et la retaper de mémoire est là où une vérification déraille.
+3. **Le montant à chercher** — total de la période, crédit appliqué et montant dû en colones. Si le client a payé dans sa propre devise, le chiffre dans _cette_ devise est montré aussi, et c'est celui qui figurera sur le relevé.
+4. **Où on lui a dit d'envoyer** — le destinataire que la facture a enregistré, pour que vous cherchiez dans le bon compte. C'est un instantané que la facture a gardé et non une ligne vivante, donc il reste lisible même après que ce destinataire a été modifié ou désactivé.
+5. **Le justificatif**, derrière un bouton. C'est une **corroboration, pas une preuve** : ce qui tranche, c'est de retrouver le paiement à la banque. Il ne se charge que si vous le demandez, et son absence ne vous bloque jamais.
+
+Puis l'une de deux issues :
+
+- **Approuver** — la facture passe à <span class="pill green">Payé</span> et toutes ses commandes se soldent avec elle. La note est facultative.
+- **Rejeter** — **un motif est obligatoire**, et le bouton reste désactivé tant que vous n'en écrivez pas un. Ce motif parvient au client, et c'est tout l'enjeu : une réclamation rejetée sans motif revient telle quelle, avec le même fichier téléversé à nouveau.
+
+<div class="callout warn">
+<strong>Le champ de notes remplace ce qui s'y trouve déjà</strong>
+Approuver ou rejeter écrase la note de la facture. La note qu'elle porte est affichée au-dessus du champ mais délibérément pas pré-remplie — lisez-la avant d'écrire, et ne renvoyez pas la phrase de quelqu'un d'autre comme la vôtre.
+</div>
+
+### Enregistrer un paiement arrivé par une autre voie {#record-bill-payment}
+
+Utilisez `Enregistrer le Paiement` quand l'argent vous est parvenu autrement — des espèces au comptoir, un virement que vous avez déjà rapproché à la banque, une carte prise par téléphone. Ici vous affirmez un fait plutôt que de déposer une réclamation, donc cela solde la facture immédiatement, sans vérification ultérieure.
+
+| Champ                        | Notes                                                                                                                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Moyen de paiement**        | Carte, SINPE Móvil, Virement bancaire ou Espèces.                                                                                                                                          |
+| **Devise**                   | Obligatoire — le formulaire ne s'envoie pas sans elle. Elle enregistre _lequel_ des chiffres déjà figés de la facture a réellement été payé, pas un taux consulté maintenant.              |
+| **Destinataire du paiement** | Proposé pour SINPE Móvil et Virement bancaire seulement, et limité aux destinations actives de ce moyen. Changer de moyen efface le choix, car un destinataire appartient à un seul moyen. |
+| **Référence**                | Facultative, et pré-remplie depuis la facture quand elle en porte déjà une.                                                                                                                |
+| **Justificatif de paiement** | Facultatif ici. Un client qui déclare un virement doit en joindre une ; vous avez déjà reçu l'argent, donc votre enregistrement est le fait.                                               |
+| **Notes**                    | Pré-remplie depuis la facture, car l'envoi écrit ce champ quoi qu'il arrive — le laisser vide effacerait en silence une note laissée par un acte antérieur, motif de rejet compris.        |
+
+<div class="callout info">
+<strong>Le crédit du compte n'est pas dans la liste des moyens, et c'est voulu</strong>
+Le crédit ne compte comme payé qu'une fois que la clôture de la période l'a réellement appliqué à la facture, et rien d'autre ne l'applique. L'enregistrer à la main marquerait une facture payée avec de l'argent que rien n'a dépensé, donc le panneau ne le propose pas.
+</div>
+
+Les espèces sont dans la liste de l'opérateur et absentes de celle du client, et l'asymétrie est tout l'enjeu : **un client ne peut pas prouver qu'il a remis des espèces.** L'administrateur qui les a reçues est la seule personne à pouvoir dire que cela a eu lieu. La carte fonctionne à l'inverse — le client peut payer par carte lui-même, dans l'application, et vous pouvez aussi enregistrer un paiement pris ailleurs.
+
+### L'écran de détail de la facture {#bill-detail}
+
+`Voir` sur n'importe quelle ligne ouvre la facture à `/period-bills/<code>`. **Il n'y a pas de liste de factures dans la barre latérale** — l'onglet _Factures de période_ est le chemin vers une facture, et la flèche de retour vous y ramène. Les mêmes boutons `Vérifier` et `Enregistrer le Paiement` sont dans l'en-tête, et seulement pour une facture qui les admet encore : une facture déjà <span class="pill green">Payé</span> n'en propose aucun.
+
+Trois parties :
+
+- **Facture de période** — total de la période, crédit appliqué, montant dû, la date de clôture, la date d'échéance, et une ligne par devise dans laquelle ses lignes ont été convenues.
+- **Moyen de paiement** — n'apparaît qu'une fois qu'il y a quelque chose à montrer : le moyen, la référence copiable, l'instantané du destinataire, le justificatif, la note.
+- **Ce que couvre cette facture** — une ligne par commande, avec le code de la commande, la devise dans laquelle elle a été convenue, le taux de change figé sur son devis, et le montant dans cette devise comme en colones.
+
+<div class="callout info">
+<strong>Les montants ne sont jamais reconvertis</strong>
+Une ligne convenue en colones porte un seul chiffre en colones et n'a eu besoin d'aucun taux — c'est pourquoi la colonne du taux affiche un tiret sur ces lignes plutôt que le taux du jour. Une ligne convenue dans une autre devise porte ce montant, le taux figé sur son devis, et le montant en colones qui en découle à cet instant. Rien n'est consulté quand l'argent arrive, donc une facture peut toujours énoncer ce qui lui est dû avant que quiconque paie.
 </div>
 
 ---
@@ -569,7 +682,7 @@ Comptes d'entreprise. Les entreprises peuvent avoir :
 
 - Plusieurs utilisateurs autorisés à créer des commandes.
 - Des tarifs négociés différents de ceux du grand public.
-- Une facturation consolidée mensuelle.
+- Une facturation consolidée par période plutôt qu'à la commande — voir [Facturation sur compte](#period-bills).
 - Leur propre catalogue d'adresses fréquentes.
 
 ---
@@ -647,10 +760,21 @@ Registre immuable de toutes les actions administratives. Utile pour :
 
 <figure>
   <img src="/guide/screenshots/15-settings.png" alt="Paramètres généraux" />
-  <figcaption>Écran <em>Paramètres</em>. Trois cartes : <em>Langue</em> (sélecteur en ligne), <em>Paramètres de devise</em> et <em>Fenêtre de service</em> (les deux dernières ouvrent des sous-pages via la flèche droite).</figcaption>
+  <figcaption>Écran <em>Paramètres</em>. La capture est antérieure à trois des cartes qu'il porte aujourd'hui — la liste à jour est ci-dessous.</figcaption>
 </figure>
 
-C'est ici que vivent les paramètres globaux de l'opération. Attention : la liste est volontairement courte — seulement ce qu'un administrateur doit changer à la main. Le reste du comportement (tarifs, fenêtres par commande, faisabilité de la répartition) est modélisé dans ses propres sections.
+C'est ici que vivent les paramètres globaux de l'opération. La liste est volontairement courte — seulement ce qu'un administrateur doit changer à la main. Le reste du comportement (tarifs, fenêtres par commande, faisabilité de la répartition) est modélisé dans ses propres sections.
+
+Les cartes, de haut en bas. Les trois premières se modifient sur place ; les trois dernières portent une flèche droite et ouvrent une sous-page.
+
+| Carte                                | Ce qu'elle règle                                                                                                                                                                                                                                                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Langue**                           | La langue de l'interface pour l'administrateur qui l'utilise — voir ci-dessous.                                                                                                                                                                                            |
+| **Types de Véhicule Pris en Charge** | Quels types de véhicule un chauffeur de cette flotte peut se voir attribuer. Cochez ceux que vous exploitez et enregistrez.                                                                                                                                                |
+| **Temps d'attente**                  | Tarif à la minute et tolérance au-delà de l'estimation, pour le temps qu'un chauffeur passe à attendre à un arrêt au-delà de ce qui était coté. Mettez le tarif à zéro et l'attente n'est pas facturée. Une décision de liste de prix, prise une fois — pas à la commande. |
+| **Paramètres de devise** →           | Quelles devises la plateforme accepte, comment les taux sont obtenus, et comment chacune arrondit.                                                                                                                                                                         |
+| **Destinations de paiement** →       | Où l'on dit au client d'envoyer l'argent d'une facture de période.                                                                                                                                                                                                         |
+| **Fenêtre de service** →             | Quand la plateforme accepte de nouvelles commandes, et ce qu'il advient de celles laissées sans chauffeur.                                                                                                                                                                 |
 
 ### Langue
 
@@ -716,6 +840,27 @@ L'arrondi affecte la façon dont les montants sont présentés au client final, 
 Le taux se saisit comme <em>combien d'unités de la devise de base équivalent à 1 unité de cette devise</em>. Si on saisit par erreur à l'envers (p. ex. <code>0,002</code> au lieu de <code>490</code>), l'aperçu peint une alerte ambre suggérant la valeur inverse.
 </div>
 
+### Destinations de paiement {#settings-payment-destinations}
+
+Déclarer un virement sans destination demande à quelqu'un de payer sans dire où, donc cette liste est ce qui rend SINPE Móvil et le virement bancaire utilisables tout court. Ce sont les comptes de l'entreprise, pas quelque chose que le client enregistre.
+
+Le tableau liste chaque destination avec son moyen, son titulaire, son numéro de compte (ou de téléphone, pour SINPE Móvil), sa devise et son état actif. `+ Créer` ouvre le formulaire ; le crayon modifie une ligne et la corbeille en supprime une.
+
+Les champs du formulaire dépendent du moyen :
+
+| Moyen                 | Champs qu'il admet                                                                                                                  |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **SINPE Móvil**       | Numéro de téléphone. Pas de devise — SINPE Móvil reçoit des colones et rien d'autre.                                                |
+| **Virement bancaire** | Devise, nom de la banque, numéro de compte, et IBAN s'il y en a un.                                                                 |
+| **Les deux**          | Nom du titulaire et identifiant légal (les deux obligatoires), un montant maximum, un ordre d'affichage, et l'interrupteur _actif_. |
+
+Le **montant maximum** est le plafond par virement — SINPE Móvil en a un bien réel, et une destination en dessous du montant d'une facture n'est tout simplement pas proposée pour elle. C'est un filtre sur le montant, pas sur les factures qui peuvent utiliser le moyen : une facture libellée en dollars payée par SINPE Móvil est simplement payée en colones.
+
+<div class="callout warn">
+<strong>Désactiver plutôt que supprimer, et créer plutôt que réaffecter</strong>
+La facture enregistre comme <em>instantané</em> la destination qu'elle a montrée au client, donc supprimer une ligne ne réécrit jamais une ancienne facture — mais une ligne désactivée reste lisible pour qui en lit une. Et le <em>moyen</em> ne peut pas être changé après la création : il décide lesquels des autres champs la ligne peut porter, donc le changer sur place laisserait une destination avec les données du mauvais moyen. Pour basculer une destination vers un autre moyen, désactivez-la et créez-en une nouvelle.
+</div>
+
 ### Fenêtre de service {#settings-service-window}
 
 <figure>
@@ -754,6 +899,8 @@ Le seuil ne compte que les heures à l'intérieur de la fenêtre de service. Une
 
 ## Glossaire des états {#state-glossary}
 
+Les états d'une facture ne sont pas ici — ils vivent avec le flux qui les utilise, dans [La vie d'une facture](#bill-states).
+
 ### États de la commande {#order-states}
 
 | Code interne                                              | Étiquette                                                  | Signification                                                 |
@@ -775,12 +922,18 @@ Le seuil ne compte que les heures à l'intérieur de la fenêtre de service. Une
 
 ### États de paiement {#payment-states}
 
-| Code            | Étiquette                                            | Signification                                     |
-| --------------- | ---------------------------------------------------- | ------------------------------------------------- |
-| `unpaid`        | <span class="pill amber">Non payée</span>            | Aucun paiement enregistré.                        |
-| `paid`          | <span class="pill green">Payée</span>                | Encaissement complet reçu.                        |
-| `surcharge_due` | <span class="pill amber">Surcharge en attente</span> | Après conciliation il reste un solde à percevoir. |
-| `refunded`      | <span class="pill gray">Remboursée</span>            | Remboursement total exécuté.                      |
+Les huit, dans l'ordre où le système les déclare.
+
+| Code            | Étiquette                                      | Signification                                                                                                                                                                                                                       |
+| --------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unpaid`        | <span class="pill amber">Non Payé</span>       | Aucun paiement enregistré.                                                                                                                                                                                                          |
+| `authorized`    | <span class="pill blue">Autorisé</span>        | Une retenue par carte est posée pour le montant coté. **Aucun argent n'a bougé** — une retenue expire d'elle-même, et la conciliation capture.                                                                                      |
+| `paid`          | <span class="pill green">Payé</span>           | Encaissement complet reçu.                                                                                                                                                                                                          |
+| `on_account`    | <span class="pill blue">Sur Compte</span>      | Facturée au compte au lieu d'être débitée : la commande est une ligne de la facture de cette période, et passe à <span class="pill green">Payé</span> quand cette facture est soldée. Voir [Facturation sur compte](#period-bills). |
+| `surcharge_due` | <span class="pill amber">Supplément Dû</span>  | Après conciliation il reste un solde à percevoir.                                                                                                                                                                                   |
+| `refunded`      | <span class="pill gray">Remboursé</span>       | Remboursement total exécuté.                                                                                                                                                                                                        |
+| `voided`        | <span class="pill gray">Annulé</span>          | La retenue par carte a été libérée sans jamais être débitée — une annulation avant capture.                                                                                                                                         |
+| `chargeback`    | <span class="pill red">Rétrofacturation</span> | Le client a contesté le paiement auprès de sa banque et l'argent a été repris.                                                                                                                                                      |
 
 ---
 
@@ -813,6 +966,18 @@ Parce que la conciliation a détecté que le coût réel des produits était sup
 ### Comment se génèrent les PIN de livraison ? {#faq-pin-generation}
 
 Automatiquement à la création de la commande — un code à 6 chiffres unique par commande. Il est montré au client dans son application et au chauffeur lors de la livraison. Il sert de vérification d'identité du destinataire.
+
+### Le client dit avoir payé sa facture, mais elle apparaît toujours impayée — que faire ? {#faq-declared-not-paid}
+
+Regardez d'abord l'état de la facture. <span class="pill amber">Vérification en Attente</span> veut dire que sa réclamation est arrivée et c'est à **nous** de la traiter — retrouvez le virement à la banque et [approuvez-le](#verify-declaration) ; l'échéance continue de courir entre-temps, donc ce n'est pas une attente à laisser traîner. Si la facture est encore <span class="pill blue">Émise</span> sans déclaration dessus, son paiement ne nous est jamais parvenu comme réclamation : demandez la référence et le justificatif, ou [enregistrez-le vous-même](#record-bill-payment) si vous voyez déjà l'argent.
+
+### Puis-je solder une facture avec le crédit du compte du client ? {#faq-credit-settle}
+
+Non, et il n'y a délibérément pas d'option pour le faire. Le crédit est appliqué par la clôture de la période, automatiquement — la facture que vous regardez affiche déjà _Crédit appliqué_ et un _Montant dû_ crédit déduit. Voir [Le crédit du compte n'est pas dans la liste des moyens](#record-bill-payment) pour la raison pour laquelle il ne peut pas être enregistré à la main.
+
+### Pourquoi ce compte est-il bloqué pour commander ? {#faq-account-blocked}
+
+Pour l'une de deux raisons, et l'écran du compte dit au client laquelle : une facture du compte est **échue**, ou ce que le compte engage — ses factures impayées plus ce que la période en cours a accumulé — a atteint la limite fixée pour lui. Le blocage agit à la création de la commande, donc le client le voit avant de la composer plutôt qu'après. Solder la facture échue règle la première ; relever la limite ou solder des factures règle la seconde.
 
 ### Puis-je créer une commande depuis le panneau sans que le client ne l'initie ? {#faq-admin-create}
 


### PR DESCRIPTION
Refs LorenzoWynberg/mandados-api#212 — W7 Slice 3.

The routed operator guide at `/guide` (`content/guide/guide.{en,es,fr}.md`) had gone stale against deferred billing. Every stale claim was a count an operator could disprove by looking at their own screen.

## Corrected

| Claim | Was | Is | Instrument |
|---|---|---|---|
| Needs Attention tabs | 5 | **6** | `/usr/bin/grep -oE 'TabsTrigger value="[a-z-]+"' 'app/[lang]/(dashboard)/needs-attention/page.tsx' \| sort -u \| wc -l` → 6 distinct tab values |
| Settings cards | 3 | **6** | `/usr/bin/grep -cE '^      <Card' 'app/[lang]/(dashboard)/settings/page.tsx'` → 6 top-level `<Card` elements |
| Payment states | 4 of 8 | **8** | keys of `Enums.PaymentStatus`, `data/app-enums.ts` |

The `### The five tabs {#five-tabs}` heading became `### The tabs {#tabs}` — it now carries no number at all, so the count cannot rot again; the table is the enumeration.

Two screenshots genuinely predate the change (`15-settings.png` shows 3 of 6 cards, `22-needs-attention.png` shows 5 of 6 tabs). Rather than reference images that do not exist, their captions now say the capture predates the current list. No new image is referenced — `public/guide/screenshots/**` is outside this slice, and new captures for the bill screens are worth a follow-up.

## Added — written from the source, not from the design notes

- **Billing on account** — what an `on_account` order is and why it never appears in *Not Yet Paid*; the bill's four states; the **four** reasons a bill reaches the queue (`unresolved_charge`, `overdue`, `declaration_to_verify`, `quiet`).
- **Verifying a declared payment** — a declaration is a claim, not a payment; a rejection **requires** a reason, because one rejected without one returns as the same file re-uploaded.
- **Recording a payment that arrived out of band** — card **is** recordable by hand; the method that is not is **account credit**, since only `PeriodBillService::close()` moves the ledger. Cash is admin-only because a customer cannot prove they handed it over.
- **Payment destinations** under Settings — method immutability, and why deactivating beats deleting.
- Three FAQ entries, and a note that reading the queue is staff while settle/approve/reject are admin-only.

## Parity

All three files stay strict parallel translations, which is what keeps `extractToc.ts` generating the same table of contents per language:

- `wc -l` → **984 / 984 / 984**
- `/usr/bin/grep -c '^#'` → **87 / 87 / 87**
- outline identity (line-number + anchor-id pairs, diffed pairwise) → **exit 0** on en↔es, en↔fr, es↔fr
- anchors unique per file → **72 / 72 distinct**; zero dangling internal links

## Notes

Two corrections to the dispatch brief, both established against the source and confirmed by the dispatcher ([#212 comment](https://github.com/LorenzoWynberg/mandados-api/issues/212#issuecomment-5608499903)): card **is** hand-recordable (the exclusion is `Credit`), and Settings has six cards rather than four.

Markdown content only — no component, route handler or React code is touched.