### PR TITLE
chore: sync generated types for DeclarationPending

### DIFF
--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -343,6 +343,7 @@ export const Enums = {
     Unresolved: 'unresolved',
     NoUsableCard: 'no_usable_card',
     NotPayable: 'not_payable',
+    DeclarationPending: 'declaration_pending',
     Unsupported: 'unsupported',
   },
   PeriodBillStatus: {

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -1673,6 +1673,7 @@ declare namespace App.Enums {
     Unresolved = 'unresolved',
     NoUsableCard = 'no_usable_card',
     NotPayable = 'not_payable',
+    DeclarationPending = 'declaration_pending',
     Unsupported = 'unsupported',
   }
   export enum PeriodBillStatus {


### PR DESCRIPTION
## Summary
- Sync `types/generated.d.ts`, `types/response.d.ts` and `types/notifications.d.ts` from api's `epic/deferred-billing` tip (api PR #282, `7ad32ce`)
- Regenerate `data/app-enums.ts` via `npm run gen:enums`
- Adds `PeriodBillChargeOutcome.DeclarationPending` ('declaration_pending') — a customer pressing Pay by card on a bill with a standing payment declaration is now refused rather than charged twice

## Scope
Type sync only. No component, hook, or page changes — this repo does not branch on the new enum today.

## Test plan
- [x] Copied files diffed byte-identical against api's `origin/epic/deferred-billing` tip
- [x] `npm run check` (format:check + lint + typecheck) — clean, no drift
- [x] `npm run test:run` — 27 files / 248 tests passed, same as baseline