### PR TITLE
docs(guide): use the app's own word for reconciling a transfer

### DIFF
--- a/content/guide/guide.es.md
+++ b/content/guide/guide.es.md
@@ -452,7 +452,7 @@ Aprobar o rechazar sobrescribe la nota de la factura. La nota que traiga se mues
 
 ### Registrar un pago que entró por otra vía {#record-bill-payment}
 
-Use `Registrar Pago` cuando el dinero le llegó por otro lado — efectivo en el mostrador, una transferencia que usted ya casó en el banco, una tarjeta cobrada por teléfono. Aquí usted está afirmando un hecho y no presentando un reclamo, así que salda la factura de inmediato, sin verificación posterior.
+Use `Registrar Pago` cuando el dinero le llegó por otro lado — efectivo en el mostrador, una transferencia que usted ya concilió en el banco, una tarjeta cobrada por teléfono. Aquí usted está afirmando un hecho y no presentando un reclamo, así que salda la factura de inmediato, sin verificación posterior.
 
 | Campo                   | Notas                                                                                                                                                                                           |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The Spanish guide described a transfer the operator `ya casó en el banco`.

**`casar` for matching transactions is a Spain banking regionalism** and reads wrong in Costa Rica — flagged by the maintainer, who is the native speaker and the one whose judgement counts here.

It is also **inconsistent with this document's own vocabulary**: `conciliar` / `Conciliación` already appears in the guide's intro (`:7`), the Needs Attention tab table (`:102`) and the reconciliation walkthrough (`:335`, `:345`) — and the api's Spanish locale names that tab `Conciliación` (`lang/es/orders.php`). So this is not a taste call: the guide had two words for one concept and one of them was wrong.

```
- una transferencia que usted ya casó en el banco
+ una transferencia que usted ya concilió en el banco
```

One line. Line counts and heading/anchor parity across en/es/fr are unaffected (984/984/984, 87/87/87).

**Draft on purpose** — held open in case the maintainer flags anything else in the Spanish added by #47, so the fixes land together rather than one PR per phrase.