### PR TITLE
fix: never invent pickup/delivery times when the feasibility check fails

### DIFF
--- a/components/orders/AssignDriverModal.tsx
+++ b/components/orders/AssignDriverModal.tsx
@@ -26,7 +26,7 @@ import { useDriverList } from '@/hooks/drivers';
 import { useAssignOrder } from '@/hooks/orders';
 import { actionLabel, vehicleTypeLabel, dispatchPolicyLabel } from '@/utils/lang';
 import { formatDateTime } from '@/utils/format';
-import { ChevronDown, UserPlus, Users } from 'lucide-react';
+import { AlertTriangle, ChevronDown, UserPlus, Users } from 'lucide-react';
 
 type DriverCandidate = App.Data.Feasibility.DriverCandidate;
 
@@ -47,7 +47,11 @@ export function AssignDriverModal({ order }: AssignDriverModalProps) {
   const [overrideOpen, setOverrideOpen] = useState(false);
   const [overrideDriverId, setOverrideDriverId] = useState<string>('');
 
-  const { data: feasibility, isLoading } = useFeasibilityCheck({
+  const {
+    data: feasibility,
+    isLoading,
+    isError: feasibilityIsError,
+  } = useFeasibilityCheck({
     orderPublicId: order.publicId,
     enabled: open,
   });
@@ -104,6 +108,15 @@ export function AssignDriverModal({ order }: AssignDriverModalProps) {
           {isLoading ? (
             <div className="text-muted-foreground py-8 text-center text-sm">
               {t('common:loading', { defaultValue: 'Loading...' })}
+            </div>
+          ) : feasibilityIsError ? (
+            // A failed check is not "no candidates" — that reads as a real
+            // negative result and nudges toward outsourcing, which this
+            // project avoids where possible. Say the check failed instead;
+            // the override select below still works for a manual pick.
+            <div className="border-destructive/30 bg-destructive/10 flex items-start gap-2 rounded-md border p-3">
+              <AlertTriangle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+              <p className="text-destructive text-sm">{t('quotes:feasibility.check_failed')}</p>
             </div>
           ) : candidates.length === 0 ? (
             <div className="text-muted-foreground rounded-md border border-dashed py-8 text-center text-sm">

--- a/components/orders/CreateQuoteDialog.tsx
+++ b/components/orders/CreateQuoteDialog.tsx
@@ -78,7 +78,11 @@ export function CreateQuoteDialog({
   const calculateDistance = useCalculateDistance();
 
   // Fetch feasibility when dialog is open
-  const { data: feasibility, isLoading: feasibilityLoading } = useFeasibilityCheck({
+  const {
+    data: feasibility,
+    isLoading: feasibilityLoading,
+    isError: feasibilityIsError,
+  } = useFeasibilityCheck({
     orderPublicId,
     enabled: open,
   });
@@ -118,21 +122,32 @@ export function CreateQuoteDialog({
   const idleMinuteRate = idleData?.idleMinuteRate ?? 0;
   const includedMinutes = idleData?.includedMinutes ?? 0;
 
-  // Compute effective proposed times: feasibility suggestions override defaults when not editing
+  // Compute effective proposed times: feasibility suggestions override defaults when not
+  // editing. A failed check is NOT a "no suggestion" — it must never fall through to the
+  // hardcoded placeholders in getDefaultFormData(), so it resolves to blank instead. Blank
+  // fails the submit-button guard below, which forces an explicit manual entry rather than
+  // silently persisting an invented time onto a real quote.
   const effectivePickup =
     !editingTimes && feasibility?.suggestedPickup
       ? toDateTimeLocal(new Date(feasibility.suggestedPickup))
-      : formData.pickupProposedFor;
+      : !editingTimes && feasibilityIsError
+        ? ''
+        : formData.pickupProposedFor;
 
   const effectiveDelivery =
     !editingTimes && feasibility?.suggestedDelivery
       ? toDateTimeLocal(new Date(feasibility.suggestedDelivery))
-      : formData.deliveryProposedFor;
+      : !editingTimes && feasibilityIsError
+        ? ''
+        : formData.deliveryProposedFor;
 
   // Top-ranked candidate is the system suggestion; an explicit choice (a driver
   // id, or null for "none") overrides it. An untouched selector accepts the
-  // suggestion.
-  const suggestedDriverId = feasibility?.candidates?.[0]?.driverId ?? null;
+  // suggestion. A failed check leaves this undefined rather than null — null
+  // means "the system suggests no driver", which a failure never asserted.
+  const suggestedDriverId = feasibilityIsError
+    ? undefined
+    : (feasibility?.candidates?.[0]?.driverId ?? null);
   const effectivePreferredDriverId =
     preferredDriverId === undefined ? suggestedDriverId : preferredDriverId;
 
@@ -153,6 +168,20 @@ export function CreateQuoteDialog({
       }));
     }
   }, [calculateDistance.data]);
+
+  // A failed check can land after the admin has already switched to manual
+  // entry — e.g. they clicked the pencil while the check was still loading,
+  // which seeds the editable fields from whatever effectivePickup/Delivery
+  // held at that instant. The `!editingTimes` guard above only blanks the
+  // read-only display; it does nothing once editingTimes is already true, so
+  // without this the seeded (invented) default would keep sitting in the
+  // inputs right next to a banner that says no time was suggested. Scrub the
+  // underlying state directly so it can't leak through either path.
+  useEffect(() => {
+    if (open && feasibilityIsError) {
+      setFormData((prev) => ({ ...prev, pickupProposedFor: '', deliveryProposedFor: '' }));
+    }
+  }, [open, feasibilityIsError]);
 
   // Reset form with fresh defaults when dialog opens
   const handleOpenChange = (isOpen: boolean) => {
@@ -371,6 +400,18 @@ export function CreateQuoteDialog({
                   defaultValue: 'Checking driver availability...',
                 })}
               </span>
+            </div>
+          ) : feasibilityIsError ? (
+            <div className="flex flex-col gap-1 pt-2">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="text-destructive h-4 w-4 shrink-0" />
+                <span className="text-destructive text-sm font-medium">
+                  {t('quotes:feasibility.check_failed')}
+                </span>
+              </div>
+              <p className="text-muted-foreground pl-6 text-xs">
+                {t('quotes:feasibility.check_failed_hint')}
+              </p>
             </div>
           ) : feasibility ? (
             <div className="pt-2">
@@ -766,7 +807,7 @@ export function CreateQuoteDialog({
           {feasibility && (
             <QuoteDriverSelector
               candidates={feasibility.candidates ?? []}
-              suggestedDriverId={suggestedDriverId}
+              suggestedDriverId={suggestedDriverId ?? null}
               value={preferredDriverId}
               onChange={setPreferredDriverId}
               initialDate={
@@ -869,11 +910,14 @@ export function CreateQuoteDialog({
           <Button
             variant="outline"
             onClick={() => handleSubmit(false)}
-            disabled={isPending || !distanceKm}
+            disabled={isPending || !distanceKm || !effectivePickup || !effectiveDelivery}
           >
             {t('quotes:create.save_draft', { defaultValue: 'Save as Draft' })}
           </Button>
-          <Button onClick={() => handleSubmit(true)} disabled={isPending || !distanceKm}>
+          <Button
+            onClick={() => handleSubmit(true)}
+            disabled={isPending || !distanceKm || !effectivePickup || !effectiveDelivery}
+          >
             <Send className="mr-2 h-4 w-4" />
             {t('quotes:create.create_send', { defaultValue: 'Create & Send' })}
           </Button>

--- a/components/orders/__tests__/AssignDriverModal.test.tsx
+++ b/components/orders/__tests__/AssignDriverModal.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AssignDriverModal } from '../AssignDriverModal';
+
+type FeasibilityResult = App.Data.Feasibility.FeasibilityResult;
+
+// Radix's Dialog relies on pointer capture, which happy-dom doesn't
+// implement — without these, interactions inside it silently no-op under
+// test, though everything works fine in a real browser.
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  vehicleTypeLabel: (v: string | null) => String(v),
+  dispatchPolicyLabel: (v: string | null) => String(v),
+}));
+
+let feasibilityQuery: {
+  data: FeasibilityResult | undefined;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+// Same seam as CreateQuoteDialog.test.tsx: the component consumes isError
+// exactly as the real hook exposes it, so controlling this mock stands in
+// for the endpoint succeeding, still loading, or failing.
+vi.mock('@/hooks/feasibility', () => ({
+  useFeasibilityCheck: () => feasibilityQuery,
+}));
+
+vi.mock('@/hooks/drivers', () => ({
+  useDriverList: () => ({ data: { items: [] } }),
+}));
+
+const assignMutate = vi.fn();
+
+vi.mock('@/hooks/orders', () => ({
+  useAssignOrder: () => ({ mutate: assignMutate, isPending: false }),
+}));
+
+function renderModal() {
+  return render(<AssignDriverModal order={{ publicId: 'ord-1' }} />);
+}
+
+async function openModal() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'assign_driver.button' }));
+  return user;
+}
+
+beforeEach(() => {
+  assignMutate.mockClear();
+  feasibilityQuery = { data: undefined, isLoading: false, isError: false };
+});
+
+// The same bug family as CreateQuoteDialog: a failed check used to read
+// identically to a genuine "zero candidates" result (feasibility?.candidates
+// ?? [] collapses both to an empty array), which rendered "No internal
+// candidates found... outsource this order elsewhere" — an unearned claim
+// that could steer a real dispatch decision on a false premise.
+describe('AssignDriverModal — a failed feasibility check', () => {
+  it('says the check failed rather than claiming no candidates exist', async () => {
+    feasibilityQuery = { data: undefined, isLoading: false, isError: true };
+    renderModal();
+    await openModal();
+
+    expect(screen.getByText('quotes:feasibility.check_failed')).toBeInTheDocument();
+    expect(screen.queryByText('assign_driver.no_candidates')).not.toBeInTheDocument();
+  });
+});
+
+describe('AssignDriverModal — a successful check that genuinely finds no candidates', () => {
+  it('still says no candidates were found — a real negative result, not a failure', async () => {
+    feasibilityQuery = {
+      data: { candidates: [] } as unknown as FeasibilityResult,
+      isLoading: false,
+      isError: false,
+    };
+    renderModal();
+    await openModal();
+
+    expect(screen.getByText('assign_driver.no_candidates')).toBeInTheDocument();
+    expect(screen.queryByText('quotes:feasibility.check_failed')).not.toBeInTheDocument();
+  });
+});

--- a/components/orders/__tests__/CreateQuoteDialog.test.tsx
+++ b/components/orders/__tests__/CreateQuoteDialog.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CreateQuoteDialog } from '../CreateQuoteDialog';
+import { Enums } from '@/data/app-enums';
+
+type FeasibilityResult = App.Data.Feasibility.FeasibilityResult;
+type DriverCandidate = App.Data.Feasibility.DriverCandidate;
+
+// Radix's Dialog relies on pointer capture, which happy-dom doesn't
+// implement — without these, interactions inside it silently no-op under
+// test, though everything works fine in a real browser.
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/lang', () => ({
+  actionLabel: (key: string) => key,
+  validationAttribute: (key: string) => key,
+}));
+
+let feasibilityQuery: {
+  data: FeasibilityResult | undefined;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+// The seam this suite exercises: the dialog consumes isError/data exactly as
+// the real hook exposes them (it needs no change — see hooks/feasibility),
+// so controlling this mock's return value stands in for the endpoint
+// succeeding, still loading, or failing.
+vi.mock('@/hooks/feasibility', () => ({
+  useFeasibilityCheck: () => feasibilityQuery,
+}));
+
+const createQuoteMutate = vi.fn();
+const sendQuoteMutate = vi.fn();
+
+vi.mock('@/hooks/quotes', () => ({
+  useCreateQuote: () => ({ mutate: createQuoteMutate, isPending: false }),
+  useSendQuote: () => ({ mutate: sendQuoteMutate, isPending: false }),
+}));
+
+vi.mock('@/hooks/orders', () => ({
+  useCalculateDistance: () => ({ mutate: vi.fn(), isPending: false, data: undefined }),
+  useChangeTier: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/pricing', () => ({
+  useCalculatePricing: () => ({
+    data: {
+      serviceFee: 0,
+      distanceFee: 100,
+      multiplier: 1,
+      subtotal: 100,
+      taxRate: 0.13,
+      tax: 13,
+      total: 113,
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/currencies', () => ({
+  useCurrencyList: () => ({ data: { items: [] } }),
+}));
+
+vi.mock('@/hooks/settings', () => ({
+  useIdleTime: () => ({ data: undefined }),
+}));
+
+// Stubbed so its own data hooks (drivers, schedules, routes) never need
+// wiring — this suite is only about what suggestedDriverId it is handed.
+vi.mock('../QuoteDriverSelector', () => ({
+  QuoteDriverSelector: ({ suggestedDriverId }: { suggestedDriverId: number | null }) => (
+    <div data-testid="driver-selector">suggested:{String(suggestedDriverId)}</div>
+  ),
+}));
+
+function driverCandidate(overrides: Partial<DriverCandidate> = {}): DriverCandidate {
+  return {
+    driverId: 42,
+    driverName: 'Ada',
+    extraDistanceKm: 0,
+    suggestedPickup: '2026-09-11T14:00:00+00:00',
+    suggestedDelivery: '2026-09-11T16:00:00+00:00',
+    score: 1,
+    travelTimeMinutes: 20,
+    vehicleType: null,
+    dispatchPolicy: null,
+    onboardLoad: 0,
+    ...overrides,
+  };
+}
+
+function renderDialog() {
+  return render(<CreateQuoteDialog orderId={1} orderPublicId="ord-1" orderDistanceKm={10} />);
+}
+
+async function openDialog() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'quotes:create.button' }));
+  return user;
+}
+
+beforeEach(() => {
+  createQuoteMutate.mockClear();
+  sendQuoteMutate.mockClear();
+  feasibilityQuery = { data: undefined, isLoading: false, isError: false };
+});
+
+// The defect this slice fixes: a 500 from GET orders/{order}/feasibility used
+// to return no data, and the dialog silently fell back to getDefaultFormData's
+// hardcoded now+2h / now+4h placeholders — which then got persisted onto real
+// quotes as pickup/delivery times. These tests hold the error path itself,
+// not just the (already-working) success path.
+describe('CreateQuoteDialog — a failed feasibility check', () => {
+  it('shows the failure state and leaves the proposed times blank rather than the generated placeholders', async () => {
+    feasibilityQuery = { data: undefined, isLoading: false, isError: true };
+    renderDialog();
+    await openDialog();
+
+    expect(screen.getByText('quotes:feasibility.check_failed')).toBeInTheDocument();
+    expect(screen.getByText('quotes:feasibility.check_failed_hint')).toBeInTheDocument();
+    expect(screen.queryByText('quotes:feasibility.checking')).not.toBeInTheDocument();
+
+    // No generated now+2h/now+4h time reaches the display — it shows the
+    // dialog's own "unknown" placeholder instead.
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getAllByText('—').length).toBeGreaterThanOrEqual(2);
+
+    // No driver suggestion is invented from the failed check either.
+    expect(screen.queryByTestId('driver-selector')).not.toBeInTheDocument();
+
+    // A quote can't be created or sent with no proposed times.
+    expect(screen.getByRole('button', { name: 'quotes:create.save_draft' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'quotes:create.create_send' })).toBeDisabled();
+  });
+
+  it('starts the manual time editor blank, not pre-filled with an invented time', async () => {
+    feasibilityQuery = { data: undefined, isLoading: false, isError: true };
+    renderDialog();
+    const user = await openDialog();
+
+    await user.click(screen.getByRole('button', { name: 'edit' }));
+
+    const pickupInput = screen.getByLabelText('quotes:create.proposed_pickup') as HTMLInputElement;
+    const deliveryInput = screen.getByLabelText(
+      'quotes:create.proposed_delivery'
+    ) as HTMLInputElement;
+    expect(pickupInput.value).toBe('');
+    expect(deliveryInput.value).toBe('');
+  });
+
+  it('still lets an admin create a quote by entering both times by hand', async () => {
+    feasibilityQuery = { data: undefined, isLoading: false, isError: true };
+    renderDialog();
+    const user = await openDialog();
+
+    await user.click(screen.getByRole('button', { name: 'edit' }));
+
+    const pickupInput = screen.getByLabelText('quotes:create.proposed_pickup');
+    const deliveryInput = screen.getByLabelText('quotes:create.proposed_delivery');
+    fireEvent.change(pickupInput, { target: { value: '2026-09-12T09:00' } });
+    fireEvent.change(deliveryInput, { target: { value: '2026-09-12T11:00' } });
+
+    const saveButton = screen.getByRole('button', { name: 'quotes:create.save_draft' });
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
+
+    expect(createQuoteMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pickupProposedFor: expect.stringContaining('2026-09-12T09:00'),
+        deliveryProposedFor: expect.stringContaining('2026-09-12T11:00'),
+      }),
+      expect.anything()
+    );
+  });
+
+  // The race the letter of the earlier fix missed: switching to manual entry
+  // while the check is still loading seeds the fields from the invented
+  // default (unrelated to this slice — that's the untouched loading path).
+  // If the check then fails, that leftover default must not keep sitting in
+  // the fields next to a banner that says no time was suggested.
+  it('scrubs a leftover invented default if the check fails after the admin already switched to manual entry', async () => {
+    feasibilityQuery = { data: undefined, isLoading: true, isError: false };
+    const { rerender } = renderDialog();
+    const user = await openDialog();
+
+    await user.click(screen.getByRole('button', { name: 'edit' }));
+    const pickupInput = screen.getByLabelText('quotes:create.proposed_pickup') as HTMLInputElement;
+    const deliveryInput = screen.getByLabelText(
+      'quotes:create.proposed_delivery'
+    ) as HTMLInputElement;
+    expect(pickupInput.value).not.toBe('');
+    expect(deliveryInput.value).not.toBe('');
+
+    feasibilityQuery = { data: undefined, isLoading: false, isError: true };
+    rerender(<CreateQuoteDialog orderId={1} orderPublicId="ord-1" orderDistanceKm={10} />);
+
+    await waitFor(() => expect(pickupInput.value).toBe(''));
+    expect(deliveryInput.value).toBe('');
+  });
+});
+
+describe('CreateQuoteDialog — a successful feasibility check', () => {
+  it('uses the real suggestion for times and driver, untouched by the failure-path guard', async () => {
+    feasibilityQuery = {
+      isLoading: false,
+      isError: false,
+      data: {
+        level: Enums.FeasibilityLevel.Green,
+        candidates: [driverCandidate({ driverId: 7 })],
+        outsourceRequired: false,
+        suggestedPickup: '2026-09-11T14:00:00+00:00',
+        suggestedDelivery: '2026-09-11T16:00:00+00:00',
+        windowStart: null,
+        windowEnd: null,
+        timeSensitive: false,
+        planningMode: false,
+        driversEvaluated: 3,
+      } as unknown as FeasibilityResult,
+    };
+    renderDialog();
+    await openDialog();
+
+    expect(screen.queryByText('quotes:feasibility.check_failed')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('driver-selector')).toHaveTextContent('suggested:7');
+    expect(screen.getByRole('button', { name: 'quotes:create.save_draft' })).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary

The quote dialog must never substitute invented times for a failed feasibility suggestion. `GET orders/{order}/feasibility` failing used to leave `CreateQuoteDialog` with no suggestion to prefer, so it silently fell through to `getDefaultFormData()`'s hardcoded `now + 2h` / `now + 4h` placeholders, which then got submitted onto real quotes as pickup/delivery times — observed drifting outside the driver's shift on live quotes.

### CreateQuoteDialog.tsx

- Destructures `isError` from `useFeasibilityCheck` (no hook change needed — it already exposes the full react-query result) and renders an explicit failure banner in the dialog header, as a sibling of the existing loading branch.
- `effectivePickup`/`effectiveDelivery` resolve to blank instead of the invented default while the check is erroring and the admin hasn't started editing.
- A `useEffect` also scrubs the underlying form state directly, closing a race where an admin who switches to manual entry *before* the check resolves (seeding the fields from the still-invented default) would otherwise keep that leftover value if the check then fails.
- `suggestedDriverId` no longer collapses a failed check into an explicit "no driver suggested" (`null`); it stays `undefined`, which an untouched driver selector correctly reads as "nothing to accept" rather than a real system verdict.
- Submit ("Save as Draft" / "Create & Send") is guarded on both proposed times being present, not on the error state directly — an admin can still create a quote by typing both times by hand while the check is down; the dialog is not locked outright.

### AssignDriverModal.tsx (folded in — see Sweep below)

Same bug family, milder consequence: `feasibility?.candidates ?? []` collapsed a failed check to the same empty array as a genuine "zero candidates" result, rendering "No internal candidates found... outsource this order elsewhere." That's an unearned claim steering a real dispatch decision (outsourcing costs money, which this project avoids where possible) on a check that never ran to completion. Now destructures `isError` and renders an explicit "could not check driver availability" state ahead of the empty-candidates branch, reusing `quotes:feasibility.check_failed`. The manual override select (any active driver) is untouched and still works during a failure.

## Translation keys (pinned with the sibling api slice)

- `quotes:feasibility.check_failed` → "Could not check driver availability" — used in both files above
- `quotes:feasibility.check_failed_hint` → "No times were suggested — enter pickup and delivery manually." — CreateQuoteDialog only; does not fit AssignDriverModal's context and was deliberately not reused there

Both land under the existing `feasibility` block in `lang/{en,es,fr}/quotes.php` in the api repo, flat snake_case matching siblings (`checking`, `green`, `no_drivers_for_tier`). Consumed via raw `t()`, no `defaultValue` — the keys are expected to exist, and masking a missing/misregistered key was the class of failure this slice exists to stop.

## Fence notes (both granted by the dispatcher mid-run)

1. `components/orders/__tests__/CreateQuoteDialog.test.tsx` — brief's `Owns` named only `CreateQuoteDialog.tsx`, but its own verify bar required testing the error path, which needed a test file. Granted for that named path.
2. `components/orders/AssignDriverModal.tsx` (+ its test file) — found during the sweep (see below), flagged to the dispatcher rather than fixed unilaterally, then granted after the dispatcher verified it and confirmed the family closes at exactly two consumers.

## Sweep: bug family closed at two

`useFeasibilityCheck` has exactly two consumers in this repo: `CreateQuoteDialog.tsx` (this slice's original target) and `AssignDriverModal.tsx` (found during the sweep, same masking pattern, different downstream harm — a misleading "no candidates" claim instead of a fabricated persisted time). Both are fixed in this PR; no other consumer exists to sweep.

## Test plan

- [x] `npm run check` (format-check + lint + typecheck) — green
- [x] `npm run test:run` — full suite green (see gate comment on this PR), 46 files / 320 tests
- [x] `components/orders/__tests__/CreateQuoteDialog.test.tsx` — 5/5 passing, including a regression test for the load-then-error race
- [x] `components/orders/__tests__/AssignDriverModal.test.tsx` — 2/2 passing (failed check vs. genuine empty result)
- [x] Verified both new test files actually fail against their respective pre-fix code (stashed each fix in turn, reran, confirmed red, restored)
