### PR TITLE
fix(i18n): point retry-dispatch call at the existing common.retry key

### DIFF
--- a/components/orders/NeedsAttentionCard.tsx
+++ b/components/orders/NeedsAttentionCard.tsx
@@ -143,7 +143,7 @@ export function NeedsAttentionCard({ item }: NeedsAttentionCardProps) {
             <RefreshCw
               className={`mr-1 h-4 w-4 ${retryDispatch.isPending ? 'animate-spin' : ''}`}
             />
-            {t('needs_attention.retry_dispatch', { defaultValue: 'Retry' })}
+            {t('common:retry')}
           </Button>
 
           {!order.driverId && (


### PR DESCRIPTION
## Summary
- `NeedsAttentionCard.tsx` called `t('needs_attention.retry_dispatch', { defaultValue: 'Retry' })` against a key that does not exist in api and is not going to — `common.retry` already carries this meaning (`Retry` / `Reintentar` / `Réessayer`, en/es/fr).
- Adding a second spelling is the defect api#239 is about; api's `fix(i18n): add the locale keys consumer apps call but api never declared` commit lists four such consumer call-fixes and explicitly leaves this shape for its repos to fix — this is the fifth.
- `common.retry` is a **top-level** key in `lang/{en,es,fr}/common.php`, not nested under `common.actions`, so `actionLabel()` doesn't apply (it resolves `common:actions.<key>`). Changed the call to `t('common:retry')`, matching `AssignDriverModal.tsx`'s existing `t('common:loading', ...)` shape for a top-level `common` key called from a component bound to `useTranslation('orders')`.
- Dropped `defaultValue` — this repo's rule is never use it on a key that exists, and it now does.

## Test plan
- [x] Verified `common.retry` exists top-level (not under `actions`) in en/es/fr, both in `lang/{en,es,fr}/common.php` and the compiled `public/locales/{en,es,fr}/common.json`, read from the api worktree on `epic/deferred-billing` (`/Users/dev-wynberg/.worktrees/Mandados/deferred-billing/api`, commit `a52a56c`).
- [x] `git diff --name-only` against fork point `7c421cb` lists only `components/orders/NeedsAttentionCard.tsx`.
- [x] `defaultValue` count in the file: 11 before → 10 after (exactly one dropped; the other 10 masks in this file are untouched).
- [x] `/pipeline:review` run on the uncommitted diff (one reviewer, correctness + conventions) — approved, no findings applied. One pre-existing, out-of-scope observation noted: `AssignDriverModal.tsx`'s own `common:loading` calls still carry `defaultValue` despite the key existing — not introduced by this diff, not touched.
- [x] Gate (`npm run check && npm run test:run`), measured baseline at fork point vs. after edit: `npm run check` (format:check + lint + typecheck, no short-circuit) green both times; tests 38 files / 285 tests passed, identical count before and after.