### PR TITLE
fix(i18n): translated validation messages across admin forms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Coverage target: 100% on all tested utility files.
 3. **API errors**: Use `applyApiErrorsToForm()` to bridge API → form errors
 4. **i18n**: Always use namespaces. **Do not add `defaultValue` to a key that exists** — see below
 5. **Queries**: Invalidate queries after mutations for fresh data
+6. **Zod messages**: Every check needs one, and a **module-scope** schema needs a lazy one — see below
 
 ---
 
@@ -94,6 +95,39 @@ dangerous rather than merely redundant:
 If a key you need is missing from api's `lang/`, ask for it there — do not invent
 a fallback here. Existing call sites that still pass `defaultValue` predate this
 rule and are not worth churning on their own.
+
+### Zod validation messages must be lazy at module scope
+
+A zod check with no message falls back to **zod's own English**, in every locale, forever. So give
+every check a message from `validation:` — and when the schema sits at **module scope**, make it
+lazy:
+
+```typescript
+// module scope — the body runs at import, before i18next has fetched anything
+const schema = z.object({
+  name: z.string().min(3, { error: validationMessageLazy('min.string', 'name', { min: 3 }) }),
+});
+```
+
+i18next initialises asynchronously over HTTP; i18next 26 returns `undefined` until it resolves, zod
+reads `undefined` as "no message" and prints its English default, and the string never updates when
+the language changes. `validationMessageLazy()` returns a thunk that zod calls at parse time.
+Use plain `validationMessage()` only inside a component body, where the schema re-evaluates on
+render. Pass it as zod's `error` option — `message` does not accept a function.
+
+Give the **type** a message too wherever the bound input can hand zod the wrong one — an
+`<Input type="number" {...field} />` stores a string, which fails `z.number()` before any check
+runs, so a message on `.min()` alone never renders:
+
+```typescript
+z.number({ error: validationMessageLazy('numeric', 'minKm') }).min(0, { error: ... });
+```
+
+The attribute argument is a `validation:attributes.*` key, and **this repo cannot add one** (the
+locale JSON is the api's). If a field has none, leave its message off and raise the missing key —
+never pass a key that does not resolve, which renders `attributes.foo` to the user. Note that
+`data/app-enums.ts`'s `Attributes` enum is **not** a reliable check — it lags the api's
+`validation.php` badly; verify against the api's `lang/{en,es,fr}/validation.php` itself.
 
 ### Placeholder Capitalization
 

--- a/app/[lang]/(dashboard)/drivers/create/page.tsx
+++ b/app/[lang]/(dashboard)/drivers/create/page.tsx
@@ -17,9 +17,12 @@ import {
   capitalize,
   modelLabel,
   validationAttribute,
+  validationMessageLazy,
   vehicleTypeLabel,
   dispatchPolicyLabel,
 } from '@/utils/lang';
+import { formatDateOnly, toDateString } from '@/utils/format';
+import i18n from '@/config/i18next';
 import { Enums } from '@/data/app-enums';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -46,28 +49,49 @@ const eighteenYearsAgo = new Date(today.getFullYear() - 18, today.getMonth(), to
 
 const formSchema = z.object({
   user: z.object({
-    name: z.string().min(3),
-    email: z.string().email(),
-    phone: z.string().regex(/^\+[\d\s\-]{7,20}$/),
-    password: z.string().min(8),
+    name: z.string().min(3, { error: validationMessageLazy('min.string', 'name', { min: 3 }) }),
+    email: z.string().email({ error: validationMessageLazy('email', 'email') }),
+    phone: z
+      .string()
+      .regex(/^\+[\d\s\-]{7,20}$/, { error: validationMessageLazy('regex', 'phone') }),
+    password: z
+      .string()
+      .min(8, { error: validationMessageLazy('min.string', 'password', { min: 8 }) }),
     dateOfBirth: z.string().refine(
       (val) => {
         const date = new Date(val);
         return date <= eighteenYearsAgo;
       },
-      { message: 'Must be at least 18 years old' }
+      {
+        error: validationMessageLazy('before_or_equal', 'dateOfBirth', () => ({
+          date: formatDateOnly(toDateString(eighteenYearsAgo), i18n.language),
+        })),
+      }
     ),
-    avatar: z.string().min(1),
-    sexId: z.number().min(1),
-    langCode: z.string().min(1),
+    avatar: z.string().min(1, { error: validationMessageLazy('required', 'avatar') }),
+    sexId: z.number().min(1, { error: validationMessageLazy('required', 'sex') }),
+    langCode: z.string().min(1, { error: validationMessageLazy('required', 'langCode') }),
   }),
-  licenseNumber: z.string().regex(/^\d-?\d{4}-?\d{4}|\d{12}$/),
-  licensePlateNumber: z.string().regex(/^[A-Z0-9]{3}-\d{3}$/),
-  licenseExpirationDate: z
+  licenseNumber: z.string().regex(/^\d-?\d{4}-?\d{4}|\d{12}$/, {
+    error: validationMessageLazy('regex', 'licenseNumber'),
+  }),
+  licensePlateNumber: z
     .string()
-    .refine((val) => new Date(val) > today, { message: 'Must be a future date' }),
+    .regex(/^[A-Z0-9]{3}-\d{3}$/, { error: validationMessageLazy('regex', 'licensePlate') }),
+  licenseExpirationDate: z.string().refine((val) => new Date(val) > today, {
+    error: validationMessageLazy('after', 'licenseExpires', () => ({
+      date: formatDateOnly(toDateString(today), i18n.language),
+    })),
+  }),
+  // `licensePhotoFront` / `licensePhotoBack` have no `validation:attributes.*` entry on the API,
+  // and the labels above reach for `drivers:license_photo_*` instead. Supplying a message here
+  // would have to name an attribute that does not resolve, so these stay on zod's own default
+  // until the API gains the keys. See the hand-back for the list.
   licensePhotoFront: z.string().min(1),
   licensePhotoBack: z.string().min(1),
+  // `defaultVehicleType` and `dispatchPolicy` have no `validation:attributes.*` entry either, and
+  // like `calculationMode` on the pricing pages they are unreachable from the UI anyway: each
+  // Select is bound to this same member list and defaults to a valid one. Left on zod's default.
   defaultVehicleType: z.enum([
     Enums.VehicleType.Motorcycle,
     Enums.VehicleType.Car,

--- a/app/[lang]/(dashboard)/pricing/[id]/edit/page.tsx
+++ b/app/[lang]/(dashboard)/pricing/[id]/edit/page.tsx
@@ -30,28 +30,69 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { applyApiErrorsToForm } from '@/utils/form';
-import { actionLabel, resourceMessage, validationAttribute } from '@/utils/lang';
+import {
+  actionLabel,
+  resourceMessage,
+  validationAttribute,
+  validationMessageLazy,
+} from '@/utils/lang';
 import { Enums } from '@/data/app-enums';
 
 const tierSchema = z.object({
-  minKm: z.number().min(0),
-  maxKm: z.number().min(0).nullable(),
-  flatFee: z.number().min(0).nullable(),
-  perKmRate: z.number().min(0).nullable(),
-  order: z.number().min(0),
+  minKm: z
+    .number({ error: validationMessageLazy('numeric', 'minKm') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'minKm', { min: 0 }) }),
+  maxKm: z
+    .number({ error: validationMessageLazy('numeric', 'maxKm') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'maxKm', { min: 0 }) })
+    .nullable(),
+  flatFee: z
+    .number({ error: validationMessageLazy('numeric', 'flatFee') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'flatFee', { min: 0 }) })
+    .nullable(),
+  perKmRate: z
+    .number({ error: validationMessageLazy('numeric', 'perKmRate') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'perKmRate', { min: 0 }) })
+    .nullable(),
+  order: z
+    .number({ error: validationMessageLazy('numeric', 'order') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'order', { min: 0 }) }),
 });
 
 const formSchema = z.object({
-  name: z.string().min(1).max(255),
-  serviceFee: z.number().min(0),
-  taxRate: z.number().min(0).max(1),
+  name: z
+    .string()
+    .min(1, { error: validationMessageLazy('required', 'name') })
+    .max(255, { error: validationMessageLazy('max.string', 'name', { max: 255 }) }),
+  serviceFee: z
+    .number({ error: validationMessageLazy('numeric', 'serviceFee') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'serviceFee', { min: 0 }) }),
+  taxRate: z
+    .number({ error: validationMessageLazy('numeric', 'taxRate') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'taxRate', { min: 0 }) })
+    .max(1, { error: validationMessageLazy('max.numeric', 'taxRate', { max: 1 }) }),
+  // `calculationMode` has no `validation:attributes.*` entry on the API — its label reaches for
+  // `pricing:calculation_mode` instead — so it keeps zod's default. Unreachable from the UI in
+  // any case: the Select is bound to this same list and defaults to a valid member.
   calculationMode: z.enum([
     Enums.PricingCalculationMode.DISCRETE,
     Enums.PricingCalculationMode.CUMULATIVE,
   ]),
-  expeditedMultiplier: z.number().min(0.01),
-  regularMultiplier: z.number().min(0.01),
-  cheapestMultiplier: z.number().min(0.01),
+  expeditedMultiplier: z
+    .number({ error: validationMessageLazy('numeric', 'expeditedMultiplier') })
+    .min(0.01, {
+      error: validationMessageLazy('min.numeric', 'expeditedMultiplier', { min: 0.01 }),
+    }),
+  regularMultiplier: z
+    .number({ error: validationMessageLazy('numeric', 'regularMultiplier') })
+    .min(0.01, {
+      error: validationMessageLazy('min.numeric', 'regularMultiplier', { min: 0.01 }),
+    }),
+  cheapestMultiplier: z
+    .number({ error: validationMessageLazy('numeric', 'cheapestMultiplier') })
+    .min(0.01, {
+      error: validationMessageLazy('min.numeric', 'cheapestMultiplier', { min: 0.01 }),
+    }),
   notes: z.string().nullable(),
   tiers: z.array(tierSchema),
 });

--- a/app/[lang]/(dashboard)/pricing/create/page.tsx
+++ b/app/[lang]/(dashboard)/pricing/create/page.tsx
@@ -29,28 +29,64 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { applyApiErrorsToForm } from '@/utils/form';
-import { actionLabel, validationAttribute } from '@/utils/lang';
+import { actionLabel, validationAttribute, validationMessageLazy } from '@/utils/lang';
 import { Enums } from '@/data/app-enums';
 
 const tierSchema = z.object({
-  minKm: z.number().min(0),
-  maxKm: z.number().min(0).nullable(),
-  flatFee: z.number().min(0).nullable(),
-  perKmRate: z.number().min(0).nullable(),
-  order: z.number().min(0),
+  minKm: z
+    .number({ error: validationMessageLazy('numeric', 'minKm') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'minKm', { min: 0 }) }),
+  maxKm: z
+    .number({ error: validationMessageLazy('numeric', 'maxKm') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'maxKm', { min: 0 }) })
+    .nullable(),
+  flatFee: z
+    .number({ error: validationMessageLazy('numeric', 'flatFee') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'flatFee', { min: 0 }) })
+    .nullable(),
+  perKmRate: z
+    .number({ error: validationMessageLazy('numeric', 'perKmRate') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'perKmRate', { min: 0 }) })
+    .nullable(),
+  order: z
+    .number({ error: validationMessageLazy('numeric', 'order') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'order', { min: 0 }) }),
 });
 
 const formSchema = z.object({
-  name: z.string().min(1).max(255),
-  serviceFee: z.number().min(0),
-  taxRate: z.number().min(0).max(1),
+  name: z
+    .string()
+    .min(1, { error: validationMessageLazy('required', 'name') })
+    .max(255, { error: validationMessageLazy('max.string', 'name', { max: 255 }) }),
+  serviceFee: z
+    .number({ error: validationMessageLazy('numeric', 'serviceFee') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'serviceFee', { min: 0 }) }),
+  taxRate: z
+    .number({ error: validationMessageLazy('numeric', 'taxRate') })
+    .min(0, { error: validationMessageLazy('min.numeric', 'taxRate', { min: 0 }) })
+    .max(1, { error: validationMessageLazy('max.numeric', 'taxRate', { max: 1 }) }),
+  // `calculationMode` has no `validation:attributes.*` entry on the API — its label reaches for
+  // `pricing:calculation_mode` instead — so it keeps zod's default. Unreachable from the UI in
+  // any case: the Select is bound to this same list and defaults to a valid member.
   calculationMode: z.enum([
     Enums.PricingCalculationMode.DISCRETE,
     Enums.PricingCalculationMode.CUMULATIVE,
   ]),
-  expeditedMultiplier: z.number().min(0.01),
-  regularMultiplier: z.number().min(0.01),
-  cheapestMultiplier: z.number().min(0.01),
+  expeditedMultiplier: z
+    .number({ error: validationMessageLazy('numeric', 'expeditedMultiplier') })
+    .min(0.01, {
+      error: validationMessageLazy('min.numeric', 'expeditedMultiplier', { min: 0.01 }),
+    }),
+  regularMultiplier: z
+    .number({ error: validationMessageLazy('numeric', 'regularMultiplier') })
+    .min(0.01, {
+      error: validationMessageLazy('min.numeric', 'regularMultiplier', { min: 0.01 }),
+    }),
+  cheapestMultiplier: z
+    .number({ error: validationMessageLazy('numeric', 'cheapestMultiplier') })
+    .min(0.01, {
+      error: validationMessageLazy('min.numeric', 'cheapestMultiplier', { min: 0.01 }),
+    }),
   notes: z.string().nullable(),
   activate: z.boolean(),
   tiers: z.array(tierSchema),

--- a/app/[lang]/(dashboard)/staff/create/__tests__/page.test.tsx
+++ b/app/[lang]/(dashboard)/staff/create/__tests__/page.test.tsx
@@ -43,6 +43,9 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/utils/lang', () => ({
   actionLabel: (key: string) => key,
   validationAttribute: (key: string) => key,
+  // The page's module-scope schema calls this at import and hands the thunk to zod,
+  // so the stub has to return a function rather than a string.
+  validationMessageLazy: (key: string) => () => key,
 }));
 
 const mutateAsync = vi.fn();

--- a/app/[lang]/(dashboard)/staff/create/page.tsx
+++ b/app/[lang]/(dashboard)/staff/create/page.tsx
@@ -12,7 +12,9 @@ import { useCreateStaff } from '@/hooks/staff';
 import { CatalogService } from '@/services/catalogService';
 import { UploadService } from '@/services/uploadService';
 import { applyApiErrorsToForm } from '@/utils/form';
-import { actionLabel, validationAttribute } from '@/utils/lang';
+import { actionLabel, validationAttribute, validationMessageLazy } from '@/utils/lang';
+import { formatDateOnly, toDateString } from '@/utils/format';
+import i18n from '@/config/i18next';
 import { Enums } from '@/data/app-enums';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -46,20 +48,27 @@ const eighteenYearsAgo = new Date(today.getFullYear() - 18, today.getMonth(), to
 const STAFF_ROLES = [Enums.Role.DISPATCH, Enums.Role.ADMIN] as const;
 
 const formSchema = z.object({
-  name: z.string().min(3),
-  email: z.string().email(),
-  phone: z.string().regex(/^\+[\d\s\-]{7,20}$/),
+  name: z.string().min(3, { error: validationMessageLazy('min.string', 'name', { min: 3 }) }),
+  email: z.string().email({ error: validationMessageLazy('email', 'email') }),
+  phone: z.string().regex(/^\+[\d\s\-]{7,20}$/, { error: validationMessageLazy('regex', 'phone') }),
   dateOfBirth: z.string().refine(
     (val) => {
       const date = new Date(val);
       return date <= eighteenYearsAgo;
     },
-    { message: 'Must be at least 18 years old' }
+    // NOTE: this form requires 18, while the API's StoreUserData::rules() only requires 13 for a
+    // non-driver — so the date named here is the stricter client rule, not what the server
+    // enforces. Raised with the dispatcher; the threshold is a product decision, not changed here.
+    {
+      error: validationMessageLazy('before_or_equal', 'dateOfBirth', () => ({
+        date: formatDateOnly(toDateString(eighteenYearsAgo), i18n.language),
+      })),
+    }
   ),
   avatar: z.string().optional(),
-  sexId: z.number().min(1),
-  langCode: z.string().min(1),
-  role: z.enum(STAFF_ROLES),
+  sexId: z.number().min(1, { error: validationMessageLazy('required', 'sex') }),
+  langCode: z.string().min(1, { error: validationMessageLazy('required', 'langCode') }),
+  role: z.enum(STAFF_ROLES, { error: validationMessageLazy('in', 'role') }),
 });
 
 type FormValues = z.infer<typeof formSchema>;

--- a/components/orders/AddStopDialog.tsx
+++ b/components/orders/AddStopDialog.tsx
@@ -31,7 +31,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useCreateStop } from '@/hooks/orders';
-import { actionLabel, capitalize } from '@/utils/lang';
+import { actionLabel, capitalize, validationMessageLazy } from '@/utils/lang';
 import { Enums } from '@/data/app-enums';
 import {
   MapAddressPicker,
@@ -42,7 +42,7 @@ import {
 type OrderStopData = App.Data.Order.OrderStopData;
 
 const formSchema = z.object({
-  type: z.string().min(1),
+  type: z.string().min(1, { error: validationMessageLazy('required', 'type') }),
   contactName: z.string().optional(),
   contactPhone: z.string().optional(),
   instructions: z.string().optional(),

--- a/components/orders/EditStopDetailsDialog.tsx
+++ b/components/orders/EditStopDetailsDialog.tsx
@@ -27,6 +27,7 @@ import { actionLabel, validationAttribute } from '@/utils/lang';
 
 type OrderStopData = App.Data.Order.OrderStopData;
 
+// No validation message to translate here: every field is optional and carries no check.
 const formSchema = z.object({
   contactName: z.string().optional(),
   contactPhone: z.string().optional(),

--- a/components/profile/ChangePasswordCard.tsx
+++ b/components/profile/ChangePasswordCard.tsx
@@ -19,23 +19,29 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { applyApiErrorsToForm } from '@/utils/form';
-import { validationMessage } from '@/utils/lang';
+import { validationMessageLazy } from '@/utils/lang';
 import { useUpdatePasswordMutation } from '@/hooks/auth';
 
 const passwordSchema = z
   .object({
-    currentPassword: z.string().min(1, validationMessage('required', 'currentPassword')),
+    currentPassword: z
+      .string()
+      .min(1, { error: validationMessageLazy('required', 'currentPassword') }),
     password: z
       .string()
-      .min(8, validationMessage('min.string', 'password', { min: 8 }))
-      .regex(/[a-zA-Z]/, validationMessage('password.letters', 'password'))
-      .regex(/(?=.*[a-z])(?=.*[A-Z])/, validationMessage('password.mixed', 'password'))
-      .regex(/\d/, validationMessage('password.numbers', 'password'))
-      .regex(/[^A-Za-z0-9]/, validationMessage('password.symbols', 'password')),
-    passwordConfirmation: z.string().min(1, validationMessage('required', 'passwordConfirmation')),
+      .min(8, { error: validationMessageLazy('min.string', 'password', { min: 8 }) })
+      .regex(/[a-zA-Z]/, { error: validationMessageLazy('password.letters', 'password') })
+      .regex(/(?=.*[a-z])(?=.*[A-Z])/, {
+        error: validationMessageLazy('password.mixed', 'password'),
+      })
+      .regex(/\d/, { error: validationMessageLazy('password.numbers', 'password') })
+      .regex(/[^A-Za-z0-9]/, { error: validationMessageLazy('password.symbols', 'password') }),
+    passwordConfirmation: z
+      .string()
+      .min(1, { error: validationMessageLazy('required', 'passwordConfirmation') }),
   })
   .refine((data) => data.password === data.passwordConfirmation, {
-    message: validationMessage('confirmed', 'password'),
+    error: validationMessageLazy('confirmed', 'password'),
     path: ['passwordConfirmation'],
   });
 

--- a/components/profile/__tests__/ChangePasswordCard.test.tsx
+++ b/components/profile/__tests__/ChangePasswordCard.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The property under test is a matter of TIMING, so this file controls when translations become
+// available relative to when the module-scope schema is built. `loadedTranslations` starts null to
+// stand in for the window before i18next has fetched anything (see the note on `validationMessageLazy`
+// in utils/lang.ts); the component is imported while it is still null, and only then filled —
+// exactly the order a real page hits.
+let loadedTranslations: Record<string, string> | null = null;
+
+const mockT = vi.fn((key: string, options?: Record<string, unknown>) => {
+  if (!loadedTranslations) return undefined;
+  const template = loadedTranslations[key];
+  if (template === undefined) return key;
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(options?.[name] ?? ''));
+});
+
+vi.mock('@/config/i18next', () => ({ default: { t: mockT } }));
+
+const SPANISH: Record<string, string> = {
+  'validation:attributes.currentPassword': 'contraseña actual',
+  'validation:attributes.password': 'contraseña',
+  'validation:attributes.passwordConfirmation': 'confirmación de contraseña',
+  'validation:required': 'El campo {{attribute}} es obligatorio.',
+  'validation:min.string': 'El campo {{attribute}} debe tener al menos {{min}} caracteres.',
+  'validation:password.letters': 'El campo {{attribute}} debe contener al menos una letra.',
+  'validation:password.mixed':
+    'El campo {{attribute}} debe contener al menos una mayúscula y una minúscula.',
+  'validation:password.numbers': 'El campo {{attribute}} debe contener al menos un número.',
+  'validation:password.symbols': 'El campo {{attribute}} debe contener al menos un símbolo.',
+  'validation:confirmed': 'La confirmación del campo {{attribute}} no coincide.',
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, ready: true }),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('@/utils/form', () => ({ applyApiErrorsToForm: vi.fn() }));
+
+const mutate = vi.fn();
+vi.mock('@/hooks/auth', () => ({
+  useUpdatePasswordMutation: () => ({ mutate, isPending: false }),
+}));
+
+// Imported dynamically, and deliberately NOT at the top of the file: a static import would run
+// the module body before the test body, taking the timing this file exists to control out of
+// its hands. `loadedTranslations` is still null here, so the schema is built in the pre-init window.
+const { ChangePasswordCard } = await import('../ChangePasswordCard');
+
+// Pins the premise directly, so that hoisting the import back to the top of the file fails here
+// rather than silently voiding every assertion below.
+expect(mockT).not.toHaveBeenCalled();
+
+// Fragments of zod's own built-in English, which is what the user sees whenever a message
+// resolves to `undefined`. Kept broad on purpose: the assertion is that NONE of zod's wording
+// reaches the DOM, whatever phrasing this version of zod uses.
+const ZOD_ENGLISH_PATTERN = /Too small|Invalid|expected|characters$|must contain|match pattern/i;
+
+async function submitForm() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'auth:update_password.button' }));
+}
+
+describe('ChangePasswordCard validation messages', () => {
+  beforeEach(() => {
+    loadedTranslations = null;
+  });
+
+  it('renders the translated message for every field, though the schema was built before i18n was ready', async () => {
+    loadedTranslations = SPANISH;
+    render(<ChangePasswordCard />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText('El campo contraseña actual es obligatorio.')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('El campo contraseña debe tener al menos 8 caracteres.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('El campo confirmación de contraseña es obligatorio.')
+    ).toBeInTheDocument();
+  });
+
+  it('never falls back to a zod English default', async () => {
+    loadedTranslations = SPANISH;
+    const { container } = render(<ChangePasswordCard />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-slot="form-message"]').length).toBeGreaterThan(0);
+    });
+
+    const messages = Array.from(container.querySelectorAll('[data-slot="form-message"]')).map(
+      (el) => el.textContent ?? ''
+    );
+    for (const message of messages) {
+      expect(message).not.toMatch(ZOD_ENGLISH_PATTERN);
+    }
+  });
+
+  it('follows a language switch that happens after the schema was built', async () => {
+    loadedTranslations = SPANISH;
+    render(<ChangePasswordCard />);
+
+    await submitForm();
+    await waitFor(() => {
+      expect(screen.getByText('El campo contraseña actual es obligatorio.')).toBeInTheDocument();
+    });
+
+    // The switch itself — the same module-scope schema object, a different language. An eagerly
+    // resolved message would still be showing the Spanish it captured the first time round.
+    loadedTranslations = {
+      ...SPANISH,
+      'validation:attributes.currentPassword': 'mot de passe actuel',
+      'validation:required': 'Le champ {{attribute}} est obligatoire.',
+    };
+
+    await submitForm();
+    await waitFor(() => {
+      expect(screen.getByText('Le champ mot de passe actuel est obligatoire.')).toBeInTheDocument();
+    });
+  });
+
+  it('reports the complexity rules in the user language, not zod regex wording', async () => {
+    loadedTranslations = SPANISH;
+    render(<ChangePasswordCard />);
+
+    await userEvent
+      .setup()
+      .type(screen.getByLabelText('auth:update_password.new_password'), 'abcdefghi');
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'El campo contraseña debe contener al menos una mayúscula y una minúscula.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -567,6 +567,7 @@ if (hasValidationErrors(err)) {
 ```typescript
 import {
   validationMessage,
+  validationMessageLazy,
   resourceMessage,
   crudSuccessMessage,
   crudErrorMessage,
@@ -575,6 +576,7 @@ import {
 } from '@/utils/lang';
 
 validationMessage('required', 'email'); // "The email field is required"
+validationMessageLazy('required', 'email'); // () => "The email field is required"
 resourceMessage('created', 'order'); // "Order created"
 crudSuccessMessage('created', 'order'); // "Order created successfully"
 crudErrorMessage('delete', 'order'); // "Failed to delete order"
@@ -605,10 +607,11 @@ applyRounding(12, 'nearest', 5); // 10
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { validationMessageLazy } from '@/utils/lang'
 
 const schema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1),
+  email: z.string().email({ error: validationMessageLazy('email', 'email') }),
+  name: z.string().min(1, { error: validationMessageLazy('required', 'name') }),
 })
 
 type FormValues = z.infer<typeof schema>
@@ -636,6 +639,39 @@ function MyForm() {
   )
 }
 ```
+
+### Validation messages
+
+A zod check with no message argument falls back to **zod's own English string**, in every locale,
+permanently — so every check that a user can trip needs one.
+
+Which helper depends on where the schema is declared:
+
+| Schema declared…              | Helper                    | Why                                                                 |
+| ----------------------------- | ------------------------- | ------------------------------------------------------------------- |
+| at **module scope**           | `validationMessageLazy()` | The module body runs at import, before i18next has fetched anything |
+| inside the **component body** | `validationMessage()`     | Re-evaluated on every render, always after init                     |
+
+The JSDoc on `validationMessageLazy` in `utils/lang.ts` carries the mechanism. Pass it as zod's
+`error` option — `message` does not take a function:
+
+```typescript
+z.string().min(3, { error: validationMessageLazy('min.string', 'name', { min: 3 }) });
+z.string().refine(isAdult, {
+  error: validationMessageLazy('before_or_equal', 'dateOfBirth', () => ({ date })),
+});
+
+// Put one on the TYPE too wherever the bound input can hand zod the wrong type — an
+// `<Input type="number" {...field} />` gives react-hook-form a string, which fails
+// `z.number()` before any check runs:
+z.number({ error: validationMessageLazy('numeric', 'minKm') }).min(0, {
+  error: validationMessageLazy('min.numeric', 'minKm', { min: 0 }),
+});
+```
+
+The second argument is an `attributes.*` key. **The locale JSON lives in the api repo, so this repo
+cannot add one** — if a field has no entry there, leave that field's message off and raise the
+missing key rather than passing a key that does not resolve, which renders the raw key to the user.
 
 ---
 

--- a/utils/__tests__/lang.test.ts
+++ b/utils/__tests__/lang.test.ts
@@ -5,6 +5,7 @@ import {
   getModelGender,
   validationAttribute,
   validationMessage,
+  validationMessageLazy,
   resourceMessage,
   crudSuccessMessage,
   crudErrorMessage,
@@ -131,6 +132,62 @@ describe('validationMessage', () => {
     mockT.mockReturnValue('validation:min');
     const result = validationMessage('min');
     expect(result).toBe('validation:min');
+  });
+});
+
+describe('validationMessageLazy', () => {
+  beforeEach(() => {
+    mockT.mockImplementation((key: string, options?: Record<string, unknown>) => {
+      if (key === 'validation:attributes.email') return 'email';
+      if (key === 'validation:required') {
+        return `The ${options?.attribute} field is required.`;
+      }
+      if (key === 'validation:min.string') {
+        return `The ${options?.attribute} field must be at least ${options?.min} characters.`;
+      }
+      return key;
+    });
+  });
+
+  it('does not touch i18next until the thunk is called', () => {
+    mockT.mockClear();
+    const resolveMessage = validationMessageLazy('required', 'email');
+
+    expect(mockT).not.toHaveBeenCalled();
+
+    expect(resolveMessage()).toBe('The email field is required.');
+    expect(mockT).toHaveBeenCalled();
+  });
+
+  it('resolves against the translations present at call time, not at creation time', () => {
+    // Stands in for i18next before init: i18next 26 returns undefined for every key
+    // until the locale JSON has been fetched.
+    mockT.mockReturnValue(undefined);
+    const resolveMessage = validationMessageLazy('required', 'email');
+    expect(resolveMessage()).toBeUndefined();
+
+    // ...and once it has, the same thunk yields the translation.
+    mockT.mockImplementation((key: string, options?: Record<string, unknown>) => {
+      if (key === 'validation:attributes.email') return 'correo';
+      if (key === 'validation:required') return `El campo ${options?.attribute} es obligatorio.`;
+      return key;
+    });
+    expect(resolveMessage()).toBe('El campo correo es obligatorio.');
+  });
+
+  it('forwards the attribute and the interpolation values', () => {
+    expect(validationMessageLazy('min.string', 'email', { min: 8 })()).toBe(
+      'The email field must be at least 8 characters.'
+    );
+  });
+
+  it('defers a thunk passed as the interpolation values', () => {
+    let min = 8;
+    const resolveMessage = validationMessageLazy('min.string', 'email', () => ({ min }));
+
+    min = 12;
+
+    expect(resolveMessage()).toBe('The email field must be at least 12 characters.');
   });
 });
 

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -44,6 +44,36 @@ export const validationMessage = (
     ...(extra ?? {}),
   });
 
+/**
+ * Lazy variant of {@link validationMessage}, for schemas declared at module scope.
+ *
+ * i18next initialises asynchronously — it fetches the locale JSON over HTTP — while a module
+ * body runs at import. A `validationMessage()` call evaluated there therefore resolves before
+ * any translation exists: i18next 26 returns `undefined` in that window, a validation library
+ * reads `undefined` as "no message" and falls back to its own built-in English default, and the
+ * string stays frozen that way even after the user switches language.
+ *
+ * Returning a thunk defers the lookup to parse time, which is always after init and always in
+ * the language currently selected. Pass it as zod's `error` option, which accepts a function:
+ * `z.string().min(3, { error: validationMessageLazy('min.string', 'name', { min: 3 }) })`.
+ *
+ * `extra` may itself be a function, for interpolation values that are themselves
+ * locale-dependent — a formatted date, say. Passing those as a plain object would evaluate them
+ * in the module body and freeze them in whatever language was loaded then, which is the same bug
+ * one level down.
+ *
+ * A schema built inside a component body re-evaluates on every render and does not need this;
+ * `validationMessage()` is correct there.
+ */
+export const validationMessageLazy =
+  (
+    key: string,
+    attributeKey?: string,
+    extra?: Record<string, unknown> | (() => Record<string, unknown>)
+  ) =>
+  () =>
+    validationMessage(key, attributeKey, typeof extra === 'function' ? extra() : extra);
+
 export const resourceMessage = (
   key: string,
   resourceKey: string,


### PR DESCRIPTION
Fixes #63

A Spanish or French admin saw English validation errors on essentially every form. Two separate causes:

- **Eight module-scope zod schemas supplied no message argument at all**, so zod emitted its own English default permanently, in every locale, regardless of i18n state.
- **One schema resolved its messages eagerly at import.** i18next initialises asynchronously and fetches the locale JSON over HTTP; i18next 26 returns `undefined` until that resolves, zod reads `undefined` as "no message given" and substitutes its English default, and the string stays frozen that way even after a language switch.

## What changed

`validationMessageLazy()` in `utils/lang.ts` returns a thunk that zod calls at **parse** time — always after init, always in the current language. Its `extra` argument may itself be a function, so locale-dependent interpolation values (a formatted date) are not frozen in the module body one level down.

Every check a user can trip across the 10 module-scope schemas now carries a translated message.

One bug found while sweeping, specific to the pricing forms: their numeric inputs are bound with a bare `{...field}` spread, so react-hook-form stores the raw DOM string. `z.number()` failed at the base type and `.min()` never ran, leaving `Invalid input: expected number, received string` on screen no matter what message the check carried. Every numeric field now carries a message on the **type** as well as the check.

## Deliberately left on zod's default

The locale JSON lives in the api repo and this repo cannot add a key, so a field with no `validation:attributes.*` entry keeps zod's default rather than rendering a raw key to the user. Each site says so:

| Field | Reachable from the UI? |
| --- | --- |
| `licensePhotoFront`, `licensePhotoBack` | **Yes** — submit with no upload and the English string shows |
| `defaultVehicleType`, `dispatchPolicy`, `calculationMode` | No — Select bound to the same member list, valid default |

`licensePlateNumber` and `licenseExpirationDate` use the `licensePlate` / `licenseExpires` keys their own `FormLabel`s already use, so message and label agree.

## Verification

- `npm run check` clean.
- `components/profile/__tests__/ChangePasswordCard.test.tsx` pins the **timing** rather than the shape: it mocks the translation source to return `undefined` until a dictionary is installed, imports the component dynamically while it is still empty, asserts the premise held before any test runs, and asserts a language switch is followed after the schema was built. Reverting the schema to the eager form fails the file at import.
- `grep -rn "String must contain\|Invalid email\|Must be at least 18" app components lib` → 0 hits, from 2 at the fork point.

## Not addressed here

Reported to the dispatcher rather than filed: the missing `attributes.*` keys above; `components/catalogs/ElementCreateDialog.tsx:127`, which uses react-hook-form `rules` and renders **no** message at all; two hardcoded `'Failed to upload image'` strings blocked by the same missing keys; and `data/app-enums.ts`'s `Attributes` enum lagging the api's `validation.php` by 55 entries, which is enough to produce false negatives for anyone using it to check whether a key exists.
