### PR TITLE
chore: replace deprecated eslint-env comment in FCM service worker

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,5 +1,4 @@
-/* eslint-env serviceworker */
-/* global firebase */
+/* global importScripts, self, firebase */
 /**
  * Firebase Cloud Messaging service worker — web push for the admin dashboard.
  *


### PR DESCRIPTION
## Summary
- `public/firebase-messaging-sw.js:1` used `/* eslint-env serviceworker */`, which flat-config ESLint no longer recognizes — it prints an `ESLintEnvWarning` today and becomes a hard error in eslint v10.
- Replaces it with `/* global importScripts, self, firebase */`, the exact set of bare globals the file body references (verified by reading the file, not copied from the issue).
- Took the file-local `/* global */` route rather than a flat-config override: only this one file in the repo needs these globals, so a `files`-scoped block in `eslint.config.mjs` would add indirection for a single consumer with no benefit. The eslint config is untouched.

Closes admin#45.

## Test plan
- [x] Reproduced the warning pre-change: `npm run check` was green (exit 0) but printed `ESLintEnvWarning: ... Found in .../public/firebase-messaging-sw.js at line 1` during the lint step.
- [x] Post-change: `npm run check` is green with no warning of any kind.
- [x] `npm run test:run` — 27 files / 248 tests, unchanged before and after.
- [x] `npx eslint public/firebase-messaging-sw.js` alone — zero errors, zero warnings post-change.
- [x] `git status --porcelain` — only `public/firebase-messaging-sw.js` touched.