### PR TITLE
fix(i18n): fix locale call sites left by api PR #285's key cleanup

### DIFF
--- a/app/[lang]/(dashboard)/orders/[id]/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/__tests__/page.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import OrderDetailPage from '../page';
+
+// This page's own params/router come through next/navigation — override the
+// blanket vitest.setup.ts stub so `params.id` resolves to a real order id.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useParams: () => ({ id: 'order-1', lang: 'en' }),
+  usePathname: () => '',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, ready: true }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  capitalize: (value: string) => value,
+  resourceMessage: (key: string) => key,
+  statusLabel: (status: string) => status,
+  validationAttribute: (key: string) => key,
+}));
+
+// isAdmin: false keeps the dispatcher card (and its useDispatchUsers query)
+// off the tree — irrelevant to the outsource button under test.
+vi.mock('@/hooks/auth', () => ({ useRole: () => ({ isAdmin: false }) }));
+
+const outsourceMutate = vi.fn();
+
+vi.mock('@/hooks/orders', () => ({
+  useOrder: () => ({
+    data: {
+      id: 1,
+      publicId: 'order-1',
+      status: 'approved',
+      driver: null,
+      stops: [],
+      quotes: [],
+      currentQuote: null,
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteOrder: () => ({ mutate: vi.fn(), isPending: false }),
+  useCalculateDistance: () => ({ mutate: vi.fn(), isPending: false }),
+  useOutsourceOrder: () => ({ mutate: outsourceMutate, isPending: false }),
+  useUpdateStop: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/currencies', () => ({ useCurrencyList: () => ({ data: { items: [] } }) }));
+vi.mock('@/hooks/users', () => ({ useDispatchUsers: () => ({ data: { items: [] } }) }));
+
+// Everything below always renders once `order.publicId` is set — none of it
+// bears on the outsource button, so it is stubbed out like the sibling
+// businesses/[id] and users/[id] page tests do for their own heavy children.
+vi.mock('@/components/payments/PaymentSection', () => ({ PaymentSection: () => null }));
+vi.mock('@/components/invoices/InvoiceSection', () => ({ InvoiceSection: () => null }));
+vi.mock('@/components/orders/ReceiptSection', () => ({ ReceiptSection: () => null }));
+vi.mock('@/components/orders/OrderActivityCard', () => ({ OrderActivityCard: () => null }));
+vi.mock('@/components/orders/ShareTrackingLinkDialog', () => ({
+  ShareTrackingLinkDialog: () => null,
+}));
+vi.mock('@/components/orders/AddStopDialog', () => ({ AddStopDialog: () => null }));
+vi.mock('@/components/chat/ChatTabs', () => ({ ChatTabs: () => null }));
+
+describe('OrderDetailPage — outsource button label', () => {
+  it("uses actionLabel('outsource') instead of the nonexistent orders:detail.outsource key", () => {
+    render(<OrderDetailPage />);
+
+    // common:actions.outsource exists; orders:detail.outsource does not — a
+    // regression back to the raw t() call would render the dead key instead.
+    expect(screen.getByRole('button', { name: /outsource/i })).toHaveTextContent('outsource');
+    expect(screen.queryByText('orders:detail.outsource')).not.toBeInTheDocument();
+  });
+});

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -234,7 +234,7 @@ export default function OrderDetailPage() {
                 disabled={outsourceOrder.isPending}
               >
                 <ExternalLink className="mr-2 h-4 w-4" />
-                {t('orders:detail.outsource', { defaultValue: 'Outsource' })}
+                {actionLabel('outsource')}
               </Button>
             )}
           {order.status === Enums.OrderStatus.COMPLETED &&

--- a/app/[lang]/(dashboard)/settings/payment-destinations/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/settings/payment-destinations/__tests__/page.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+import PaymentDestinationsPage from '../page';
+
+const mockT = vi.fn<(key: string, options?: Record<string, unknown>) => string>((key) => key);
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: mockT, ready: true }) }));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  capitalize: (value: string) => value,
+  modelLabel: (key: string) => key,
+  resourceMessage: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+vi.mock('@/hooks/useLocalizedRouter', () => ({
+  useLocalizedRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('@/hooks/paymentDestinations', () => ({
+  usePaymentDestinations: () => ({
+    data: [
+      {
+        id: 1,
+        method: 'sinpe_mobile',
+        holderName: 'Provider A',
+        active: true,
+      },
+      {
+        id: 2,
+        method: 'sinpe_mobile',
+        holderName: 'Provider B',
+        active: false,
+      },
+    ],
+    isLoading: false,
+  }),
+  useDeletePaymentDestination: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/components/paymentDestinations/PaymentDestinationDialog', () => ({
+  PaymentDestinationDialog: () => null,
+}));
+
+describe('PaymentDestinationsPage — common:active / common:inactive pluralization', () => {
+  beforeEach(() => {
+    mockT.mockClear();
+  });
+
+  it('passes count on the column header, since common.active is a genuine plural (_one/_other only)', () => {
+    render(<PaymentDestinationsPage />);
+
+    const headerCall = mockT.mock.calls.find(([key]) => key === 'common:active');
+    expect(headerCall).toBeDefined();
+    expect(headerCall?.[1]).toEqual({ count: 2 });
+  });
+
+  it('passes count on each row badge, describing that one destination', () => {
+    render(<PaymentDestinationsPage />);
+
+    const activeCall = mockT.mock.calls.find(
+      ([key, opts]) => key === 'common:active' && opts?.count === 1
+    );
+    const inactiveCall = mockT.mock.calls.find(([key]) => key === 'common:inactive');
+
+    expect(activeCall?.[1]).toEqual({ count: 1 });
+    expect(inactiveCall?.[1]).toEqual({ count: 1 });
+  });
+});

--- a/app/[lang]/(dashboard)/settings/payment-destinations/page.tsx
+++ b/app/[lang]/(dashboard)/settings/payment-destinations/page.tsx
@@ -101,7 +101,7 @@ export default function PaymentDestinationsPage() {
                   <TableHead>{validationAttribute('holderName')}</TableHead>
                   <TableHead>{validationAttribute('accountNumber')}</TableHead>
                   <TableHead>{validationAttribute('currencyCode')}</TableHead>
-                  <TableHead>{t('common:active')}</TableHead>
+                  <TableHead>{t('common:active', { count: 2 })}</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -118,7 +118,9 @@ export default function PaymentDestinationsPage() {
                     <TableCell>{destination.currencyCode ?? '-'}</TableCell>
                     <TableCell>
                       <Badge variant={destination.active ? 'secondary' : 'outline'}>
-                        {destination.active ? t('common:active') : t('common:inactive')}
+                        {destination.active
+                          ? t('common:active', { count: 1 })
+                          : t('common:inactive', { count: 1 })}
                       </Badge>
                     </TableCell>
                     <TableCell className="text-right">

--- a/components/payments/PaymentSection.tsx
+++ b/components/payments/PaymentSection.tsx
@@ -239,10 +239,7 @@ function PaymentCard({ payment }: { payment: PaymentData }) {
             />
           )}
           {payment.receiptUrl && (
-            <EvidenceLinkButton
-              href={payment.receiptUrl}
-              label={t('payments:receipt', { defaultValue: 'Receipt' })}
-            />
+            <EvidenceLinkButton href={payment.receiptUrl} label={t('payments:receipt')} />
           )}
           {canRefund && <RefundDialog payment={payment} />}
           {canVoid && payment.publicId && <VoidPaymentDialog paymentPublicId={payment.publicId} />}

--- a/components/payments/__tests__/PaymentSection.test.tsx
+++ b/components/payments/__tests__/PaymentSection.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { PaymentSection } from '../PaymentSection';
+import { useOrderPayments } from '@/hooks/payments';
+import { useRole } from '@/hooks/auth';
+import { useOrderCurrencySymbol } from '@/hooks/currencies';
+
+type PaymentData = App.Data.Payment.PaymentData;
+type OrderData = App.Data.Order.OrderData;
+
+const mockT = vi.fn<(key: string, options?: Record<string, unknown>) => string>((key) => key);
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: mockT }) }));
+
+// The real helpers resolve translations from the API at runtime (see
+// config/i18next.ts), which this test suite has no server for. Stub them to
+// identity so assertions can target the raw keys they were given.
+vi.mock('@/utils/lang', () => ({
+  capitalize: (value: string) => value,
+  statusLabel: (status: string) => status,
+  validationAttribute: (key: string) => key,
+}));
+
+vi.mock('@/hooks/payments', () => ({ useOrderPayments: vi.fn() }));
+vi.mock('@/hooks/auth', () => ({ useRole: vi.fn() }));
+vi.mock('@/hooks/currencies', () => ({ useOrderCurrencySymbol: vi.fn() }));
+
+function order(overrides: Partial<OrderData> = {}): OrderData {
+  return {
+    publicId: 'ord-1',
+    paymentStatus: 'paid',
+    currencyCode: 'CRC',
+    ...overrides,
+  } as OrderData;
+}
+
+function payment(overrides: Partial<PaymentData> = {}): PaymentData {
+  return {
+    publicId: 'pay-1',
+    status: 'succeeded',
+    amount: 1000,
+    ...overrides,
+  } as PaymentData;
+}
+
+beforeEach(() => {
+  mockT.mockClear();
+  vi.mocked(useRole).mockReturnValue({
+    role: undefined,
+    isAdmin: false,
+    isDispatch: false,
+    isStaff: false,
+  });
+  vi.mocked(useOrderCurrencySymbol).mockReturnValue('₡');
+});
+
+describe('PaymentSection — receipt link label', () => {
+  it('asks i18next for payments:receipt without a defaultValue', () => {
+    vi.mocked(useOrderPayments).mockReturnValue({
+      data: [payment({ receiptUrl: 'https://provider.example/r/1' })],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useOrderPayments>);
+
+    render(<PaymentSection order={order()} />);
+
+    // The link renders regardless of the call shape below (mockT is an
+    // identity function) — this only exists so the query below has
+    // something real to find.
+    expect(screen.getByRole('link', { name: 'payments:receipt' })).toBeInTheDocument();
+
+    const receiptCall = mockT.mock.calls.find(([key]) => key === 'payments:receipt');
+    expect(receiptCall).toBeDefined();
+    // #285 fixed the duplicate declaration that made this key resolve to an
+    // object instead of "Receipt" — a `defaultValue` here would silently mask
+    // a future regression of that same bug instead of surfacing it.
+    expect(receiptCall?.[1]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

api PR #285 added 19 missing locale keys, but deliberately left four consumer call-fixes out because a key with that meaning already existed under another name — adding a second spelling would be exactly the duplicate-key defect that PR fixed. This is admin's share of those call-fixes (three of the four; driver owns the other one).

- `components/payments/PaymentSection.tsx` — dropped the now-pointless `defaultValue` on `t('payments:receipt')`. PR #285 renamed the colliding array declaration to `digital_receipt`, freeing the scalar, so the key now resolves correctly on its own.
- `app/[lang]/(dashboard)/orders/[id]/page.tsx` — replaced `t('orders:detail.outsource', { defaultValue: 'Outsource' })` (no such key) with `actionLabel('outsource')`, which reaches the existing `common.actions.outsource`.
- `app/[lang]/(dashboard)/settings/payment-destinations/page.tsx` — added an explicit `count` to the `common:active` / `common:inactive` calls. Both are genuine singular|plural pairs in api (`'Active|Active'` in English, but `'Activo|Activos'` / `'Actif|Actifs'` in Spanish/French — they inflect even though English collapses both forms) and compile to `_one`/`_other` only, so a bare call never resolved.

No locale keys were added or edited anywhere — every change is a call-site fix.

## Test plan

- [x] Baseline measured in this worktree before any change: 33 files / 276 tests
- [x] Each fix reversal-proved: temporarily restored the old call, confirmed the matching new test went red, restored the fix
- [x] Gate run in the foreground: `npm run lint && npm run typecheck && npm run format && npm run test:run`
- [x] Final: lint clean (0 errors), typecheck clean, 36 files / 280 tests passing (+3 files / +4 tests, matching the new test files)
- [x] Reviewed via `/pipeline:review` (goal/stragglers, correctness, conventions dimensions) — one finding applied (missing `mockT.mockClear()` in the payment-destinations test), no correctness or convention defects

⛔ Draft — not for merge yet.