### PR TITLE
fix(orders): move the share-link trigger into the Order Details card

### DIFF
--- a/app/[lang]/(dashboard)/orders/[id]/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
 
 import OrderDetailPage from '../page';
 
@@ -32,17 +32,19 @@ vi.mock('@/utils/lang', () => ({
 }));
 
 // isAdmin: false keeps the dispatcher card (and its useDispatchUsers query)
-// off the tree — irrelevant to the outsource button under test.
+// off the tree — irrelevant to the actions under test.
 vi.mock('@/hooks/auth', () => ({ useRole: () => ({ isAdmin: false }) }));
 
 const outsourceMutate = vi.fn();
+// Read when the page renders, so a test can set it before calling render().
+let orderStatus = 'approved';
 
 vi.mock('@/hooks/orders', () => ({
   useOrder: () => ({
     data: {
       id: 1,
       publicId: 'order-1',
-      status: 'approved',
+      status: orderStatus,
       driver: null,
       stops: [],
       quotes: [],
@@ -60,18 +62,24 @@ vi.mock('@/hooks/orders', () => ({
 vi.mock('@/hooks/currencies', () => ({ useCurrencyList: () => ({ data: { items: [] } }) }));
 vi.mock('@/hooks/users', () => ({ useDispatchUsers: () => ({ data: { items: [] } }) }));
 
-// Everything below always renders once `order.publicId` is set — none of it
-// bears on the outsource button, so it is stubbed out like the sibling
-// businesses/[id] and users/[id] page tests do for their own heavy children.
+// Everything below renders once `order.publicId` is set (ProofOfDeliveryCard
+// once the order is completed) — stubbed out like the sibling businesses/[id]
+// and users/[id] page tests do for their own heavy children. The share dialog
+// stub leaves a marker so where it renders, and whether it does, can be read.
 vi.mock('@/components/payments/PaymentSection', () => ({ PaymentSection: () => null }));
 vi.mock('@/components/invoices/InvoiceSection', () => ({ InvoiceSection: () => null }));
 vi.mock('@/components/orders/ReceiptSection', () => ({ ReceiptSection: () => null }));
 vi.mock('@/components/orders/OrderActivityCard', () => ({ OrderActivityCard: () => null }));
+vi.mock('@/components/orders/ProofOfDeliveryCard', () => ({ ProofOfDeliveryCard: () => null }));
 vi.mock('@/components/orders/ShareTrackingLinkDialog', () => ({
-  ShareTrackingLinkDialog: () => null,
+  ShareTrackingLinkDialog: () => <div data-testid="share-tracking-link" />,
 }));
 vi.mock('@/components/orders/AddStopDialog', () => ({ AddStopDialog: () => null }));
 vi.mock('@/components/chat/ChatTabs', () => ({ ChatTabs: () => null }));
+
+beforeEach(() => {
+  orderStatus = 'approved';
+});
 
 describe('OrderDetailPage — outsource button label', () => {
   it("uses actionLabel('outsource') instead of the nonexistent orders:detail.outsource key", () => {
@@ -82,4 +90,27 @@ describe('OrderDetailPage — outsource button label', () => {
     expect(screen.getByRole('button', { name: /outsource/i })).toHaveTextContent('outsource');
     expect(screen.queryByText('orders:detail.outsource')).not.toBeInTheDocument();
   });
+});
+
+describe('OrderDetailPage — share tracking link', () => {
+  it('renders in the Order Details card header, not the crowded page header', () => {
+    render(<OrderDetailPage />);
+
+    const detailsHeader = screen
+      .getByText('orders:detail.title')
+      .closest<HTMLElement>('[data-slot="card-header"]');
+
+    expect(detailsHeader).not.toBeNull();
+    expect(within(detailsHeader!).getByTestId('share-tracking-link')).toBeInTheDocument();
+  });
+
+  it.each(['completed', 'canceled', 'delivery_failed', 'returned_to_sender', 'denied'])(
+    'is hidden on a %s order, which the API refuses to share',
+    (status) => {
+      orderStatus = status;
+      render(<OrderDetailPage />);
+
+      expect(screen.queryByTestId('share-tracking-link')).not.toBeInTheDocument();
+    }
+  );
 });

--- a/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -73,6 +73,16 @@ type QuoteStatus = App.Enums.QuoteStatus;
 
 type OrderStatus = App.Enums.OrderStatus;
 
+// Mirrors the API's OrderStatus::terminalStatuses() — it refuses to mint a
+// share link for any of these, so the trigger is hidden rather than dead.
+const TERMINAL_ORDER_STATUSES = new Set<string>([
+  Enums.OrderStatus.COMPLETED,
+  Enums.OrderStatus.CANCELED,
+  Enums.OrderStatus.DELIVERY_FAILED,
+  Enums.OrderStatus.RETURNED_TO_SENDER,
+  Enums.OrderStatus.DENIED,
+]);
+
 export default function OrderDetailPage() {
   const params = useParams();
   const { t, ready } = useTranslation();
@@ -253,7 +263,6 @@ export default function OrderDetailPage() {
                 }
               />
             )}
-          {order.publicId && <ShareTrackingLinkDialog orderPublicId={order.publicId} />}
           <Button variant="destructive" onClick={handleDelete} disabled={deleteOrder.isPending}>
             <Trash2 className="mr-2 h-4 w-4" />
             {actionLabel('delete')}
@@ -504,10 +513,15 @@ export default function OrderDetailPage() {
         {/* Order Details */}
         <Card>
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Package className="h-5 w-5" />
-              {t('orders:detail.title', { defaultValue: 'Order Details' })}
-            </CardTitle>
+            <div className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-2">
+                <Package className="h-5 w-5" />
+                {t('orders:detail.title', { defaultValue: 'Order Details' })}
+              </CardTitle>
+              {order.publicId && !TERMINAL_ORDER_STATUSES.has(order.status ?? '') && (
+                <ShareTrackingLinkDialog orderPublicId={order.publicId} />
+              )}
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             {(order.totalDistanceKm || order.totalEstimatedMinutes) && (


### PR DESCRIPTION
## What
- Moves `ShareTrackingLinkDialog` out of the order detail page header and into the **Order Details** card header, the same pattern the Dispatcher card uses for its reassign button.
- Hides it for terminal statuses (`completed`, `canceled`, `delivery_failed`, `returned_to_sender`, `denied`). This mirrors the API's `OrderStatus::terminalStatuses()`, which `OrderController::share()` rejects with a 422.

## Why
The header row (status badge + status action + share link + delete) was too wide, so the order id wrapped onto two lines.

## Tests
`app/[lang]/(dashboard)/orders/[id]/__tests__/page.test.tsx` checks that the trigger renders inside the Order Details card header and is absent for each terminal status.
