### PR TITLE
fix(needs-attention): invalidate the bills queue on broadcast

### DIFF
--- a/hooks/orders/__tests__/useNeedsAttentionBroadcast.test.tsx
+++ b/hooks/orders/__tests__/useNeedsAttentionBroadcast.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useNeedsAttentionBroadcast } from '../useNeedsAttentionBroadcast';
+
+// A minimal stand-in for the laravel-echo private channel this hook talks to:
+// `.private('admin')` always returns the same channel object, `.listen`
+// captures the handler so a test can fire it directly, and `.stopListening`
+// is a spy the unmount assertion reads.
+function makeChannel() {
+  return {
+    listen: vi.fn((_event: string, handler: () => void) => {
+      capturedHandler = handler;
+    }),
+    stopListening: vi.fn(),
+  };
+}
+
+let channel: ReturnType<typeof makeChannel>;
+let capturedHandler: (() => void) | undefined;
+let echoInstance: { private: ReturnType<typeof vi.fn> } | null;
+
+vi.mock('@/providers/EchoProvider', () => ({
+  useEcho: () => echoInstance,
+}));
+
+// The wrapper reads the client from this module-scope binding rather than a
+// closed-over constant, so a test can swap which QueryClient is in context
+// between renders without unmounting the tree — the only way to exercise the
+// hook's `queryClientRef` guard against re-subscribing on that change.
+let currentClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={currentClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  channel = makeChannel();
+  capturedHandler = undefined;
+  echoInstance = { private: vi.fn(() => channel) };
+  currentClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+});
+
+describe('useNeedsAttentionBroadcast', () => {
+  it('invalidates the bills queue key alongside both existing orders keys', () => {
+    const invalidateSpy = vi.spyOn(currentClient, 'invalidateQueries');
+
+    renderHook(() => useNeedsAttentionBroadcast(), { wrapper });
+
+    expect(capturedHandler).toBeInstanceOf(Function);
+    capturedHandler!();
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining([
+        ['orders', 'needs-attention'],
+        ['orders', 'pending-reconciliation'],
+        ['period-bills', 'needs-attention'],
+      ])
+    );
+    expect(invalidatedKeys).toHaveLength(3);
+  });
+
+  it('unsubscribes from the admin channel on unmount', () => {
+    const { unmount } = renderHook(() => useNeedsAttentionBroadcast(), { wrapper });
+
+    expect(channel.stopListening).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(channel.stopListening).toHaveBeenCalledWith('.needs-attention.changed');
+  });
+
+  it('does not resubscribe when the queryClient reference changes', () => {
+    const { rerender } = renderHook(() => useNeedsAttentionBroadcast(), { wrapper });
+
+    expect(echoInstance!.private).toHaveBeenCalledTimes(1);
+
+    // Swap the client in context without changing `echo` — the effect that
+    // subscribes depends only on `[echo]`, so this must not re-subscribe.
+    currentClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const newInvalidateSpy = vi.spyOn(currentClient, 'invalidateQueries');
+    rerender();
+
+    expect(echoInstance!.private).toHaveBeenCalledTimes(1);
+
+    // The ref still forwards the latest client to the handler captured on the
+    // original subscription.
+    capturedHandler!();
+    expect(newInvalidateSpy).toHaveBeenCalled();
+  });
+
+  it('does nothing when no echo instance is available yet', () => {
+    echoInstance = null;
+
+    expect(() => renderHook(() => useNeedsAttentionBroadcast(), { wrapper })).not.toThrow();
+    expect(capturedHandler).toBeUndefined();
+  });
+});

--- a/hooks/orders/useNeedsAttentionBroadcast.ts
+++ b/hooks/orders/useNeedsAttentionBroadcast.ts
@@ -5,6 +5,18 @@ import { useEcho } from '@/providers/EchoProvider';
 /**
  * Listen for needs-attention broadcast events and invalidate the query cache.
  * This should be called from a component that's mounted when authenticated.
+ *
+ * `.needs-attention.changed` fires for both an order-side change and a
+ * period-bill one, so this listener spans two domains but stays beside
+ * orders: `EchoProvider` is its only call site, and one subscription on the
+ * shared `admin` channel already covers both queues (the same shape
+ * `useNotificationBroadcast` uses for its `refund-requests` key).
+ *
+ * Keys are invalidated individually rather than by `period-bills` prefix: the
+ * event carries no bill id, so a prefix invalidation would evict every open
+ * bill-detail cache (`['period-bills', publicId]`) on every occurrence —
+ * unlike `usePeriodBillMutations`, which knows the one bill that changed and
+ * prefix-invalidates on purpose.
  */
 export function useNeedsAttentionBroadcast() {
   const echo = useEcho();
@@ -25,6 +37,9 @@ export function useNeedsAttentionBroadcast() {
       });
       queryClientRef.current.invalidateQueries({
         queryKey: ['orders', 'pending-reconciliation'],
+      });
+      queryClientRef.current.invalidateQueries({
+        queryKey: ['period-bills', 'needs-attention'],
       });
     });
 

--- a/hooks/periodBills/useBillsNeedingAttention.ts
+++ b/hooks/periodBills/useBillsNeedingAttention.ts
@@ -6,6 +6,10 @@ import { PeriodBillService } from '@/services/periodBillService';
  *
  * The rows arrive ordered by the api and are handed on untouched — see
  * `BillsNeedingAttention.items` for why re-sorting them would be a defect.
+ *
+ * This key is also invalidated by `useNeedsAttentionBroadcast` (in
+ * `hooks/orders/`) on the shared `admin` channel — this queue updates live,
+ * not just after the acting admin's own settle/approve/reject.
  */
 export function useBillsNeedingAttention() {
   return useQuery({


### PR DESCRIPTION
## Summary

An operator watching the Needs Attention queue now sees a bill arrive or leave without reloading the page, the same way the orders tabs already update live.

`useNeedsAttentionBroadcast` (in `hooks/orders/`) listens for `.needs-attention.changed` on the private `admin` channel and previously invalidated only `['orders', 'needs-attention']` and `['orders', 'pending-reconciliation']`. The api fires this same event for period-bill changes too — five dispatch points in `PeriodBillService` plus the nightly `CloseBillingPeriods` run — but the bills queue's own key, `['period-bills', 'needs-attention']` (`useBillsNeedingAttention`), was never invalidated. So another operator's action, or the nightly close, updated the orders tabs live while the Bills tab stayed silently stale until a manual reload.

## The two decisions

**Where the listener lives.** Left in `hooks/orders/useNeedsAttentionBroadcast.ts` rather than moved, and widened. Its only call site is `providers/EchoProvider.tsx`, out of this slice's fence, so moving the file would mean either touching that file or a re-export indirection through the `orders` barrel for no real isolation gained — one subscription on the shared `admin` channel already covers both queues. There's direct precedent for a domain's broadcast hook reaching into a sibling domain's cache from its own folder: `hooks/notifications/useNotificationBroadcast.ts` already invalidates a `['refund-requests', 'pending']` key from inside `notifications/`. Left a pointer comment on `useBillsNeedingAttention` so the cross-domain invalidation is discoverable from the period-bills side too.

**How broad the invalidation is.** Narrow — only `['period-bills', 'needs-attention']`, not the whole `period-bills` prefix. `usePeriodBillMutations` deliberately invalidates the whole prefix, and says why in its own comment: the acting admin just changed one *known* bill, so dropping that bill's own detail cache (`['period-bills', publicId]`) alongside the list is correct. This event carries no bill id and can fire for any admin's action or the nightly close, so a prefix invalidation here would evict every open bill-detail cache on every occurrence for bills that mostly have nothing to do with what changed. This mirrors the existing asymmetry already in this same hook: the two `orders` keys are targeted narrowly too, even though a sibling mutation hook (`useCancelOrder`) invalidates the whole `orders` prefix on its own action.

**Urgency counters** — checked and unaffected: both the bills tab's badge count and its per-urgency summary in `app/[lang]/(dashboard)/needs-attention/page.tsx` read from the same `useBillsNeedingAttention()` query this change already invalidates. No second key needed the same treatment.

## Verification

- New test file (`hooks/orders/__tests__/useNeedsAttentionBroadcast.test.tsx`, 4 tests) covers: the bills key is invalidated alongside both existing orders keys (and only those three); the channel is unsubscribed on unmount; the listener does not resubscribe when the `QueryClient` reference changes (still forwards to the latest client via the existing ref); a no-op when no echo instance is available yet.
- Reversal proof: reverting the bills-key invalidation on the source file turned the first test red while the other three stayed green — confirmed before restoring the real change.
- Existing tests for this hook's call site (`app/[lang]/(dashboard)/needs-attention/__tests__/page.test.tsx`) and the period-bills hooks pass unchanged.

## Test plan

- [x] `npm run check` (format-check + lint + typecheck)
- [x] Targeted test files pass: the new broadcast test, `hooks/periodBills/__tests__/*`, the needs-attention page test
- [x] Full gate run (`npm run check && npm run test:run`) — verdict posted as a comment on this PR