### PR TITLE
chore: consolidate getToken() copies, drop resolved defaultValue fallbacks

### DIFF
--- a/app/[lang]/(dashboard)/drivers/create/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/page.tsx
@@ -198,9 +198,7 @@ export default function CreateDriverPage() {
           {/* Personal Info */}
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('drivers:personal_info', { defaultValue: 'Personal Information' })}
-              </CardTitle>
+              <CardTitle>{t('drivers:personal_info')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid gap-4 sm:grid-cols-2">
@@ -367,9 +365,7 @@ export default function CreateDriverPage() {
           {/* License Info */}
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('drivers:license_info', { defaultValue: 'License Information' })}
-              </CardTitle>
+              <CardTitle>{t('drivers:license_info')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid gap-4 sm:grid-cols-2">
@@ -422,11 +418,7 @@ export default function CreateDriverPage() {
                   name="licensePhotoFront"
                   render={() => (
                     <FormItem>
-                      <FormLabel>
-                        {t('drivers:license_photo_front', {
-                          defaultValue: 'License Photo (Front)',
-                        })}
-                      </FormLabel>
+                      <FormLabel>{t('drivers:license_photo_front')}</FormLabel>
                       <FormControl>
                         <div className="flex items-center gap-4">
                           <Input
@@ -457,9 +449,7 @@ export default function CreateDriverPage() {
                   name="licensePhotoBack"
                   render={() => (
                     <FormItem>
-                      <FormLabel>
-                        {t('drivers:license_photo_back', { defaultValue: 'License Photo (Back)' })}
-                      </FormLabel>
+                      <FormLabel>{t('drivers:license_photo_back')}</FormLabel>
                       <FormControl>
                         <div className="flex items-center gap-4">
                           <Input

--- a/app/[lang]/(dashboard)/settings/currencies/page.tsx
+++ b/app/[lang]/(dashboard)/settings/currencies/page.tsx
@@ -407,7 +407,7 @@ export default function CurrencySettingsPage() {
                   type="number"
                   step="0.01"
                   min="0"
-                  placeholder={`${t('common:e_g', { defaultValue: 'e.g.' })} 490.00`}
+                  placeholder={`${t('common:e_g')} 490.00`}
                   value={editForm.manualRate}
                   onChange={(e) => setEditForm((f) => ({ ...f, manualRate: e.target.value }))}
                 />

--- a/components/drivers/ScheduleEventDialog.tsx
+++ b/components/drivers/ScheduleEventDialog.tsx
@@ -109,7 +109,7 @@ export function ScheduleEventDialog({
           <div className="space-y-2">
             <div className="flex items-center gap-3">
               <div className="flex-1">
-                <Label className="text-sm">{t('common:start', { defaultValue: 'Start' })}</Label>
+                <Label className="text-sm">{t('common:start')}</Label>
                 <Input
                   type="time"
                   value={startTime}
@@ -118,7 +118,7 @@ export function ScheduleEventDialog({
                 />
               </div>
               <div className="flex-1">
-                <Label className="text-sm">{t('common:end', { defaultValue: 'End' })}</Label>
+                <Label className="text-sm">{t('common:end')}</Label>
                 <Input
                   type="time"
                   value={endTime}
@@ -130,8 +130,8 @@ export function ScheduleEventDialog({
             {!isTimeValid && (
               <p className="text-destructive text-xs">
                 {t('validation:after', {
-                  attribute: t('common:end', { defaultValue: 'End' }),
-                  date: t('common:start', { defaultValue: 'Start' }),
+                  attribute: t('common:end'),
+                  date: t('common:start'),
                   defaultValue: 'End time must be after start time',
                 })}
               </p>
@@ -139,9 +139,7 @@ export function ScheduleEventDialog({
           </div>
 
           <div className="space-y-2">
-            <Label className="text-sm">
-              {t('drivers:schedule.vehicle_override', { defaultValue: 'Vehicle Override' })}
-            </Label>
+            <Label className="text-sm">{t('drivers:schedule.vehicle_override')}</Label>
             <Select
               value={vehicleType ?? USE_DEFAULT_VEHICLE}
               onValueChange={(value) =>
@@ -153,9 +151,7 @@ export function ScheduleEventDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value={USE_DEFAULT_VEHICLE}>
-                  {t('drivers:schedule.use_default_vehicle', {
-                    defaultValue: 'Use default vehicle',
-                  })}
+                  {t('drivers:schedule.use_default_vehicle')}
                 </SelectItem>
                 {Object.values(Enums.VehicleType).map((vt) => (
                   <SelectItem key={vt} value={vt}>

--- a/components/evidence/EvidenceDialog.tsx
+++ b/components/evidence/EvidenceDialog.tsx
@@ -77,12 +77,7 @@ export function EvidenceDialog({ source, title, resourceLabel, onClose }: Eviden
               <Button variant="outline" size="sm" asChild>
                 <a href={file.url} download={title}>
                   <Download className="mr-2 h-4 w-4" />
-                  {/* `common:download` does not exist in the api's lang files in
-                      any of the three languages. Carried over verbatim from the
-                      dialog this replaces rather than invented here — a consumer
-                      repo cannot add a key — so the fallback stays as the marker
-                      that the key is still owed upstream. */}
-                  {t('common:download', { defaultValue: 'Download' })}
+                  {t('common:download')}
                 </a>
               </Button>
             </div>

--- a/components/orders/EditStopDetailsDialog.tsx
+++ b/components/orders/EditStopDetailsDialog.tsx
@@ -85,9 +85,7 @@ export function EditStopDetailsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>
-            {t('orders:detail.edit_stop_details', { defaultValue: 'Edit Stop Details' })}
-          </DialogTitle>
+          <DialogTitle>{t('orders:detail.edit_stop_details')}</DialogTitle>
         </DialogHeader>
 
         <Form {...form}>

--- a/components/orders/ReceiptSection.tsx
+++ b/components/orders/ReceiptSection.tsx
@@ -46,7 +46,7 @@ function ReceiptCard({
             </span>
             {isImage && (
               <Badge variant="secondary" className="text-xs">
-                {t('common:image', { defaultValue: 'Image' })}
+                {t('common:image')}
               </Badge>
             )}
           </div>

--- a/components/orders/ReconciliationDialog.tsx
+++ b/components/orders/ReconciliationDialog.tsx
@@ -451,7 +451,7 @@ export function ReconciliationDialog({
 
             {/* Notes */}
             <div className="space-y-2">
-              <Label>{t('common:notes', { defaultValue: 'Notes' })}</Label>
+              <Label>{t('common:notes')}</Label>
               <Textarea
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}

--- a/hooks/orders/useShareLinkMutations.ts
+++ b/hooks/orders/useShareLinkMutations.ts
@@ -21,9 +21,7 @@ export function useMintShareLink() {
       queryClient.setQueryData(['orders', 'share', publicId], {
         shareExpiresAt: data.shareExpiresAt,
       });
-      toast.success(
-        i18next.t('orders:share.toast_minted', { defaultValue: 'Tracking link ready to share.' })
-      );
+      toast.success(i18next.t('orders:share.toast_minted'));
     },
     onError: (error) => {
       if (isApiError(error)) {
@@ -45,9 +43,7 @@ export function useRevokeShareLink() {
     mutationFn: (publicId: string) => OrderService.revokeShareLink(publicId),
     onSuccess: (_data, publicId) => {
       queryClient.setQueryData(['orders', 'share', publicId], null);
-      toast.success(
-        i18next.t('orders:share.toast_revoked', { defaultValue: 'Tracking link revoked.' })
-      );
+      toast.success(i18next.t('orders:share.toast_revoked'));
     },
     onError: (error) => {
       if (isApiError(error)) {

--- a/lib/api/__tests__/client.test.ts
+++ b/lib/api/__tests__/client.test.ts
@@ -122,3 +122,44 @@ describe('api.getBlob — reading a file off an authorized route', () => {
     expect(logout).toHaveBeenCalled();
   });
 });
+
+// `uploadService.ts` and `chatService.ts` used to read the bearer token
+// themselves for a raw multipart `fetch` — the only reason being that a
+// binary/multipart request could not go through the shared client. Both now
+// call `postMultipart()` directly instead of keeping their own copy, which
+// makes token attachment here the one place a regression in either surfaces.
+describe('api.postMultipart — the multipart call every FormData upload now goes through', () => {
+  function okJson(body: unknown = { item: {} }) {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => body,
+    };
+  }
+
+  it('attaches the bearer token, the same as a JSON request', async () => {
+    fetchMock.mockResolvedValue(okJson());
+
+    await api.postMultipart('/upload/image', new FormData());
+
+    expect(headersOf(0).Authorization).toBe('Bearer tok-123');
+  });
+
+  it('omits Content-Type so the browser sets the multipart boundary', async () => {
+    fetchMock.mockResolvedValue(okJson());
+
+    await api.postMultipart('/upload/image', new FormData());
+
+    expect(headersOf(0)['Content-Type']).toBeUndefined();
+  });
+
+  it('sends no token when there is none, rather than a bare "Bearer"', async () => {
+    window.localStorage.clear();
+    fetchMock.mockResolvedValue(okJson());
+
+    await api.postMultipart('/upload/image', new FormData());
+
+    expect(headersOf(0).Authorization).toBeUndefined();
+  });
+});

--- a/services/__tests__/chatService.test.ts
+++ b/services/__tests__/chatService.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ChatService } from '../chatService';
+import { api } from '@/lib/api/client';
+import { Enums } from '@/data/app-enums';
+
+type OrderMessageData = App.Data.Chat.OrderMessageData;
+
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    postMultipart: vi.fn(),
+  },
+}));
+
+// `data/app-enums.ts` holds plain string constants; `generated.d.ts` declares
+// nominal TS enums over the same values, deliberately not assignable to each
+// other — production code never needs the bridge, only this fixture does.
+function message(overrides: Partial<OrderMessageData> = {}): OrderMessageData {
+  return {
+    id: 1,
+    orderId: 10,
+    businessId: null,
+    userId: 5,
+    channel: Enums.ChatChannel.Support as App.Enums.ChatChannel,
+    body: 'hi',
+    imageUrl: null,
+    createdAt: '2026-09-10T00:00:00Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ChatService.sendMessage', () => {
+  // Bearer-token attachment and the multipart headers live once in
+  // `api.postMultipart()` — see `lib/api/__tests__/client.test.ts` — so this
+  // only pins that `sendMessage` is a pass-through to it with the right
+  // fields and route, and unwraps the `item` envelope.
+  it('sends body and image under their form fields and returns the item', async () => {
+    const item = message({ body: 'hello there' });
+    vi.mocked(api.postMultipart).mockResolvedValue({ item });
+    const image = new File(['bytes'], 'photo.png', { type: 'image/png' });
+
+    const result = await ChatService.sendMessage('order-1', 'support', {
+      body: 'hello there',
+      image,
+    });
+
+    expect(api.postMultipart).toHaveBeenCalledWith(
+      '/orders/order-1/chat/support',
+      expect.any(FormData)
+    );
+    const formData = vi.mocked(api.postMultipart).mock.calls[0][1] as FormData;
+    expect(formData.get('body')).toBe('hello there');
+    expect(formData.get('image')).toBe(image);
+    expect(result).toBe(item);
+  });
+
+  it('omits an absent body or image rather than sending an empty field', async () => {
+    vi.mocked(api.postMultipart).mockResolvedValue({ item: message() });
+
+    await ChatService.sendMessage('order-1', 'support', {});
+
+    const formData = vi.mocked(api.postMultipart).mock.calls[0][1] as FormData;
+    expect(formData.has('body')).toBe(false);
+    expect(formData.has('image')).toBe(false);
+  });
+});

--- a/services/__tests__/periodBillService.test.ts
+++ b/services/__tests__/periodBillService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { PeriodBillService } from '../periodBillService';
 import { api } from '@/lib/api/client';
@@ -11,6 +11,7 @@ vi.mock('@/lib/api/client', () => ({
     get: vi.fn(),
     post: vi.fn(),
     postMultipart: vi.fn(),
+    getBlob: vi.fn(),
   },
 }));
 
@@ -147,39 +148,17 @@ describe('PeriodBillService verification acts', () => {
 });
 
 describe('PeriodBillService.fetchProof', () => {
-  const fetchMock = vi.fn();
+  // The bearer token and the authenticated-fetch handling (401 clears the
+  // session, a failure raises the api's message) live once in
+  // `api.getBlob()` — see `lib/api/__tests__/client.test.ts` — so this only
+  // pins that `fetchProof` is a pass-through to it with the right route.
+  it('delegates to the shared client, which carries a byte stream that api.get() cannot', async () => {
+    const bytes = new Blob(['x']);
+    vi.mocked(api.getBlob).mockResolvedValue(bytes);
 
-  beforeEach(() => {
-    vi.stubGlobal('fetch', fetchMock);
-    fetchMock.mockReset();
-    window.localStorage.setItem(
-      'admin-auth-storage',
-      JSON.stringify({ state: { token: 'tok-123' } })
-    );
-  });
+    const result = await PeriodBillService.fetchProof('pb-1');
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    window.localStorage.clear();
-  });
-
-  // `PeriodBillData.proofUrl` names an authenticated stream route on a private
-  // disk. The bytes cannot come through `api.get()`, which parses JSON, and a
-  // request without the bearer token is answered 401 — so the header is the
-  // whole point of this method.
-  it('requests the proof route with the bearer token attached', async () => {
-    fetchMock.mockResolvedValue({ ok: true, blob: async () => new Blob(['x']) });
-
-    await PeriodBillService.fetchProof('pb-1');
-
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(String(url)).toContain('/period-bills/pb-1/proof');
-    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-123');
-  });
-
-  it('throws rather than returning an error body as if it were the file', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 404, blob: async () => new Blob() });
-
-    await expect(PeriodBillService.fetchProof('pb-1')).rejects.toThrow('404');
+    expect(api.getBlob).toHaveBeenCalledWith('/period-bills/pb-1/proof');
+    expect(result).toBe(bytes);
   });
 });

--- a/services/__tests__/uploadService.test.ts
+++ b/services/__tests__/uploadService.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { UploadService } from '../uploadService';
+import { api } from '@/lib/api/client';
+
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    postMultipart: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UploadService.upload', () => {
+  // Bearer-token attachment (when one exists) and the multipart headers live
+  // once in `api.postMultipart()` — see `lib/api/__tests__/client.test.ts` —
+  // so this only pins that `upload` is a pass-through to it with the file
+  // under the `image` field and the route the api registers.
+  it('sends the file under the image field to the shared client', async () => {
+    vi.mocked(api.postMultipart).mockResolvedValue({ url: '/uploads/photo.png' });
+    const file = new File(['bytes'], 'photo.png', { type: 'image/png' });
+
+    const url = await UploadService.upload(file);
+
+    expect(api.postMultipart).toHaveBeenCalledWith('/upload/image', expect.any(FormData));
+    const formData = vi.mocked(api.postMultipart).mock.calls[0][1] as FormData;
+    expect(formData.get('image')).toBe(file);
+    expect(url).toBe('/uploads/photo.png');
+  });
+});

--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -2,9 +2,8 @@ import { api } from '@/lib/api/client';
 
 type OrderMessageData = App.Data.Chat.OrderMessageData;
 type SuccessBasic = Api.Response.SuccessBasic;
+type Single<T> = Api.Response.Single<T>;
 type ChatUnreadCounts = Record<string, number>;
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://api.mandados.test:60';
 
 export const ChatService = {
   async getMessages(
@@ -24,24 +23,17 @@ export const ChatService = {
     channel: string,
     data: { body?: string; image?: File }
   ): Promise<OrderMessageData> {
-    // Need to use FormData for file upload, bypass the normal JSON api client
+    // FormData for the optional image, via the shared client's multipart
+    // method rather than the JSON one.
     const formData = new FormData();
     if (data.body) formData.append('body', data.body);
     if (data.image) formData.append('image', data.image);
 
-    // Get token from localStorage
-    const token = getToken();
-    const response = await fetch(`${API_URL}/orders/${orderPublicId}/chat/${channel}`, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      body: formData,
-    });
-    if (!response.ok) throw new Error('Failed to send message');
-    const json = await response.json();
-    return json.item;
+    const response = await api.postMultipart<Single<OrderMessageData>>(
+      `/orders/${orderPublicId}/chat/${channel}`,
+      formData
+    );
+    return response.item;
   },
 
   async markRead(
@@ -58,17 +50,3 @@ export const ChatService = {
     return api.get<ChatUnreadCounts>(`/orders/${orderPublicId}/chat-unread`);
   },
 };
-
-function getToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const stored = localStorage.getItem('admin-auth-storage');
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      return parsed?.state?.token || null;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}

--- a/services/periodBillService.ts
+++ b/services/periodBillService.ts
@@ -7,8 +7,6 @@ type SettlementMethod = App.Enums.SettlementMethod;
 type Multiple<T> = Api.Response.Multiple<T>;
 type Single<T> = Api.Response.Single<T>;
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.mandados.cr';
-
 /** How many bills sit at each urgency, counted by the API across all reasons. */
 export type BillAttentionSummary = Partial<Record<AttentionUrgency, number>>;
 
@@ -32,25 +30,6 @@ export interface SettlePeriodBillParams {
   destinationId?: number | null;
   notes?: string | null;
   proof?: File | null;
-}
-
-/**
- * Read the bearer token the way `lib/api/client.ts` and `services/uploadService.ts`
- * both do. Needed here because the comprobante is a byte stream: `api.get()`
- * parses JSON and returns `{}` for anything else, so it cannot carry the file.
- */
-function getToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const stored = localStorage.getItem('admin-auth-storage');
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      return parsed?.state?.token || null;
-    }
-  } catch {
-    return null;
-  }
-  return null;
 }
 
 export const PeriodBillService = {
@@ -128,18 +107,6 @@ export const PeriodBillService = {
    * here with the token attached and handed to the caller as an object URL.
    */
   async fetchProof(publicId: string): Promise<Blob> {
-    const token = getToken();
-    const response = await fetch(`${API_URL}/period-bills/${publicId}/proof`, {
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      credentials: 'include',
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to load proof (${response.status})`);
-    }
-
-    return response.blob();
+    return api.getBlob(`/period-bills/${publicId}/proof`);
   },
 };

--- a/services/uploadService.ts
+++ b/services/uploadService.ts
@@ -1,39 +1,18 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://api.mandados.test:60';
+import { api } from '@/lib/api/client';
 
 export const UploadService = {
+  /**
+   * `upload/image` is a public route (needed during registration before an
+   * auth token exists) that also accepts an authenticated call, so this goes
+   * through the shared client's `postMultipart()` rather than a bespoke
+   * fetch: it already attaches the bearer token when one is present and
+   * omits it otherwise, which is exactly this endpoint's contract.
+   */
   async upload(file: File): Promise<string> {
     const formData = new FormData();
     formData.append('image', file);
 
-    const token = getToken();
-    const response = await fetch(`${API_URL}/upload/image`, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      body: formData,
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to upload image');
-    }
-
-    const json = await response.json();
-    return json.url;
+    const response = await api.postMultipart<{ url: string }>('/upload/image', formData);
+    return response.url;
   },
 };
-
-function getToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const stored = localStorage.getItem('admin-auth-storage');
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      return parsed?.state?.token || null;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}


### PR DESCRIPTION
## Summary

Re-scopes admin#44: the binary-download half is already closed (PR #52 added
`getBlob()` to `lib/api/client.ts`). What remained was three duplicated
`getToken()` implementations — `chatService.ts`, `periodBillService.ts`,
`uploadService.ts` — each doing a raw `fetch` because the shared client
couldn't carry a binary response or a multipart POST at the time. Now that it
exposes `getBlob()` and `postMultipart()`, all three delegate to it directly;
no local `getToken()` remains anywhere outside `lib/api/client.ts` itself.

Also sweeps `defaultValue` call sites that api PR #285 resolved: 17 sites
across 8 files had a now-pointless fallback dropped because the underlying
locale key resolves (verified against api epic tip `e7b415f`). Two call
sites (`AssignDriverModal.tsx`'s `orders:assign_driver.*`,
`NeedsAttentionCard.tsx`'s `orders:needs_attention.retry_dispatch`) are left
untouched — both genuinely still missing from api's lang files.

## Changes

- `services/uploadService.ts`, `services/chatService.ts`,
  `services/periodBillService.ts` now call `api.postMultipart()` /
  `api.getBlob()` instead of keeping a local token copy + raw `fetch`.
- `lib/api/client.ts` has zero diff — it already had both methods from #52.
- 17 `defaultValue` call sites dropped their now-pointless fallback.
- `EvidenceDialog.tsx`'s stale comment claiming `common:download` doesn't
  exist upstream is corrected — it exists now.

## Test plan

- [x] `npm run check` clean (format:check + lint + typecheck)
- [x] `npm run test:run` — 38 files / 285 tests passing (baseline at
      `f093d68`: 36 files / 280 tests)
- [x] Reversal proof: broke the shared `getToken()` in `lib/api/client.ts`,
      confirmed exactly the two token-attachment tests in `client.test.ts`
      (`getBlob`, `postMultipart`) reddened while all 283 others stayed
      green, then reverted (zero net diff on `client.ts`)
- [x] `/pipeline:review` — 5 reviewers (goal/stragglers, correctness, reuse,
      simplification, conventions), nothing to apply