### PR TITLE
chore: sync generated types for RefundRequestStatus.Unresolved

### DIFF
--- a/data/app-enums.ts
+++ b/data/app-enums.ts
@@ -397,6 +397,7 @@ export const Enums = {
     Pending: 'pending',
     Approved: 'approved',
     Denied: 'denied',
+    Unresolved: 'unresolved',
   },
   Role: {
     BUSINESS_OWNER: 'business.owner',

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -1728,6 +1728,7 @@ declare namespace App.Enums {
     Pending = 'pending',
     Approved = 'approved',
     Denied = 'denied',
+    Unresolved = 'unresolved',
   }
   export enum Role {
     BUSINESS_OWNER = 'business.owner',


### PR DESCRIPTION
## Summary

Consumer half of api #302 (LorenzoWynberg/mandados-api#307 — the contract, merges first). `RefundRequestStatus` gains a fourth case, `Unresolved`, for a gateway refund whose outcome could not be confirmed.

- Regeneration only: `types/generated.d.ts` and `data/app-enums.ts`, byte-identical to the api source (`diff` verified).
- Checked where admin surfaces refund requests (`RefundRequestCard.tsx`, the "Solicitudes de Reembolso" needs-attention tab) — the card is origin-driven (system-raised vs. customer-requested), not status-driven, and no dedicated `RefundRequestStatus` label/badge map exists anywhere in admin to extend. Reported rather than invented, per the slice's own instruction.
- Note: since api's `RefundRequestController::index()` now also lists `Unresolved` requests (not just `Pending`), the existing triage card will start showing them too — correctly, since that's the point of the new status — but with the same `Approve`/`Deny` buttons as any other row. Clicking either now returns a clear, specific refusal (`errors.refund.outcome_unresolved`) rather than misbehaving; a dedicated resolve UI (`confirmRefund`/`reverseRefund`) is out of this slice's scope.

## Test plan

- [x] `npm run check` (format:check, lint, typecheck) — clean
- [x] `npm run test:run` — 286 passed / 38 files, unchanged from baseline at fork point `053995b`