### PR TITLE
fix(orders): lock the refund method to credit off the API's verdict

### DIFF
--- a/components/orders/ApproveRefundRequestDialog.tsx
+++ b/components/orders/ApproveRefundRequestDialog.tsx
@@ -26,17 +26,21 @@ interface ApproveRefundRequestDialogProps {
   publicId: string;
   orderPublicId: string;
   /**
-   * The order's payment status. `ON_ACCOUNT` is the one value that changes
-   * what this dialog may offer, because such an order has no payment row for
-   * the settlement lookup below to find.
+   * The API's own verdict that this refund can only be given back as credit,
+   * off `RefundRequestData`. It is the answer rather than the facts behind
+   * it: `Order::refundIsCreditOnly()` decides it, `approve()` branches on
+   * that same method, and this dialog reads the result. Re-deriving it here
+   * from a payment status is what shipped a Gateway default the server
+   * refused every time — a settled period bill moves the order to `PAID`, so
+   * the status no longer tells this apart from an ordinary card delivery.
    */
-  paymentStatus?: string | null;
+  isCreditOnly?: boolean;
 }
 
 export function ApproveRefundRequestDialog({
   publicId,
   orderPublicId,
-  paymentStatus,
+  isCreditOnly,
 }: ApproveRefundRequestDialogProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -54,13 +58,12 @@ export function ApproveRefundRequestDialog({
     .sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))[0];
   const isManual = settledPayment?.provider === Enums.PaymentProvider.Manual;
 
-  // A delivery billed to an account was never charged, so it has no payment
-  // row at all — the lookup above finds nothing and, left alone, reads that
-  // emptiness as a card payment and offers to reverse a charge that does not
-  // exist. The API branches on this same status and accepts nothing but
-  // credit, so the dialog has to know it before the admin picks.
-  const isOnAccount = paymentStatus === Enums.PaymentStatus.ON_ACCOUNT;
-  const balanceOnly = isOnAccount || isManual;
+  // Two independent reasons no card charge stands behind this money, and
+  // either one locks the settlement to credit. A manually-settled payment is
+  // visible from here — the row above says so. Whether the delivery was
+  // billed to an account is not, and is not meant to be: the API states that
+  // verdict outright so this dialog never has to reassemble it.
+  const balanceOnly = isCreditOnly || isManual;
 
   // The method the admin hasn't explicitly overridden — recomputed from the
   // loaded payment each render rather than synced via an effect.

--- a/components/orders/RefundRequestCard.tsx
+++ b/components/orders/RefundRequestCard.tsx
@@ -103,7 +103,7 @@ export function RefundRequestCard({ refundRequest }: RefundRequestCardProps) {
           <ApproveRefundRequestDialog
             publicId={refundRequest.publicId as string}
             orderPublicId={orderPublicId}
-            paymentStatus={order?.paymentStatus}
+            isCreditOnly={refundRequest.isCreditOnly}
           />
 
           <DenyRefundRequestDialog publicId={refundRequest.publicId as string} />

--- a/components/orders/__tests__/ApproveRefundRequestDialog.test.tsx
+++ b/components/orders/__tests__/ApproveRefundRequestDialog.test.tsx
@@ -41,14 +41,22 @@ const cardPayment = {
   createdAt: '2026-01-01T00:00:00Z',
 } as unknown as PaymentData;
 
-function open(paymentStatus?: string) {
+const manualPayment = {
+  status: Enums.TransactionStatus.Succeeded,
+  provider: Enums.PaymentProvider.Manual,
+  createdAt: '2026-01-01T00:00:00Z',
+} as unknown as PaymentData;
+
+function renderDialog(isCreditOnly?: boolean) {
   return render(
-    <ApproveRefundRequestDialog
-      publicId="rr-1"
-      orderPublicId="ord-1"
-      paymentStatus={paymentStatus}
-    />
+    <ApproveRefundRequestDialog publicId="rr-1" orderPublicId="ord-1" isCreditOnly={isCreditOnly} />
   );
+}
+
+async function openDialog() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'approve' }));
+  return user;
 }
 
 beforeEach(() => {
@@ -56,15 +64,19 @@ beforeEach(() => {
   payments = [];
 });
 
-// An account-billed delivery has no payment row at all, so the settled-payment
-// lookup finds nothing. Read as a card payment, the dialog would default to a
-// gateway reversal — which the API answers with a 422 every single time.
-describe('ApproveRefundRequestDialog — an order billed to an account', () => {
+// The verdict arrives already decided — `RefundRequestData.isCreditOnly`, the
+// answer `Order::refundIsCreditOnly()` gave, which is the same method
+// `approve()` branches on. What produced it is deliberately not on the wire:
+// a delivery still sitting on an open account and one whose settled bill has
+// since moved it to `PAID` are one case from here, and the second is the one
+// that shipped broken — reading the payment status put Gateway in front of
+// the admin and the server answered 422 every time. No fixture in this file
+// can tell those apart, which is the point; the API test
+// `RefundCreditOnlyVerdictTest` is what holds them apart on the wire.
+describe('ApproveRefundRequestDialog — the API says credit is the only settlement', () => {
   it('locks the settlement to credit and explains why', async () => {
-    const user = userEvent.setup();
-    open(Enums.PaymentStatus.ON_ACCOUNT);
-
-    await user.click(screen.getByRole('button', { name: 'approve' }));
+    renderDialog(true);
+    await openDialog();
 
     const select = screen.getByRole('combobox');
     expect(select).toHaveTextContent(`payments:refund_method.${Enums.RefundMethod.Balance}`);
@@ -73,10 +85,9 @@ describe('ApproveRefundRequestDialog — an order billed to an account', () => {
   });
 
   it('submits the credit method the API accepts', async () => {
-    const user = userEvent.setup();
-    open(Enums.PaymentStatus.ON_ACCOUNT);
+    renderDialog(true);
+    const user = await openDialog();
 
-    await user.click(screen.getByRole('button', { name: 'approve' }));
     const dialog = screen.getByRole('dialog');
     await user.click(within(dialog).getByRole('button', { name: 'approve' }));
 
@@ -87,15 +98,29 @@ describe('ApproveRefundRequestDialog — an order billed to an account', () => {
   });
 });
 
+// `isManual` is a separate and independently correct reason for the same
+// lock — cash and SINPE are settled by hand, and money is never sent back
+// out the same way. The verdict joins it rather than replacing it, so a
+// wire that says nothing about credit still locks a manual payment.
+describe('ApproveRefundRequestDialog — a manually-settled payment', () => {
+  it('locks to credit even when the API sends no credit-only verdict', async () => {
+    payments = [manualPayment];
+    renderDialog(undefined);
+    await openDialog();
+
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveTextContent(`payments:refund_method.${Enums.RefundMethod.Balance}`);
+    expect(select).toBeDisabled();
+  });
+});
+
 // The contrast case: a real card charge still defaults to reversing the card,
 // and the admin may still choose credit instead.
 describe('ApproveRefundRequestDialog — an order paid by card', () => {
   it('defaults to a gateway reversal and leaves the choice open', async () => {
-    const user = userEvent.setup();
     payments = [cardPayment];
-    open(Enums.PaymentStatus.PAID);
-
-    await user.click(screen.getByRole('button', { name: 'approve' }));
+    renderDialog(false);
+    await openDialog();
 
     const select = screen.getByRole('combobox');
     expect(select).toHaveTextContent(`payments:refund_method.${Enums.RefundMethod.Gateway}`);

--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -136,6 +136,12 @@ export const Enums = {
     Denied: 'denied',
     Sent: 'sent',
   },
+  DebtChargeResolution: {
+    Settled: 'settled',
+    Freed: 'freed',
+    Unresolved: 'unresolved',
+    NotResolvable: 'not_resolvable',
+  },
   DeliveryTier: {
     Expedited: 'expedited',
     Regular: 'regular',

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -1044,6 +1044,7 @@ declare namespace App.Data.RefundRequest {
     refundId?: number | null;
     createdAt?: string;
     updatedAt?: string;
+    isCreditOnly?: boolean;
     order?: App.Data.Order.OrderData | null;
     user?: App.Data.User.UserData | null;
   };
@@ -1465,6 +1466,12 @@ declare namespace App.Enums {
     Approved = 'approved',
     Denied = 'denied',
     Sent = 'sent',
+  }
+  export enum DebtChargeResolution {
+    Settled = 'settled',
+    Freed = 'freed',
+    Unresolved = 'unresolved',
+    NotResolvable = 'not_resolvable',
   }
   export enum DeliveryTier {
     Expedited = 'expedited',


### PR DESCRIPTION
Admin half of LorenzoWynberg/mandados-api#296. Pairs with LorenzoWynberg/mandados-api#298 — **merge that first**, this depends on the DTO field it adds.

## The defect

`ApproveRefundRequestDialog` computed:

```ts
const isOnAccount = paymentStatus === Enums.PaymentStatus.ON_ACCOUNT;
const balanceOnly = isOnAccount || isManual;
```

That is only the first half of the union the API branches on, and it reads `PAID` once a period bill settles — so on the ordinary sequence (delivery, bill closes, customer pays, customer asks for a refund) the dialog pre-selected a gateway refund the server refuses with a 422.

## The change

Read `RefundRequestData.isCreditOnly` — the verdict the API now states outright, computed by the same `Order::refundIsCreditOnly()` that `approve()` branches on — OR'd with the separate and still-correct `isManual` reason.

```ts
const balanceOnly = isCreditOnly || isManual;
```

`RefundRequestCard` threads `refundRequest.isCreditOnly` in place of `order?.paymentStatus`. The `PaymentStatusBadge` still reads the payment status; that is a separate, legitimate display.

**The lock already worked.** `RefundMethodFields` already reduced the options to `[Balance]`, set `disabled={balanceOnly}` and rendered a hint. Only the input to `balanceOnly` was wrong, so no change was needed there — which is fortunate, since that component is outside this slice's fence.

## Behaviour in the three cases

| Case | `isCreditOnly` | Dialog |
|---|---|---|
| Period bill settled — order now `PAID`, line present | `true` | Balance locked in, Gateway not offered |
| Approved deferred order, no line yet | `true` | Balance locked in |
| Ordinary card-paid order | `false` | Gateway default, still selectable |

The first two are one case from the dialog's side, which is the point: what produced the verdict is deliberately not on the wire.

## Reversal check

Dropping the verdict (`balanceOnly = isManual`, reproducing the defect) reddens 3 of 5 tests — exactly the credit-only ones — while the `isManual` and card cases stay green. Restored: all pass.

## Not in this PR — flagged, not fixed

- **`payments:refund.balance_only_hint` says the wrong thing now.** *"Refunds on a cash or SINPE payment are always issued as credit."* is the `isManual` reason; an account-billed delivery has no payment row at all, cash or otherwise. Already wrong for the old on-account half, but that half almost never fired — this change makes it routine. Needs an api locale change plus probably two hints selected by which reason locked; both `lang/**` and `RefundMethodFields.tsx` are out of this slice's fence.
- **`RefundMethodFields.tsx`'s prop docblock** is falsified in the small for the same reason.
- **`RefundRequestCard` renders `order?.business?.name`, but `index()` does not eager-load `order.business`** and `OrderData::$business` is `AutoWhenLoadedLazy` — so that branch never renders in triage. Pre-existing.
- The Radix pointer-capture shim in this test file is duplicated in two other test files; `vitest.setup.ts` is its natural home. Pre-existing.

## Generated types

`types/generated.d.ts` and `data/app-enums.ts` are regenerated in the api and copied byte-identically — `diff` clean against `api/resources/types/` for all three `.d.ts`. The `DebtChargeResolution` enum they gain is pre-existing drift the regeneration swept up, not part of this change.